### PR TITLE
Fix typo solider -> soldier

### DIFF
--- a/Ultimate_Cataclysm/gfx/UltimateCataclysm/pngs_large_64x64/monsters/mon_ant_soldier/mon_ant_soldier.json
+++ b/Ultimate_Cataclysm/gfx/UltimateCataclysm/pngs_large_64x64/monsters/mon_ant_soldier/mon_ant_soldier.json
@@ -1,5 +1,5 @@
 {
-  "id": "mon_ant_solider",
-  "fg": ["mon_ant_solider"],
+  "id": "mon_ant_soldier",
+  "fg": ["mon_ant_soldier"],
   "bg": []
 }


### PR DESCRIPTION
Prevented soldier ant tiles from showing up.
![image](https://user-images.githubusercontent.com/42699974/67117673-d0cc8000-f1d2-11e9-86ac-8978002e8dd5.png)
