### PR TITLE
Fixes so the tileset will compose again

### DIFF
--- a/Ultimate_Cataclysm/gfx/UltimateCataclysm/pngs_giant_96x96/terrain/t_tree/t_tree.json
+++ b/Ultimate_Cataclysm/gfx/UltimateCataclysm/pngs_giant_96x96/terrain/t_tree/t_tree.json
@@ -1,21 +1,23 @@
-{
-  "id": "t_tree",
-  "fg": [
-    { "weight":100, "sprite": "t_tree" },
-    { "weight":100, "sprite": "t_tree2" },
-    { "weight":100, "sprite": "t_tree3" },
-    { "weight":100, "sprite": "t_tree4" }
-  ],
-  "bg": []
-},
-{
-  "id": "t_tree_season_autumn",
+[
+  {
+    "id": "t_tree",
     "fg": [
-    { "weight":100, "sprite": "t_tree_season_autumn" },
-    { "weight":100, "sprite": "t_tree_season_autumn2" },
-    { "weight":100, "sprite": "t_tree_season_autumn3" },
-    { "weight":100, "sprite": "t_tree_season_autumn4" },
-  ],
-    "bg": [],
+      { "weight": 100, "sprite": "t_tree" },
+      { "weight": 100, "sprite": "t_tree2" },
+      { "weight": 100, "sprite": "t_tree3" },
+      { "weight": 100, "sprite": "t_tree4" }
+    ],
+    "bg": [  ]
+  },
+  {
+    "id": "t_tree_season_autumn",
+    "fg": [
+      { "weight": 100, "sprite": "t_tree_season_autumn" },
+      { "weight": 100, "sprite": "t_tree_season_autumn2" },
+      { "weight": 100, "sprite": "t_tree_season_autumn3" },
+      { "weight": 100, "sprite": "t_tree_season_autumn4" }
+    ],
+    "bg": [  ],
     "rotates": false
-}
+  }
+]

--- a/Ultimate_Cataclysm/gfx/UltimateCataclysm/pngs_large_64x64/terrain/t_tree_young/tree_young.json
+++ b/Ultimate_Cataclysm/gfx/UltimateCataclysm/pngs_large_64x64/terrain/t_tree_young/tree_young.json
@@ -1,26 +1,28 @@
-{
-  "id": "t_tree_young",
-  "fg": [
-    { "weight":100, "sprite": "t_tree_young" },
-    { "weight":100, "sprite": "t_tree_young2" }
-  ],
-  "bg": []
-},
-{
-  "id": "t_tree_young_season_autumn",
+[
+  {
+    "id": "t_tree_young",
+    "fg": [ 
+      { "weight": 100, "sprite": "t_tree_young" }, 
+      { "weight": 100, "sprite": "t_tree_young2" } 
+    ],
+    "bg": [  ]
+  },
+  {
+    "id": "t_tree_young_season_autumn",
     "fg": [
-    { "weight":100, "sprite": "t_tree_young_season_autumn" },
-    { "weight":100, "sprite": "t_tree_young_season_autumn2" }
-  ],
-    "bg": [],
+      { "weight": 100, "sprite": "t_tree_young_season_autumn" },
+      { "weight": 100, "sprite": "t_tree_young_season_autumn2" }
+    ],
+    "bg": [  ],
     "rotates": false
-},
-{
-  "id": "t_tree_young_season_winter",
+  },
+  {
+    "id": "t_tree_young_season_winter",
     "fg": [
-    { "weight":100, "sprite": "t_tree_young_season_winter" },
-    { "weight":100, "sprite": "t_tree_young_season_winter2" }
-  ],
-    "bg": [],
+      { "weight": 100, "sprite": "t_tree_young_season_winter" },
+      { "weight": 100, "sprite": "t_tree_young_season_winter2" }
+    ],
+    "bg": [  ],
     "rotates": false
-}
+  }
+]

--- a/Ultimate_Cataclysm/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_shrub/t_shrub.json
+++ b/Ultimate_Cataclysm/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_shrub/t_shrub.json
@@ -1,11 +1,13 @@
-{
-  "id": "t_shrub",
-  "fg": [ "t_shrub" ],
-  "bg": ["t_dirt"]
-},
-{
-  "id": "t_shrub_season_winter",
+[
+  {
+    "id": "t_shrub",
+    "fg": [ "t_shrub" ],
+    "bg": [ "t_dirt" ]
+  },
+  {
+    "id": "t_shrub_season_winter",
     "fg": [ "t_shrub_winter" ],
-    "bg": ["t_dirt"],
+    "bg": [ "t_dirt" ],
     "rotates": false
-}
+  }
+]

--- a/Ultimate_Cataclysm/gfx/UltimateCataclysm/tile_info.json
+++ b/Ultimate_Cataclysm/gfx/UltimateCataclysm/tile_info.json
@@ -17,7 +17,7 @@
     "huge.png": { "sprite_width": 64, "sprite_height": 96, "sprite_offset_x": -16, "sprite_offset_y": -64  }
   },
   {
-    "giant.png": { "sprite_width": 96, "sprite_height": 96, "sprite_offset_x": -48, "sprite_offset_y": -64  }
+    "giant.png": { "sprite_width": 96, "sprite_height": 96, "sprite_offset_x": -32, "sprite_offset_y": -64  }
   },
   {
     "fallback.png": {


### PR DESCRIPTION
Obvious missing things still (once the current `looks_like` PRs for the game are merged) are tree trunks and tree stumps in the forest

![image](https://user-images.githubusercontent.com/11464/67461262-65771980-f5e9-11e9-98ef-faa2343607c4.png)

And lilypads, cattails, and the salt water versions of the water tiles in the swamp

![image](https://user-images.githubusercontent.com/11464/67461380-a96a1e80-f5e9-11e9-8453-63bd102e1cd1.png)
