### PR TITLE
Create draft release to allow easy manual editing before publish

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Ultimate Cataclysm ${{ github.ref }}
-          draft: false
+          draft: true
           prerelease: false
 
       - name: Upload Release Asset

--- a/Ultimate_Cataclysm/gfx/UltimateCataclysm/tile_info.json
+++ b/Ultimate_Cataclysm/gfx/UltimateCataclysm/tile_info.json
@@ -27,7 +27,7 @@
       "source": "https://github.com/CleverRaven/Cataclysm-DDA/tree/b2d1f9f6cf6fae9c5076d29f9779e0ca6c03c222/gfx/HoderTileset",
       "filler": true 
     }
-  }
+  },
   {
     "fallback.png": {
       "source": "https://github.com/Chezzo/Cataclysm-DDA/blob/0ca0b5307f1b2fab7edb5519a3176e1d887087a7/gfx/ChestHole32Tileset/fallback.png",


### PR DESCRIPTION
The github action now creates a draft release with the archive uploaded instead of releasing automatically.  This allows for greater flexibility and worry-free testing of the action.

I also fixed a json error that just got merged so this will run, guess my next job is adding CI for pull requests.