### PR TITLE
Update CI for compose.py changes

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -35,7 +35,7 @@ jobs:
           wget https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py
 
           cd ..
-          python3 build/compose.py UltimateCataclysm
+          python3 build/compose.py gfx/UltimateCataclysm
           cd build
 
           artifact_name=UltimateCataclysm-$(echo $GITHUB_SHA | cut -c -8)


### PR DESCRIPTION
It looks like https://github.com/CleverRaven/Cataclysm-DDA/pull/39744 broke the CI script here.

If so, this will fix it.