### PR TITLE
Update pngs_fillerhoder_32x32/vehicles

### DIFF
--- a/gfx/UltimateCataclysm/pngs_fillerhoder_32x32/vehicles/vehicles.json
+++ b/gfx/UltimateCataclysm/pngs_fillerhoder_32x32/vehicles/vehicles.json
@@ -736,6 +736,15 @@
   ]
 },
 {
+  "id": "wheel_motorbike_or",
+  "fg": [
+    "122_vp_wheel_motorbike_0"
+  ],
+  "bg": [
+    "193_battery_1"
+  ]
+},
+{
   "id": "wheel_small",
   "fg": [
     "123_vp_wheel_small_0"


### PR DESCRIPTION
Make it so off-road motorbike wheels use the same filler sprites as motorbike wheels