### PR TITLE
Use compose.py --obsolete-fillers

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -42,7 +42,7 @@ jobs:
           || echo "Error: Failed to get compose.py"
 
           cd ..
-          python3 build/compose.py --use-all gfx/UltimateCataclysm
+          python3 build/compose.py --use-all --obsolete-fillers gfx/UltimateCataclysm
           cd build
 
           artifact_name=UltimateCataclysm-$(echo $GITHUB_SHA | cut -c -8)


### PR DESCRIPTION
A new option from https://github.com/CleverRaven/Cataclysm-DDA/pull/46358 that shows what fillers are no longer needed and can be removed.