### PR TITLE
[BLB] Fix offset of big monsters

### DIFF
--- a/gfx/BrownLikeBears/tile_info.json
+++ b/gfx/BrownLikeBears/tile_info.json
@@ -10,7 +10,7 @@
     "tall.png": { "sprite_width": 30, "sprite_height": 60, "sprite_offset_x": 0, "sprite_offset_y": -40 }
   },
   {
-    "big.png": { "sprite_width": 40, "sprite_height": 40, "sprite_offset_x": 0, "sprite_offset_y": -20 }
+    "big.png": { "sprite_width": 40, "sprite_height": 40, "sprite_offset_x": -20, "sprite_offset_y": -20 }
   },
   {
     "toped.png": { "sprite_width": 20, "sprite_height": 25, "sprite_offset_x": -1, "sprite_offset_y": -5 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
BLB "Fix offset of big monsters"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, RetroDays, NeoDays, MSX, BLB, Chesthole, Infrastructure.-->

#### Content of the change

 Fix offset of big monster so they occupy the lower right corner of ther sprite

#### Testing

**Before**
![before](https://user-images.githubusercontent.com/41293484/108763209-6a3b3d00-7551-11eb-8a75-b551d3ec9037.png)


**After**
![after](https://user-images.githubusercontent.com/41293484/108763221-6e675a80-7551-11eb-9460-13e843ea1b53.png)


#### Additional informations
