### PR TITLE
Remove t_dirt in preparation for the new compose.py

### DIFF
--- a/gfx/UltimateCataclysm/pngs_fillerhoder_32x32/MShockXotto+/terrain/t_pit_corpsed.json
+++ b/gfx/UltimateCataclysm/pngs_fillerhoder_32x32/MShockXotto+/terrain/t_pit_corpsed.json
@@ -1,4 +1,4 @@
 [
-{"id": "t_pit_corpsed", "fg": "t_pit_corpsed", "bg": "t_dirt"},
+{"id": "t_pit_corpsed", "fg": "t_pit_corpsed", "bg": "t_dirt_center"},
 {"id": "t_pit_corpsed_season_winter", "fg": "t_pit_corpsed", "bg": "snow_shallow_center"}
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_dirt/t_dirt.png
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_dirt/t_dirt.png
@@ -1,1 +1,0 @@
-t_dirt_center.png


### PR DESCRIPTION
#### Summary
Ultica "Remove unused t_dirt"

#### Content of the change
Remove `t_dirt.png` In preparation for https://github.com/CleverRaven/Cataclysm-DDA/pull/48125
It was placed in a main tilesheet but only used in one filler.

#### Testing

#### Additional information
