### PR TITLE
[Chibi-Ultica] Add Magiclysm Character overlays to Chibi Ultica

### DIFF
--- a/gfx/Chibi_Ultica/pngs_ChibiNormalCharacterMagiclysm_32x32
+++ b/gfx/Chibi_Ultica/pngs_ChibiNormalCharacterMagiclysm_32x32
@@ -1,0 +1,1 @@
+../MShockXotto+/pngs_tiles_32x32/mods/Magiclysm/character

--- a/gfx/Chibi_Ultica/tile_info.json
+++ b/gfx/Chibi_Ultica/tile_info.json
@@ -20,6 +20,9 @@
     "ChibiNormalMonster.png": { "sprite_width": 32, "sprite_height": 32 }
   },
   {
+    "ChibiNormalCharacterMagiclysm.png": { "sprite_width": 32, "sprite_height": 32 }
+  },
+  {
     "ChibiNormalMonsterMagiclysm.png": { "sprite_width": 32, "sprite_height": 32 }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Chibi-Ultica "Add Magiclysm Character overlays to Chibi Ultica"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, RetroDays, NeoDays, MSX, BLB, Chesthole, MD, Infrastructure.-->

#### Content of the change

Add content from https://github.com/I-am-Erk/CDDA-Tilesets/pull/644 and https://github.com/I-am-Erk/CDDA-Tilesets/pull/645 to Chibi Ultica

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
