### PR TITLE
Ultica json for "special" otr

### DIFF
--- a/gfx/UltimateCataclysm/pngs_large_64x64/overmap/forest_thick.json
+++ b/gfx/UltimateCataclysm/pngs_large_64x64/overmap/forest_thick.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "forest_thick",
+    "id": [ "forest_thick", "special_forest_thick" ],
     "fg": [
         { "weight": 4, "sprite": "forest_thick" },
         { "weight": 1, "sprite": "forest_thick_2" }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/natural.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/natural.json
@@ -5,12 +5,12 @@
     "bg": ""
   },
   {
-    "id": "forest",
+	"id": [ "forest", "special_forest" ],
     "fg": "forest",
     "bg": "field"
   },
   {
-    "id": "field",
+    "id": [ "field", "special_field" ],
     "fg": "field",
     "bg": ""
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Ultica "json for "special" otr"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, Infrastructure.-->

#### Content of the change
Adds json for "special" overmap terrain, which seems to be used for isherwood quest. This is still an incomplete task because some terrain tiles are still missing altogether, but it's an improvement
<!-- Explain what does this pull request contain. -->

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
