### PR TITLE
Retrodays vehicle fix

### DIFF
--- a/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/retrodays_tempfix.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/retrodays_tempfix.json
@@ -15,14 +15,6 @@
     "id": [ "vp_stowboard_wheel_left", "vp_stowboard_wheel_right" ],
     "fg": ["2391_vp_stowboard_vertical_0"], "rotates": true, "multitile": true, "additional_tiles": [{"id": "broken", "fg": ["155_vp_cargo_bag_1"], "bg": []}], "bg": []},
   {
-    "id": "vp_windshield_wheel_left",
-    "fg": [ "vp_windshield_nw" ],
-    "bg": [  ],
-    "rotates": true,
-    "multitile": true,
-    "additional_tiles": [ { "id": "broken", "fg": [ "broken_windshield_nw" ], "bg": [  ] } ]
-  },
-  {
-    "id": [ "vp_windshield_wheel_right", "vp_windshield_full_wheel_left", "vp_windshield_full_wheel_right", "vp_windshield_vertical_2_left", "vp_windshield_vertical_2_right" ],
+    "id": [ "vp_windshield_wheel_left", "vp_windshield_wheel_right", "vp_windshield_full_wheel_left", "vp_windshield_full_wheel_right", "vp_windshield_vertical_2_left", "vp_windshield_vertical_2_right" ],
     "fg": ["2442_vp_windshield_0"], "rotates": true, "multitile": true, "additional_tiles": [{"id": "broken", "fg": ["2438_vp_reinforced_windshield_1"], "bg": []}], "bg": []}
 ]

--- a/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/retrodays_tempfix.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/retrodays_tempfix.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": [ "vp_halfboard_cover_right", "vp_halfboard_cover_left" ],
+    "fg": ["2368_vp_fxlhalfboard_horizontal_0"], "rotates": true, "multitile": true, "additional_tiles": [{"id": "broken", "fg": ["155_vp_cargo_bag_1"], "bg": []}], "bg": []},
+  {
+    "id": "vp_halfboard_hatch_wheel_left",
+    "fg": ["2372_vp_fxlhalfboard_sw_0"], "rotates": true, "multitile": true, "additional_tiles": [{"id": "broken", "fg": ["155_vp_cargo_bag_1"], "bg": []}], "bg": []},
+  {
+    "id": "vp_halfboard_hatch_wheel_right",
+    "fg": ["2373_vp_fxlhalfboard_se_0"], "rotates": true, "multitile": true, "additional_tiles": [{"id": "broken", "fg": ["155_vp_cargo_bag_1"], "bg": []}], "bg": []},
+  {
+    "id": [ "vp_halfboard_wheel_left", "vp_halfboard_wheel_right", "vp_board_wheel_left", "vp_board_nw_edge", "vp_board_wheel_right", "vp_board_ne_edge" ],
+    "fg": ["2366_vp_fxlhalfboard_vertical_0"], "rotates": true, "multitile": true, "additional_tiles": [{"id": "broken", "fg": ["155_vp_cargo_bag_1"], "bg": []}], "bg": []},
+  {
+    "id": [ vp_stowboard_wheel_left", "vp_stowboard_wheel_right" ],
+    "fg": ["2391_vp_stowboard_vertical_0"], "rotates": true, "multitile": true, "additional_tiles": [{"id": "broken", "fg": ["155_vp_cargo_bag_1"], "bg": []}], "bg": []},
+  {
+    "id": "vp_windshield_wheel_left",
+    "fg": [ "vp_windshield_nw" ],
+    "bg": [  ],
+    "rotates": true,
+    "multitile": true,
+    "additional_tiles": [ { "id": "broken", "fg": [ "broken_windshield_nw" ], "bg": [  ] } ]
+  },
+  {
+    "id": [ "vp_windshield_wheel_right", "vp_windshield_full_wheel_left", "vp_windshield_full_wheel_right", "vp_windshield_vertical_2_left", "vp_windshield_vertical_2_right" ],
+    "fg": ["2442_vp_windshield_0"], "rotates": true, "multitile": true, "additional_tiles": [{"id": "broken", "fg": ["2438_vp_reinforced_windshield_1"], "bg": []}], "bg": []}
+]

--- a/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/retrodays_tempfix.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/retrodays_tempfix.json
@@ -12,7 +12,7 @@
     "id": [ "vp_halfboard_wheel_left", "vp_halfboard_wheel_right", "vp_board_wheel_left", "vp_board_nw_edge", "vp_board_wheel_right", "vp_board_ne_edge" ],
     "fg": ["2366_vp_fxlhalfboard_vertical_0"], "rotates": true, "multitile": true, "additional_tiles": [{"id": "broken", "fg": ["155_vp_cargo_bag_1"], "bg": []}], "bg": []},
   {
-    "id": [ vp_stowboard_wheel_left", "vp_stowboard_wheel_right" ],
+    "id": [ "vp_stowboard_wheel_left", "vp_stowboard_wheel_right" ],
     "fg": ["2391_vp_stowboard_vertical_0"], "rotates": true, "multitile": true, "additional_tiles": [{"id": "broken", "fg": ["155_vp_cargo_bag_1"], "bg": []}], "bg": []},
   {
     "id": "vp_windshield_wheel_left",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
RetroDays "vehicle fix"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, Infrastructure.-->

#### Content of the change
Adds sprites to new vehicle part shapes in https://github.com/CleverRaven/Cataclysm-DDA/pull/50632
<!-- Explain what does this pull request contain. -->

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
