### PR TITLE
Infrastructure "Fix CI check detecting tabs in filename lines produced by git diff"

### DIFF
--- a/.github/workflows/editorconfig_conformance.yml
+++ b/.github/workflows/editorconfig_conformance.yml
@@ -30,6 +30,6 @@ jobs:
         run: |
           git diff origin/${{ github.base_ref }} --name-only '*.json' '*.py' \
           | xargs -d'\n' git diff -U0 origin/${{ github.base_ref }} -- \
-          | grep $'^+.*\t' \
+          | grep $'^+[^+].*\t' \
           && exit 1 \
           || exit 0


### PR DESCRIPTION
#### Summary
Infrastructure "Fix CI check detecting tabs in filename lines produced by git diff"

#### Content of the change
Don't detect lines starting with multiple plus signs.

`git diff -U0 master -- ants.json > /tmp/int/tmp.diff` was enough to reproduce it locally. With any file that was placed inside a directory with a space in the name.

#### Additional information
#916

https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_whitespace