### PR TITLE
Give filter masks a non-overlay sprite.

### DIFF
--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/clothes/clothes.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/clothes/clothes.json
@@ -140,7 +140,7 @@
     "bg": ""
   },
   {
-    "id": "mask_dust",
+    "id": ["mask_dust", "mask_filter"],
     "fg": "mask_dust",
     "bg": ""
   },


### PR DESCRIPTION
#### Summary
Ultica "Filter mask item uses dust mask sprite"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, Infrastructure.-->

#### Content of the change
JSON-only change to the sprite definition for dust mask, turning it into an array with an additional value.

Hopefully a trivial patch to add a sprite for filter masks and get started contributing.

This won't be very consistent with the overlay appearance, but it's
better than nothing!


#### Testing
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
Great project, excited to contribute more!