### PR TITLE
Add shared IDs for similar mutation overlays.

### DIFF
--- a/gfx/UltimateCataclysm/pngs_human_body_32x36/overlay/mutations/arachnid_arms/arachnid_arms.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_32x36/overlay/mutations/arachnid_arms/arachnid_arms.json
@@ -1,11 +1,11 @@
 [
   {
-    "id": "overlay_female_mutation_ARACHNID_ARMS",
+    "id": ["overlay_female_mutation_ARACHNID_ARMS", "overlay_female_mutation_ARACHNID_ARMS_OK"],
     "fg": "arachnid_arms_f",
     "bg": ""
   },
   {
-    "id": "overlay_male_mutation_ARACHNID_ARMS",
+    "id": ["overlay_male_mutation_ARACHNID_ARMS", "overlay_male_mutation_ARACHNID_ARMS_OK"],
     "fg": "arachnid_arms_m",
     "bg": ""
   }

--- a/gfx/UltimateCataclysm/pngs_human_body_32x36/overlay/skin/skins_mutation.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_32x36/overlay/skin/skins_mutation.json
@@ -1,21 +1,21 @@
 [
   {
-    "id": "overlay_female_mutation_CHITIN",
+    "id": ["overlay_female_mutation_CHITIN", "overlay_female_mutation_CHITIN_FUR", "overlay_female_mutation_CHITIN_FUR2"],
     "fg": "chitin_f",
     "bg": ""
   },
   {
-    "id": "overlay_male_mutation_CHITIN",
+    "id": ["overlay_male_mutation_CHITIN", "overlay_male_mutation_CHITIN_FUR", "overlay_male_mutation_CHITIN_FUR2"],
     "fg": "chitin_m",
     "bg": ""
   },
   {
-    "id": "overlay_female_mutation_CHITIN2",
+    "id": ["overlay_female_mutation_CHITIN2", "overlay_female_mutation_CHITIN3", "overlay_female_mutation_CHITIN_FUR3"],
     "fg": "chitin2_f",
     "bg": ""
   },
   {
-    "id": "overlay_male_mutation_CHITIN2",
+    "id": ["overlay_male_mutation_CHITIN2", "overlay_male_mutation_CHITIN3", "overlay_male_mutation_CHITIN_FUR3"],
     "fg": "chitin2_m",
     "bg": ""
   },


### PR DESCRIPTION
#### Summary
Ultica "Add shared IDs for similar mutation overlays.(Spider)"

#### Content of the change
This adds some of the IDs for the spider skins and limbs that don't have a sprite to the existing ones to the ID lists for skins and arachnid limbs. They are very similar anyway and this way they have an appropriate looking overlay until a better one is drawn.
This way, there aren't any jarring skin changes when mutating to a missing one and seeing your character with their original skin all of the sudden.

#### Testing
Composed the tileset and overwrote ultica on a clean copy. It seems to work.

#### Additional information
