### PR TITLE
Revert "Give filter masks a non-overlay sprite."

### DIFF
--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/clothes/clothes.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/clothes/clothes.json
@@ -140,7 +140,7 @@
     "bg": ""
   },
   {
-    "id": ["mask_dust", "mask_filter"],
+    "id": "mask_dust",
     "fg": "mask_dust",
     "bg": ""
   },


### PR DESCRIPTION
This reverts commit a9825f9e490ad7f356fc0e4ad6d9fe838cc07b09. Acepleiades
rightly pointed out in the comments of #928 that this change could be
confusing for whoever eventually implements a unique filter mask sprite.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Ultica "Revert Give filter masks a non-overlay sprite."
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, Infrastructure.-->

#### Content of the change

For the sake of practice, I'm filing this PR and adding a `looks_like`
entry to achieve the same results in the main repository.

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information

Sorry for the extra paperwork!
