### PR TITLE
[Chibi-Ultica] Fix Chibi Ultica

### DIFF
--- a/gfx/Chibi_Ultica/pngs_ChibiSmallMonster_20x20
+++ b/gfx/Chibi_Ultica/pngs_ChibiSmallMonster_20x20
@@ -1,0 +1,1 @@
+../MShockXotto+/pngs_small_20x20/monsters

--- a/gfx/Chibi_Ultica/pngs_widemonsters_32x48
+++ b/gfx/Chibi_Ultica/pngs_widemonsters_32x48
@@ -1,0 +1,1 @@
+../UltimateCataclysm/pngs_human_body_plus_32x48/monsters

--- a/gfx/Chibi_Ultica/pngs_widevehicle_32x48
+++ b/gfx/Chibi_Ultica/pngs_widevehicle_32x48
@@ -1,0 +1,1 @@
+../UltimateCataclysm/pngs_human_body_plus_32x48/vehicle

--- a/gfx/Chibi_Ultica/tile_info.json
+++ b/gfx/Chibi_Ultica/tile_info.json
@@ -47,6 +47,9 @@
     "ChibiHugeAftershockMonster.png": { "sprite_width": 128, "sprite_height": 128, "sprite_offset_x": -64, "sprite_offset_y": -96 }
   },
   {
+    "ChibismallMonster.png": { "sprite_width": 20, "sprite_height": 20, "sprite_offset_x": 0, "sprite_offset_y": 0 }
+  },
+  {
     "small.png": { "sprite_width": 20, "sprite_height": 20, "filler": true }
   },
   {
@@ -84,6 +87,12 @@
   },
   {
     "incomplete_large.png": { "sprite_width": 64, "sprite_height": 64, "sprite_offset_x": -16, "sprite_offset_y": -32, "filler": true }
+  },
+  {
+    "widemonsters.png": { "sprite_width": 32, "sprite_height": 48, "sprite_offset_y": -16, "filler": true }
+  },
+  {
+    "widevehicle.png": { "sprite_width": 32, "sprite_height": 48, "sprite_offset_y": -16, "filler": true }
   },
   {
     "fillerhoder.png": {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Chibi-Ultica "Fix Chibi Ultica"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, Infrastructure.-->

#### Content of the change

Add back monster and vehicles that were moved to 32x48 folder

#### Testing

![image](https://user-images.githubusercontent.com/41293484/132918696-788d6e97-7cc0-4d7b-bebe-c59125aa510c.png)


#### Additional information
