### PR TITLE
[MSX] Use symlink to use SurveyorMap as filler overmap

### DIFF
--- a/gfx/MShockXotto+/pngs_fillerovermap_32x32
+++ b/gfx/MShockXotto+/pngs_fillerovermap_32x32
@@ -1,0 +1,1 @@
+../SurveyorsMap/pngs_normal_32x32

--- a/gfx/MShockXotto+/tile_info.json
+++ b/gfx/MShockXotto+/tile_info.json
@@ -35,6 +35,9 @@
     "fillernormal.png": { "filler": true }
   },
   {
+    "fillerovermap.png": { "filler": true }
+  },
+  {
     "fillertall.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
MSX "Use symlink to use SurveyorMap as filler overmap"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica,NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Infrastructure.-->

#### Content of the change

Use symlink to use SurveyorMap as filler overmap
#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
