### PR TITLE
initial setup for GeneratedOvermap tileset

### DIFF
--- a/gfx/GeneratedOvermap/pngs_surveyormap_24x24
+++ b/gfx/GeneratedOvermap/pngs_surveyormap_24x24
@@ -1,0 +1,1 @@
+../SurveyorsMap/pngs_overmap_24x24/

--- a/gfx/GeneratedOvermap/tile_info.json
+++ b/gfx/GeneratedOvermap/tile_info.json
@@ -1,0 +1,19 @@
+[
+  {
+    "pixelscale": 1,
+    "width": 24,
+    "height": 24
+  },
+  {
+    "generated_overmap.png": {  }
+  },
+  {
+    "surveyormap.png": { "filler": true }
+  },
+  {
+    "fallback.png": {
+      "source": "https://github.com/Chezzo/Cataclysm-DDA/blob/0ca0b5307f1b2fab7edb5519a3176e1d887087a7/gfx/ChestHole32Tileset/fallback.png",
+      "fallback": true
+    }
+  }
+]

--- a/gfx/GeneratedOvermap/tileset.txt
+++ b/gfx/GeneratedOvermap/tileset.txt
@@ -1,0 +1,4 @@
+NAME: GeneratedOvermap
+VIEW: GeneratedOvermap+SurveyorsMap
+JSON: tile_config.json
+TILESET: generated_overmap.png


### PR DESCRIPTION
#### Summary
Smap "initial setup for GeneratedOvermap tileset"

#### Content of the change
A tileset that uses autogenerated sprites and SurveyorMap as a fallback, see 
https://github.com/CleverRaven/Cataclysm-DDA/pull/53296

#### Testing

![screenshot](https://user-images.githubusercontent.com/1585431/145438319-ba170bb5-61f4-40bf-b38d-d0c81063af80.png)

#### Additional information