### PR TITLE
[Chibi-Ultica] Use exclude argument part 1: the easy part

### DIFF
--- a/gfx/Chibi_Ultica/tile_info.json
+++ b/gfx/Chibi_Ultica/tile_info.json
@@ -68,7 +68,7 @@
     "small.png": { "sprite_width": 20, "sprite_height": 20, "filler": true }
   },
   {
-    "normal.png": { "filler": true }
+    "normal.png": { "filler": true, "exclude": [ "overlay" ] }
   },
   {
     "tallfurniture.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true }
@@ -89,7 +89,14 @@
     "centered.png": { "sprite_width": 64, "sprite_height": 64, "sprite_offset_x": -16, "sprite_offset_y": -16, "filler": true }
   },
   {
-    "large.png": { "sprite_width": 64, "sprite_height": 64, "sprite_offset_x": -16, "sprite_offset_y": -32, "filler": true }
+    "large.png": {
+      "sprite_width": 64,
+      "sprite_height": 64,
+      "sprite_offset_x": -16,
+      "sprite_offset_y": -32,
+      "filler": true,
+      "exclude": [ "overlay" ]
+    }
   },
   {
     "giant.png": { "sprite_width": 96, "sprite_height": 96, "sprite_offset_x": -32, "sprite_offset_y": -64, "filler": true }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Chibi-Ultica "Use exclude argument part 1: the easy part"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Infrastructure.-->

#### Content of the change

Use the new `exclude` option of the `compose` script where it doesn't require to restructure the folders

#### Testing

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/56602

![image](https://user-images.githubusercontent.com/41293484/162075394-cfe6b323-7cf6-4f14-94b9-896829c988cd.png)

#### Additional information
Thanks to https://github.com/CleverRaven/Cataclysm-DDA/pull/56493 we can now rework Chibi Ultica (and Altica) folder structure