### PR TITLE
[MSX] Do some silly json to fix hooves in Chibi Ultica

### DIFF
--- a/gfx/MShockXotto+/pngs_tiles_32x32/character/overlay/mutations/overlay_mutation_HOOVES.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/character/overlay/mutations/overlay_mutation_HOOVES.json
@@ -1,7 +1,9 @@
 {
   "id": [
-    "overlay_mutation_HOOVES",
-    "overlay_mutation_DEMON_HOOVES"
+    "overlay_female_mutation_HOOVES",
+    "overlay_female_mutation_DEMON_HOOVES",
+    "overlay_male_mutation_HOOVES",
+    "overlay_male_mutation_DEMON_HOOVES"
   ],
   "fg": [
     "overlay_mutation_HOOVES"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
MSX "Change json to fix hooves in chibi ultica"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Infrastructure.-->

#### Content of the change
Fixes [#53982](https://github.com/CleverRaven/Cataclysm-DDA/issues/53982)

#### Testing

![image](https://user-images.githubusercontent.com/41293484/151316336-4a52ceb5-bd40-4931-a016-d3318f256490.png)


#### Additional information

Compose.py was getting confused because MSX only defines hooves in generale while Ultica has hooves for female and male
