### PR TITLE
swapped format for layering.json

### DIFF
--- a/gfx/UltimateCataclysm/layering.json
+++ b/gfx/UltimateCataclysm/layering.json
@@ -1,8 +1,8 @@
 {
-"item_variants": [
+"variants": [
   {
     "context": "f_desk",
-    "variants": [
+    "item_variants": [
       {
         "item": "laptop",
         "sprite": [{"id": "desk_laptop", "weight": 1}],
@@ -22,7 +22,7 @@
   },
   {
     "context": "f_oven",
-    "variants": [
+    "item_variants": [
       {
         "item": "pan",
         "sprite": [{"id": "oven_pan_1", "weight": 1}, {"id": "oven_pan_2", "weight": 1}],
@@ -32,7 +32,7 @@
   },
   {
     "context": "f_brazier",
-    "variants": [
+    "item_variants": [
       {
         "item": "2x4",
         "sprite": [{"id": "brazier_2x4", "weight": 1}],
@@ -47,7 +47,7 @@
   },
   {
     "context": "f_toilet",
-    "variants": [
+    "item_variants": [
       {
         "item": "water",
         "sprite": [{"id": "toilet_water", "weight": 1}],
@@ -62,7 +62,7 @@
   },
   {
     "context": "f_fireplace",
-    "variants": [
+    "item_variants": [
       {
         "item": "log",
         "sprite": [{"id": "fireplace_log", "weight": 1}],
@@ -72,7 +72,7 @@
   },
   {
     "context": "f_cupboard",
-    "variants": [
+    "item_variants": [
       {
         "item": "battery_charger",
         "sprite": [{"id": "cupboard_battery_charger", "weight": 1}],
@@ -97,7 +97,7 @@
   },
   {
     "context": "f_sink",
-    "variants": [
+    "item_variants": [
       {
         "item": "box_small",
         "sprite": [{"id": "sink_box_small", "weight": 1}],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Ultica "Changed format for layering.json"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Infrastructure.-->

#### Content of the change
This content makes the layering.json work with https://github.com/CleverRaven/Cataclysm-DDA/pull/55416

Until that is merged this will break Ultica,
After that is merged without this Ultica will break.

<!-- Explain what does this pull request contain. -->

#### Testing
layering still works on my dirty version with https://github.com/CleverRaven/Cataclysm-DDA/pull/55416 included
![image](https://user-images.githubusercontent.com/4514073/154179469-6f9fde16-1a56-46ef-a2a4-615df25b6dda.png)

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
