### PR TITLE
[Retro/Neo Days] Update 1st_aid to 1st_aid_box

### DIFF
--- a/gfx/NeoDays/pngs_tiles_10x10/items/1st_aid_0.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/items/1st_aid_0.json
@@ -1,1 +1,13 @@
-{"id": "1st_aid", "fg": ["2006_1st_aid_0"], "rotates": false, "bg": []}
+{
+  "id": [
+    "1st_aid",
+    "1st_aid_box"
+  ],
+  "fg": [
+    "2006_1st_aid_0"
+  ],
+  "rotates": false,
+  "bg": [
+    
+  ]
+}

--- a/gfx/Retrodays/pngs_tiles_10x10/item/1st_aid_0.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/item/1st_aid_0.json
@@ -1,1 +1,13 @@
-{"id": "1st_aid", "fg": ["2006_1st_aid_0"], "rotates": false, "bg": []}
+{
+  "id": [
+    "1st_aid",
+    "1st_aid_box"
+  ],
+  "fg": [
+    "2006_1st_aid_0"
+  ],
+  "rotates": false,
+  "bg": [
+    
+  ]
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
NeoDays "Update 1st_aid to 1st_aid_box"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Infrastructure.-->

#### Content of the change

Port https://github.com/CleverRaven/Cataclysm-DDA/pull/55547
Make 1st_aid_box use the 1st_aid sprite

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information

We should probably remove 1st_aid at some point since it's obsolete, but doing it this way keep the tileset retro compatible.
