### PR TITLE
Translated Larwick overmap fixes to tileset repo

### DIFF
--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_icons.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_icons.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "cursor",
+    "fg": "cursor",
+    "bg": ""
+  },
+  {
+    "id": "highlight",
+    "fg": "highlight",
+    "bg": ""
+  },
+  {
+    "id": "highlight_item",
+    "fg": "highlight",
+    "bg": ""
+  },
+  {
+    "id": "line_target",
+    "fg": "cursor",
+    "bg": ""
+  },
+  {
+    "id": "line_trail",
+    "fg": "cursor",
+    "bg": ""
+  },
+  {
+    "id": "animation_line",
+    "fg": "cursor",
+    "bg": ""
+  },
+  {
+	"id": "unknown_map_extra",
+	"fg": "",
+	"bg": ""
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Larwick "Added definitions for highlight, highlight_item, line_target, line_trail, animation_line, and unknown_map_extra "
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
Just JSON - Translating my fixes from the main CDDA repo over to here.

#### Testing
None yet. Should probably try composing the tileset to see if it works.

#### Additional information
