### PR TITLE
Regular battery sprite for disposable ultra-light

### DIFF
--- a/gfx/UltimateCataclysm/pngs_small_20x20/items/batteries/batteries.json
+++ b/gfx/UltimateCataclysm/pngs_small_20x20/items/batteries/batteries.json
@@ -45,6 +45,11 @@
     "bg": ""
   },
   {
+    "id": "light_minus_disposable_battery_cell",
+    "fg": "light_minus_battery_cell",
+    "bg": ""
+  },
+  {
     "id": "light_minus_atomic_battery_cell",
     "fg": "light_minus_atomic_battery_cell",
     "bg": ""


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Ultica "ultra-light disposable battery uses fake item sprite"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
Use sprite from ultra-light battery instead of falling back to `battery` for ultra-light disposable battery.
<!-- Explain what does this pull request contain. -->

#### Testing
None.
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
Followed by discussion on Discord.