### PR TITLE
[Chibi] Re-add Ultica monsters as fillers

### DIFF
--- a/gfx/Chibi_Ultica/tile_info.json
+++ b/gfx/Chibi_Ultica/tile_info.json
@@ -60,7 +60,7 @@
     "small.png": { "sprite_width": 20, "sprite_height": 20, "filler": true }
   },
   {
-    "normal.png": { "filler": true, "exclude": [ "overlay/mutations", "overlay/wielded", "overlay/worn", "monsters" ] }
+    "normal.png": { "filler": true, "exclude": [ "overlay/mutations", "overlay/wielded", "overlay/worn" ] }
   },
   {
     "tall.png": {
@@ -68,7 +68,7 @@
       "sprite_height": 64,
       "sprite_offset_y": -32,
       "filler": true,
-      "exclude": [ "monsters", "overlay" ]
+      "exclude": [ "overlay" ]
     }
   },
   {
@@ -105,7 +105,7 @@
       "sprite_height": 48,
       "sprite_offset_y": -16,
       "filler": true,
-      "exclude": [ "character", "monsters", "overlay" ]
+      "exclude": [ "character", "overlay" ]
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Chibi-Ultica "Re-add Ultica monsters as fillers"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
Fixes #1322 

#### Testing

![image](https://user-images.githubusercontent.com/41293484/166142798-9222fec9-d77b-4236-aaf4-4701133bcc38.png)

#### Additional information
