### PR TITLE
feat: automatic releases

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -1,69 +1,158 @@
 # Creates a release using compose.py from https://github.com/CleverRaven/Cataclysm-DDA
 #
-# This action is triggerd by pushing any tag starting with v (e.g. v1.0.1 or v3.D)
-#
-# The release archive will be named using the version number from the tag (e.g. UltimateCataclysm-1.0)
-
-on:
-  push:
-    tags:
-    - 'v*'
+# This action is runs at 12:00 UTC Sunday
 
 name: Make Release
+concurrency: release
+on:
+  schedule:
+    - cron: '0 12 * * sun'
 
 jobs:
-  build:
-    name: Make Release
+  release:
+    name: Create Release
     runs-on: ubuntu-latest
-    container: alpine:latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      timestamp: ${{ steps.get-timestamp.outputs.time }}
+      release_already_exists: ${{ steps.tag_check.outputs.exists }}
+    steps:
+      - name: Get build timestamp
+        id: get-timestamp
+        uses: nanzm/get-time-action@v1.1
+        with:
+          timeZone: 0
+          format: 'YYYY-MM-DD'
+      - name: Generate environmental variables
+        id: generate_env_vars
+        run: |
+          echo "::set-output name=tag_name::${{ steps.get-timestamp.outputs.time }}"
+          echo "::set-output name=release_name::Tilesets Release ${{ steps.get-timestamp.outputs.time }}"
+      - name: Check if there is existing git tag
+        id: tag_check
+        uses: mukunku/tag-exists-action@v1.0.0
+        with:
+          tag: ${{ steps.generate_env_vars.outputs.tag_name }}  
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v5.5
+        if: ${{ steps.tag_check.outputs.exists == 'false' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.generate_env_vars.outputs.tag_name }}
+          tag_prefix: ""
+      - name: Get Previous tag
+        id: previous_tag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with:
+          fallback: ${{ steps.generate_env_vars.outputs.tag_name }}
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@main
+        if: ${{ steps.tag_check.outputs.exists == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.generate_env_vars.outputs.tag_name }}
+          release_name: ${{ steps.generate_env_vars.outputs.release_name }}
+          body: |
+            Full Changelog [${{ steps.previous_tag.outputs.tag }}...${{ steps.generate_env_vars.outputs.tag_name }}](https://github.com/${{ github.repository }}/compare/${{ steps.previous_tag.outputs.tag }}...${{ steps.generate_env_vars.outputs.tag_name }})
+          draft: false
+          prerelease: false
+
+  builds:
+    needs: release
+    if: ${{ needs.release.outputs.release_already_exists == 'false' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Altica
+            artifact: Altica
+            tileset_dir: gfx/Altica
+            compose_args: --use-all --obsolete-fillers
+          - name: BrownLikeBears
+            artifact: BrownLikeBears
+            tileset_dir: gfx/BrownLikeBears
+            compose_args: --use-all --obsolete-fillers
+          - name: Chibi_Ultica
+            artifact: Chibi_Ultica
+            tileset_dir: gfx/Chibi_Ultica
+            compose_args: --use-all
+          - name: HollowMoon
+            artifact: HollowMoon
+            tileset_dir: gfx/HollowMoon
+            compose_args: --use-all --obsolete-fillers
+          - name: Larwick_Overmap
+            artifact: Larwick_Overmap
+            tileset_dir: gfx/Larwick_Overmap
+            compose_args: --use-all
+          - name: MShockXotto+
+            artifact: MShockXotto+
+            tileset_dir: gfx/MShockXotto+
+            compose_args: --use-all
+          - name: NeoDays
+            artifact: NeoDaysTileset
+            tileset_dir: gfx/NeoDays
+            compose_args: --use-all
+          - name: Retrodays
+            artifact: RetroDaysTileset
+            tileset_dir: gfx/Retrodays
+            compose_args: --use-all
+          - name: SurveyorsMap
+            artifact: SurveyorsMap
+            tileset_dir: gfx/SurveyorsMap
+            compose_args: --use-all
+          - name: UltimateCataclysm
+            artifact: UltimateCataclysm
+            tileset_dir: gfx/UltimateCataclysm
+            compose_args: --use-all --obsolete-fillers
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
         run: |
-          apk add --no-cache musl-dev gcc vips-dev python3-dev zip
+          sudo apt update
+          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
 
       - name: Build
         id: build
         run: |
-          mkdir build && cd build
-          wget https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py
+          mkdir build
+          wget -q -P build https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          || echo "Error: Failed to get compose.py"
 
-          cd ..
-          python3 build/compose.py UltimateCataclysm
-          cd build
+          python3 build/compose.py ${{matrix.compose_args}} "${{matrix.tileset_dir}}" build
+          [ -f "${{matrix.tileset_dir}}/fallback.png" ] && mv "${{matrix.tileset_dir}}/fallback.png" build
+          [ -f "${{matrix.tileset_dir}}/leyering.json" ] && mv "${{matrix.tileset_dir}}/layering.json" build
 
-          release_name=UltimateCataclysm-$(basename $GITHUB_REF | cut -c 2-)
-          tileset_dir=../gfx/UltimateCataclysm
+          release_name=${{matrix.artifact}}
+
+          tileset_dir=build
 
           mkdir $release_name
-          mv $tileset_dir/*.png            $release_name
-          mv $tileset_dir/tile_config.json $release_name
-          mv $tileset_dir/tileset.txt      $release_name
+          mv build/*.png                         $release_name
+          mv build/tile_config.json              $release_name
+          mv ${{matrix.tileset_dir}}/tileset.txt $release_name
+          [ -f "${{matrix.tileset_dir}}/layering.json" ] && mv "${{matrix.tileset_dir}}/layering.json" $release_name
 
           zip -r $release_name.zip $release_name
 
           echo ::set-output name=release_name::$release_name
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Ultimate Cataclysm ${{ github.ref }}
-          draft: true
-          prerelease: false
-
       - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build/${{ steps.build.outputs.release_name }}.zip
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ${{ steps.build.outputs.release_name }}.zip
           asset_name: ${{ steps.build.outputs.release_name }}.zip
           asset_content_type: application/zip


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Infrastructure "automate releases"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
To help fris with <https://github.com/Fris0uman/CDDA-Tilesets/pull/9>

To automate what can be automated, this job is perfect for a bot, let them do it
- [x] Matrix composes all tilesets and releases them
- [x] Per-tileset composer arguments
- [x] Only runs at 12:00 UTC sundays

Still on the DOTO list - maybe for later
~~- [ ] Don't compose if there are no changes since previous release~~ 
~~- [ ] Simple automated changelog like this one <https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/cbn-experimental-2022-04-26-1858>~~
<!-- Explain what does this pull request contain. -->

#### Testing
This commit <https://github.com/casswedson/CDDA-Tilesets/commit/623636af939ceab00933deebdcdb507ed3af0ad7> triggers <https://github.com/casswedson/CDDA-Tilesets/runs/6251026427?check_suite_focus=true> making <https://github.com/casswedson/CDDA-Tilesets/releases/tag/2022-05-02>
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
