### PR TITLE
[MSX] Fix Nurse bot json

### DIFF
--- a/gfx/MShockXotto+/pngs_tall_32x48/monster/mon_nursebot.json
+++ b/gfx/MShockXotto+/pngs_tall_32x48/monster/mon_nursebot.json
@@ -1,7 +1,11 @@
 [
   {
-    "id": "mon_nursebot",
-    "fg": [ "mon_nursebot", "mon_nursebot_1", "mon_nursebot_2" ],
+    "id": [ "mon_nursebot", "mon_nursebot_defective" ],
+    "fg": [
+      { "weight": 1, "sprite": "mon_nursebot" },
+      { "weight": 1, "sprite": "mon_nursebot_1" },
+      { "weight": 1, "sprite": "mon_nursebot_2" }
+    ],
     "rotates": false,
     "bg": [  ]
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
MSX "Fix Nurse bot json"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
Fix json to:
- show all three variants
- use same sprite for nurse bot and defective nurse bot in Chibi Ultica

#### Testing
![image](https://user-images.githubusercontent.com/41293484/166643546-e6512eed-8168-44c9-8889-9606ba525214.png)


#### Additional information
