### PR TITLE
ft. releaser tweaking

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -21,21 +21,22 @@ jobs:
         id: get-timestamp
         uses: nanzm/get-time-action@v1.1
         with:
-          timeZone: 0
           format: 'YYYY-MM-DD'
       - name: Generate environmental variables
         id: generate_env_vars
         run: |
           echo "::set-output name=tag_name::${{ steps.get-timestamp.outputs.time }}"
           echo "::set-output name=release_name::Tilesets Release ${{ steps.get-timestamp.outputs.time }}"
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Check if there is existing git tag
         id: tag_check
         uses: mukunku/tag-exists-action@v1.0.0
         with:
-          tag: ${{ steps.generate_env_vars.outputs.tag_name }}  
+          tag: ${{ steps.generate_env_vars.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v3
       - name: Push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v5.5
@@ -47,8 +48,6 @@ jobs:
       - name: Get Previous tag
         id: previous_tag
         uses: WyriHaximus/github-action-get-previous-tag@v1
-        with:
-          fallback: ${{ steps.generate_env_vars.outputs.tag_name }}
       - name: Create release
         id: create_release
         uses: actions/create-release@main
@@ -125,22 +124,18 @@ jobs:
       - name: Build
         id: build
         run: |
-          mkdir build
-          wget -q -P build https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          wget https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
           || echo "Error: Failed to get compose.py"
 
-          python3 build/compose.py ${{matrix.compose_args}} "${{matrix.tileset_dir}}" build
-          [ -f "${{matrix.tileset_dir}}/fallback.png" ] && mv "${{matrix.tileset_dir}}/fallback.png" build
-          [ -f "${{matrix.tileset_dir}}/leyering.json" ] && mv "${{matrix.tileset_dir}}/layering.json" build
+          mkdir build
+          python3 compose.py ${{matrix.compose_args}} --feedback CONCISE --loglevel INFO "${{matrix.tileset_dir}}" build
 
           release_name=${{matrix.artifact}}
-
-          tileset_dir=build
-
           mkdir $release_name
-          mv build/*.png                         $release_name
-          mv build/tile_config.json              $release_name
+
+          cp -r build/*                          $release_name
           mv ${{matrix.tileset_dir}}/tileset.txt $release_name
+          [ -f "${{matrix.tileset_dir}}/fallback.png" ] && mv "${{matrix.tileset_dir}}/fallback.png" $release_name
           [ -f "${{matrix.tileset_dir}}/layering.json" ] && mv "${{matrix.tileset_dir}}/layering.json" $release_name
 
           zip -r $release_name.zip $release_name


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
To fix an error related with the default body of a release, it just compares the changes with itself

plus some other things I wanted to change, one of them is get the logs of the composer, useful when errors pop up the other was to do fewer steps to prepare the assets for a release, this saves like milliseconds, but I do like clean code
<!-- Explain what does this pull request contain. -->

#### Testing
The commit you are essencially looking at in this pr
https://github.com/casswedson/CDDA-Tilesets/commit/74aa439b6db0bf0419e857450298ebef9eb0906e
and one that fixes an ultica composer error aka https://github.com/I-am-Erk/CDDA-Tilesets/pull/1337
https://github.com/casswedson/CDDA-Tilesets/commit/20fd236b5b3f0ded7546bc4b5f2c03d65f601be4
They make https://github.com/casswedson/CDDA-Tilesets/releases/tag/2022-05-08-1740
With no tag comparison errors and the ultica asset is there
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
