### PR TITLE
Fix name of ChibiUltica artifact

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -77,8 +77,8 @@ jobs:
             artifact: BrownLikeBears
             tileset_dir: gfx/BrownLikeBears
             compose_args: --use-all --obsolete-fillers
-          - name: Chibi_Ultica
-            artifact: Chibi_Ultica
+          - name: ChibiUltica
+            artifact: ChibiUltica
             tileset_dir: gfx/Chibi_Ultica
             compose_args: --use-all
           - name: HollowMoon


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change

Change name to ChibiUltica to match the name of the folder in the game repo

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
