### PR TITLE
fix: msx artifact name

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -89,7 +89,7 @@ jobs:
             artifact: Larwick_Overmap
             tileset_dir: gfx/Larwick_Overmap
             compose_args: --use-all
-          - name: MShockXotto+
+          - name: MshockXotto+
             artifact: MShockXotto+
             tileset_dir: gfx/MShockXotto+
             compose_args: --use-all


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
in preparation for automatic tileset updates for the CDDA repo, the
release artifacts need to be named exactly as the folders in the
`gfx/` folder of CDDA

in CDDA `MshockXotto+` as a release asset here `MShockXotto+`

<!-- Explain what does this pull request contain. -->

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
