### PR TITLE
feat: skip release if there are no changes

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -37,6 +37,13 @@ jobs:
           tag: ${{ steps.generate_env_vars.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Previous tag
+        id: previous_tag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+      - name: Abort if there are no changes
+        run: |
+          # exit 1 if there are no changes, exit 0 if there are changes
+          git diff ${{ steps.previous_tag.outputs.tag }} | grep ""
       - name: Push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v5.5
@@ -45,9 +52,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.generate_env_vars.outputs.tag_name }}
           tag_prefix: ""
-      - name: Get Previous tag
-        id: previous_tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
       - name: Create release
         id: create_release
         uses: actions/create-release@main


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
also try not to 'fail' before pushing a tag, we don't want to cancel a
release but push a tag anyway

<!-- Explain what does this pull request contain. -->

#### Testing
https://github.com/casswedson/CDDA-Tilesets/commit/a0a00eb2afdd1d90c5049aa5df1256dc8f56e532 this commit doesn't make any changes, thus releaser fails, it does it before pushing a tag, pushing tags is similar to making releases I'd like to avoid that
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
