### PR TITLE
feat: auto generate release notes

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 12 * * sun'
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   release:
     name: Create Release
@@ -52,6 +55,15 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.generate_env_vars.outputs.tag_name }}
           tag_prefix: ""
+      - name: "Generate release notes"
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            /repos/I-am-Erk/CDDA-Tilesets/releases/generate-notes \
+            -f tag_name='${{ steps.generate_env_vars.outputs.tag_name }}' \
+            -f target_commitish='master' \
+            -q .body > CHANGELOG.md
       - name: Create release
         id: create_release
         uses: actions/create-release@main
@@ -61,8 +73,7 @@ jobs:
         with:
           tag_name: ${{ steps.generate_env_vars.outputs.tag_name }}
           release_name: ${{ steps.generate_env_vars.outputs.release_name }}
-          body: |
-            Full Changelog [${{ steps.previous_tag.outputs.tag }}...${{ steps.generate_env_vars.outputs.tag_name }}](https://github.com/${{ github.repository }}/compare/${{ steps.previous_tag.outputs.tag }}...${{ steps.generate_env_vars.outputs.tag_name }})
+          body_path: ./CHANGELOG.md
           draft: false
           prerelease: false
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
A few days ago, I asked Fris how to make release notes this pretty <https://github.com/I-am-Erk/CDDA-Tilesets/releases/tag/2022-05-08>

Turns out it is a feature of the releases page, tho you have to do it by hand, fris also pointed me to some api docs that could explain how to automate this

pretty release notes are very desirable, the api docs are confusing, but I got it working after some time

Testing in my cuteclysm fork
see this release <https://github.com/casswedson/CDDA-tileset/releases/tag/2022-05-12-2311> generated by this commit https://github.com/casswedson/CDDA-tileset/commit/5d157eb5b88c739f307a0facacc8cce0eb313c78

This was very useful for figuring out what needed to be done
https://github.com/cli/cli/blob/trunk/.github/workflows/releases.yml

references:
https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release
<!-- Explain what does this pull request contain. -->

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
