### PR TITLE
Update Credit.txt of MSX

### DIFF
--- a/gfx/MShockXotto+/Credit.txt
+++ b/gfx/MShockXotto+/Credit.txt
@@ -1,4 +1,4 @@
 List of previous contributors:
 
-Sir Hoder, Tsu's, Waldo, Coleen, Deon, Blockhead, Arex, Mshock, egomassive, Ragamer, ChunkofMeat,
-Ruxe, Oakforce, Xotto, Chezzo, Arkenstone1, SomeDeadGuy, budg3
+Sir Hoder, Tsu's, Waldo, Coleen, Deon, Blockhead, Arex, Mshock, egomassive, Chaosvolt, Ragamer,
+ChunkofMeat, Ruxe, Oakforce, Xotto, Chezzo, Arkenstone1, SomeDeadGuy, budg3


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
MSX "Update credit.txt of MSX"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change

<!-- Explain what does this pull request contain. -->

Credits file of MSX was missing a contributor listed. Literally my first contribution to DDA was https://github.com/CleverRaven/Cataclysm-DDA/pull/11707, which was when the Mshock set was developed into MShock Modded, which was used as the base by Xotto (source: https://discourse.cataclysmdda.org/t/20170216-big-sprite-update-mshock32xottoplus-tileset-oversprite-tileset/11301).

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

N/A

#### Additional information
