### PR TITLE
feat: minor speed up to composer workflows

### DIFF
--- a/.github/workflows/Altica_ci_build.yml
+++ b/.github/workflows/Altica_ci_build.yml
@@ -34,12 +34,11 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
+          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         id: build

--- a/.github/workflows/Chibi_ci_build.yml
+++ b/.github/workflows/Chibi_ci_build.yml
@@ -54,12 +54,11 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
+          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         id: build

--- a/.github/workflows/HitButton_ci_build.yml
+++ b/.github/workflows/HitButton_ci_build.yml
@@ -32,12 +32,11 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
+          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         id: build

--- a/.github/workflows/Larwick_Overmap_ci_build.yml
+++ b/.github/workflows/Larwick_Overmap_ci_build.yml
@@ -32,12 +32,11 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
+          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         id: build

--- a/.github/workflows/MD_ci_build.yml
+++ b/.github/workflows/MD_ci_build.yml
@@ -32,12 +32,11 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
+          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         id: build

--- a/.github/workflows/Neodays_ci_build.yml
+++ b/.github/workflows/Neodays_ci_build.yml
@@ -32,12 +32,11 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
+          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         id: build

--- a/.github/workflows/Retrodays_ci_build.yml
+++ b/.github/workflows/Retrodays_ci_build.yml
@@ -32,12 +32,11 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
+          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         id: build

--- a/.github/workflows/SurveyorsMap_ci_build.yml
+++ b/.github/workflows/SurveyorsMap_ci_build.yml
@@ -32,12 +32,11 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
+          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         id: build

--- a/.github/workflows/Ultica_ci_build.yml
+++ b/.github/workflows/Ultica_ci_build.yml
@@ -32,12 +32,11 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
+          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         id: build

--- a/.github/workflows/blb_ci_build.yml
+++ b/.github/workflows/blb_ci_build.yml
@@ -32,12 +32,11 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
+          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         id: build

--- a/.github/workflows/hm_build.yml
+++ b/.github/workflows/hm_build.yml
@@ -32,12 +32,11 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
+          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         id: build

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -129,8 +129,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
+          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code

--- a/.github/workflows/msx_ci_build.yml
+++ b/.github/workflows/msx_ci_build.yml
@@ -32,12 +32,11 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          sudo apt update
-          sudo apt install musl-dev gcc libvips-dev python3-dev python3-pip python3-wheel
+          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
           pip3 install pyvips
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         id: build


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
I use the github runners to compose **all** my changes; it's in my best interest to make performance improvements where possible, the main change here is the removal of `apt update` this saves a little time like under or around ~20 seconds, good enough for a start

I was also experimenting with caching the packages, caching would reduce an action's execution time to mostly the composing step time like 1-2 minutes, at the moment I can't get it to work correctly so here is a partial patch with performance improvements
<!-- Explain what does this pull request contain. -->

#### Testing
regular run https://github.com/casswedson/CDDA-Tilesets/actions/runs/2484825641 at 2m 19s
new run https://github.com/casswedson/CDDA-Tilesets/actions/runs/2484970368 at 1m 53s
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
