### PR TITLE
feat: cache dependencies to speed up composers

### DIFF
--- a/.github/workflows/Altica_ci_build.yml
+++ b/.github/workflows/Altica_ci_build.yml
@@ -33,9 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: |
-          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
-          pip3 install pyvips
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+        # re-installing libvips; caching it won't set it up the way we need it
+        # still cache it because we'll make it work somehow
+      - run: sudo apt-get install libvips42
+      - run: pip3 install pyvips
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/Chibi_ci_build.yml
+++ b/.github/workflows/Chibi_ci_build.yml
@@ -53,9 +53,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: |
-          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
-          pip3 install pyvips
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+        # re-installing libvips; caching it won't set it up the way we need it
+        # still cache it because we'll make it work somehow
+      - run: sudo apt-get install libvips42
+      - run: pip3 install pyvips
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/HitButton_ci_build.yml
+++ b/.github/workflows/HitButton_ci_build.yml
@@ -31,9 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: |
-          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
-          pip3 install pyvips
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+        # re-installing libvips; caching it won't set it up the way we need it
+        # still cache it because we'll make it work somehow
+      - run: sudo apt-get install libvips42
+      - run: pip3 install pyvips
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/Larwick_Overmap_ci_build.yml
+++ b/.github/workflows/Larwick_Overmap_ci_build.yml
@@ -31,9 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: |
-          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
-          pip3 install pyvips
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+        # re-installing libvips; caching it won't set it up the way we need it
+        # still cache it because we'll make it work somehow
+      - run: sudo apt-get install libvips42
+      - run: pip3 install pyvips
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/MD_ci_build.yml
+++ b/.github/workflows/MD_ci_build.yml
@@ -31,9 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: |
-          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
-          pip3 install pyvips
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+        # re-installing libvips; caching it won't set it up the way we need it
+        # still cache it because we'll make it work somehow
+      - run: sudo apt-get install libvips42
+      - run: pip3 install pyvips
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/Neodays_ci_build.yml
+++ b/.github/workflows/Neodays_ci_build.yml
@@ -31,9 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: |
-          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
-          pip3 install pyvips
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+        # re-installing libvips; caching it won't set it up the way we need it
+        # still cache it because we'll make it work somehow
+      - run: sudo apt-get install libvips42
+      - run: pip3 install pyvips
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/Retrodays_ci_build.yml
+++ b/.github/workflows/Retrodays_ci_build.yml
@@ -31,9 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: |
-          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
-          pip3 install pyvips
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+        # re-installing libvips; caching it won't set it up the way we need it
+        # still cache it because we'll make it work somehow
+      - run: sudo apt-get install libvips42
+      - run: pip3 install pyvips
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/SurveyorsMap_ci_build.yml
+++ b/.github/workflows/SurveyorsMap_ci_build.yml
@@ -31,9 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: |
-          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
-          pip3 install pyvips
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+        # re-installing libvips; caching it won't set it up the way we need it
+        # still cache it because we'll make it work somehow
+      - run: sudo apt-get install libvips42
+      - run: pip3 install pyvips
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/Ultica_ci_build.yml
+++ b/.github/workflows/Ultica_ci_build.yml
@@ -31,9 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: |
-          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
-          pip3 install pyvips
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+        # re-installing libvips; caching it won't set it up the way we need it
+        # still cache it because we'll make it work somehow
+      - run: sudo apt-get install libvips42
+      - run: pip3 install pyvips
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/blb_ci_build.yml
+++ b/.github/workflows/blb_ci_build.yml
@@ -31,9 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: |
-          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
-          pip3 install pyvips
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+        # re-installing libvips; caching it won't set it up the way we need it
+        # still cache it because we'll make it work somehow
+      - run: sudo apt-get install libvips42
+      - run: pip3 install pyvips
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/hm_build.yml
+++ b/.github/workflows/hm_build.yml
@@ -31,9 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: |
-          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
-          pip3 install pyvips
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+        # re-installing libvips; caching it won't set it up the way we need it
+        # still cache it because we'll make it work somehow
+      - run: sudo apt-get install libvips42
+      - run: pip3 install pyvips
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -128,9 +128,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: |
-          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
-          pip3 install pyvips
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+        # re-installing libvips; caching it won't set it up the way we need it
+        # still cache it because we'll make it work somehow
+      - run: sudo apt-get install libvips42
+      - run: pip3 install pyvips
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/msx_ci_build.yml
+++ b/.github/workflows/msx_ci_build.yml
@@ -31,9 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
-        run: |
-          sudo apt install musl-dev libvips-dev python3-dev python3-pip python3-wheel
-          pip3 install pyvips
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+        # re-installing libvips; caching it won't set it up the way we need it
+        # still cache it because we'll make it work somehow
+      - run: sudo apt-get install libvips42
+      - run: pip3 install pyvips
 
       - name: Checkout Code
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
I compose **all** my changes using the github runners, it takes a long time ~3 minutes here https://github.com/I-am-Erk/CDDA-Tilesets/runs/6868986119?check_suite_focus=true

It's in my best interest to speed up these boys
<!-- Explain what does this pull request contain. -->

#### Testing
Also note that every run will differ by execution time; some randomness with the internet connection idk your guess is a good as mine

First run with this patch ~2 minutes https://github.com/casswedson/CDDA-Tilesets/runs/6870968421?check_suite_focus=true it builds the cache, deps installation takes ~27 seconds, still far better than the ~2m 22s of a previous run

Consecutive runs would spend less than 10 seconds on the deps download step https://github.com/casswedson/CDDA-Tilesets/runs/6871007444?check_suite_focus=true and https://github.com/casswedson/CDDA-Tilesets/runs/6871058111?check_suite_focus=true

So caching libvips doesn't work, I am still unclear as to why, so I reinstall it for now

Also `-dev` packages are larger than their counterparts, just download the lighter versions
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
