### PR TITLE
[Infrastructure] windows wrapper for the 'compose.py'

### DIFF
--- a/tools/updtset.cmd
+++ b/tools/updtset.cmd
@@ -27,7 +27,7 @@ set def_tileset="UltimateCataclysm"
 set script_dir="T:\workshop"
 
 ::
-:: 4. Set path to the folder where to put composed tileset (for future examination)
+:: 4. Set path to the folder where to put the composed tileset (for future examination)
 
 set composed_dir="T:\workshop\compiled"
 

--- a/tools/updtset.cmd
+++ b/tools/updtset.cmd
@@ -1,0 +1,226 @@
+@echo off
+setlocal EnableDelayedExpansion
+setlocal EnableExtensions
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::ver 1.12 / 2022-06-22::::
+:: this script does following:
+:: - compose tileset from the source
+:: - put composed tileset into some folder for future use
+:: - copy said composed tileset from the folder into the game so you can try in on the fly
+:: - copy layering json file from tileset source into the game
+::
+:: PLEASE setup 5 variables below, put correct text inside a quotes
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: 1. Set correct folder same as in github desktop repository local path
+
+set tileset_fork="T:\cdda-tilesets"
+
+::
+:: 2. Set correct tileset folder name (e.g. UltimateCataclysm)
+
+set def_tileset="UltimateCataclysm"
+
+::
+:: 3. Set path to compose.py file 
+::    if it is in cdda source local repository type full path to it
+::    or if it's in your workshop type this path
+
+set script_dir="T:\workshop"
+
+::
+:: 4. Set path to the folder where to put composed tileset (for future examination)
+
+set composed_dir="T:\workshop\compiled"
+
+::
+:: 5. Set path to the folder where the CDDA game located
+
+set the_game_dir="T:\cataclysm"
+
+::
+:: all set, you're done! just doubleclick on this file.
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:removing_quotes
+SET tileset_fork=%tileset_fork:"=%
+SET def_tileset=%def_tileset:"=%
+SET script_dir=%script_dir:"=%
+SET composed_dir=%composed_dir:"=%
+SET the_game_dir=%the_game_dir:"=%
+
+:parse_command_line
+set verbose=YES
+set direct_update=NO
+set separate_composed=NO
+set tileset_arg=
+
+:next_arg
+set curarg=%1
+set curarg1=!curarg:~0,1!
+
+if /i [!curarg1!] EQU [/] (
+	if /i [!curarg!] EQU [/q] (
+		set verbose=NO
+	) else if /i [!curarg!] EQU [/d] (
+		set direct_update=YES
+	) else if /i [!curarg!] EQU [/s] (
+		set separate_composed=YES
+	) else (
+		:usage
+		echo Compose tileset and update game with it
+		echo.
+		echo %0 [/q] [/d] [/s] [tileset]
+		echo.
+		echo   /q         Quiet mode - do not print additional info. Just main steps
+		echo   /d         Direct update - will put composed tileset direclty into the game.
+		echo              Without this key will use "composed_dir" variable path and just then update the game.
+		echo   /s         Separate forder for composed tilesets - in case of using "composed_dir" variable 
+		echo              will create separate folder with corresponding name for composed tileset,
+		echo              then update the game.
+		echo   tileset    Should be the same as foldername in tileset repository.
+		echo.
+		echo   When used without any key will use variables set in the top part of the %0 script.
+		exit /b 255
+	)
+	shift /1
+	goto next_arg
+) else (
+	if /i [!curarg!] EQU [] ( goto continue ) else ( set tileset_arg=!curarg!&& shift /1 && goto next_arg )
+)
+:continue
+if /i [!verbose!] EQU [YES] (echo.)
+if /i [!verbose!] EQU [YES] (echo    For advanced use please run %0 /?)
+if /i [!verbose!] EQU [YES] (echo.)
+
+echo 1. Check if folders are correct.
+if /i [!tileset_arg!] EQU [] (
+	set tileset_name=!def_tileset!
+) else (
+	set tileset_name=!tileset_arg!
+)
+if /i [!verbose!] EQU [YES] (echo    - Will use [!tileset_name!] as tileset name.)
+if not exist "%tileset_fork%\gfx\" (
+	echo ERROR: Check tileset source dir! && goto stop)
+) else (
+	if not exist "%tileset_fork%\gfx\%tileset_name%\tile_info.json" (echo ERROR: Check tileset name. Must be one of these:&& dir "%tileset_fork%\gfx\" /AD /B && goto stop )
+)
+if /i [!verbose!] EQU [YES] (echo    - CDDA-Tileset fork with source tiles found.)
+if not exist "%script_dir%\compose.py" (echo ERROR: Cannot find compose.py file! && goto stop)
+if /i [!verbose!] EQU [YES] (echo    - Python 'compose.py' script found in [!script_dir!] folder.)
+if not exist "%composed_dir%" (echo ERROR: Check folder for composed tileset! && goto stop)
+if /i [!separate_composed!] EQU [YES] (
+	set path_to_compose=%composed_dir%\%tileset_name%
+	if not exist "!path_to_compose!" ( mkdir "!path_to_compose!" )
+) else (
+	set path_to_compose=%composed_dir%
+)
+if not exist "%the_game_dir%\cataclysm-tiles.exe" (echo ERROR: Cannot find the game! && goto stop)
+if /i [!direct_update!] EQU [YES] (
+	set path_to_compose=!the_game_dir!\gfx\!tileset_name!
+)
+if /i [!verbose!] EQU [YES] (echo    - Composed tileset will be put to [!path_to_compose!])
+if /i [!verbose!] EQU [YES] (
+	if /i [!separate_composed!] EQU [NO] (
+		echo    - No separate folder will be created!
+	) else (
+		if /i [!direct_update!] EQU [YES] (	echo    x No need to provide both /d and /s keys. Direct update always update correct tileset.)
+	)
+)
+if /i [!verbose!] EQU [YES] (echo    - Cataclysm game executable found.)
+if /i [!verbose!] EQU [YES] (echo.)
+
+
+echo 2. Check if python available.
+if /i [!verbose!] EQU [YES] (echo    - IMPORTANT: If any error apears at this stage please refer following page first.)
+if /i [!verbose!] EQU [YES] (echo      https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/TILESET.md#pyvips )
+python --version > nul
+if errorlevel 1 (echo ERROR: No Python found! && goto stop)
+if /i [!verbose!] EQU [YES] (echo    - Python found.)
+pip show pyvips --no-color 1>nul 
+if errorlevel 1 (
+	if /i [!verbose!] EQU [YES] (echo    - NO python 'pyvips' module found. Will try to install it.)
+	py -m pip install --user pyvips --no-color >nul
+	if errorlevel 1 (
+		echo    - Python 'pyvips' failed to install. && goto stop
+	)
+	if /i [!verbose!] EQU [YES] (echo    - Python 'pyvips' installed.)
+) else (
+	if /i [!verbose!] EQU [YES] (echo    - Python 'pyvips' module found.)
+)
+vips -v 1>nul
+if errorlevel 1 (
+	if /i [!verbose!] EQU [YES] (echo    - No 'libvips' library found. Please refer installation manual:)
+	if /i [!verbose!] EQU [YES] (echo      https://libvips.github.io/libvips/install.html )
+	goto stop
+) else (
+	if /i [!verbose!] EQU [YES] (echo    - Library 'libvips' found.)
+)
+if /i [!verbose!] EQU [YES] (echo.)
+
+echo 3. Lets compose %tileset_name%. Be patient it takes some time.
+if /i [!direct_update!] EQU [YES] (
+	rd /q /s "%temp%\cdda_tset_compose"
+	mkdir "%temp%\cdda_tset_compose"
+	xcopy "%the_game_dir%\gfx\%tileset_name%\fallback*.*" "%temp%\cdda_tset_compose" /Y /Q 1>nul
+	xcopy "%the_game_dir%\gfx\%tileset_name%\tileset.txt" "%temp%\cdda_tset_compose" /Y /Q 1>nul
+	if /i [!verbose!] EQU [YES] (echo    - Essential tileset files backed up to [%temp%\cdda_tset_compose].)
+)
+pushd "!path_to_compose!" || goto :deleted
+rd /q /s . 2> NUL
+popd
+:deleted
+python.exe "%script_dir%\compose.py" --use-all "%tileset_fork%\gfx\%tileset_name%" "!path_to_compose!"
+if not errorlevel 1 (
+	if /i [!verbose!] EQU [YES] (echo.)
+
+	echo 4. Now composed tileset will be copied into the game so you can refresh it.
+	if /i [!direct_update!] EQU [NO] (
+		xcopy "!path_to_compose!\*.*" "%the_game_dir%\gfx\%tileset_name%" /Y /Q 1>nul
+		if errorlevel 1 goto stop
+		if /i [!verbose!] EQU [YES] (echo    - All files are available both in)
+		if /i [!verbose!] EQU [YES] (echo      - [!path_to_compose!] and in)
+		if /i [!verbose!] EQU [YES] (echo      - [%the_game_dir%\gfx\%tileset_name%])
+		if /i [!verbose!] EQU [YES] (echo.)
+	) else (
+		xcopy "%temp%\cdda_tset_compose\fallback*.*" "%the_game_dir%\gfx\%tileset_name%" /Y /Q 1>nul
+		xcopy "%temp%\cdda_tset_compose\tileset.txt" "%the_game_dir%\gfx\%tileset_name%" /Y /Q 1>nul
+		if /i [!verbose!] EQU [YES] (echo    - Essential tileset files restored.)
+		if /i [!verbose!] EQU [YES] (echo.)
+	)
+	
+	echo 5. If there any layering info it'll be copied too.
+	if exist "%tileset_fork%\gfx\%tileset_name%\layering.json" (
+		xcopy "%tileset_fork%\gfx\%tileset_name%\layering.json" "%the_game_dir%\gfx\%tileset_name%" /Y /Q 1>nul
+		if errorlevel 1 goto stop
+		if /i [!verbose!] EQU [YES] (echo    - Additional 'layering.json' file copied)
+		if /i [!verbose!] EQU [YES] (echo      - from [%tileset_fork%\gfx\%tileset_name%])
+		if /i [!verbose!] EQU [YES] (echo      -   to [%the_game_dir%\gfx\%tileset_name%])
+	)
+	if /i [!verbose!] EQU [YES] (echo.)
+	
+	echo.
+	echo All done... Refresh tileset in game. 
+) else (
+	echo ERROR: Something went wrong! && goto stop
+)
+exit /b 0
+:stop
+echo:
+echo (press any key to close this window)
+pause >nul
+exit /b 1
+
+:: Change log
+:: 1.12
+:: + Added check for pyvips and libvips
+:: + Added installation of pyvips
+:: 1.11
+:: + Added support of paths with spaces
+:: ~ Changed behavior, now verbose is default mode
+:: ~ Changed /v key to /q - quiet mode
+:: 1.10
+:: + Now supports /v /d /s keys
+:: + Also can accept tileset name as argument so it can be provided via shortcut
+:: 1.01
+:: + Added manual reference for python (module+library)

--- a/tools/updtset.cmd
+++ b/tools/updtset.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal EnableDelayedExpansion
 setlocal EnableExtensions
-:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::ver 1.12 / 2022-06-22::::
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::ver 1.13 / 2022-06-29::::
 :: this script does following:
 :: - compose tileset from the source
 :: - put composed tileset into some folder for future use
@@ -90,9 +90,7 @@ if /i [!curarg1!] EQU [/] (
 )
 :continue
 if /i [!verbose!] EQU [YES] (echo.)
-if /i [!verbose!] EQU [YES] (echo    Edit top part for the first run.)
 if /i [!verbose!] EQU [YES] (echo    For advanced use please run %0 /?)
-if /i [!verbose!] EQU [YES] (echo    Autocloses if everything ok.)
 if /i [!verbose!] EQU [YES] (echo.)
 
 echo 1. Check if folders are correct.
@@ -136,8 +134,12 @@ if /i [!verbose!] EQU [YES] (echo.)
 echo 2. Check if python available.
 if /i [!verbose!] EQU [YES] (echo    - IMPORTANT: If any error apears at this stage please refer following page first.)
 if /i [!verbose!] EQU [YES] (echo      https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/TILESET.md#pyvips )
-python --version > nul
-if errorlevel 1 (echo ERROR: No Python found! && goto stop)
+py --version > nul
+if errorlevel 1 (
+	echo ERROR: No Python found!
+	echo If you are sure that Python is installed - please check 'path' environment variable.
+	goto stop
+)
 if /i [!verbose!] EQU [YES] (echo    - Python found.)
 pip show pyvips --no-color 1>nul 
 if errorlevel 1 (
@@ -152,8 +154,9 @@ if errorlevel 1 (
 )
 vips -v 1>nul
 if errorlevel 1 (
-	if /i [!verbose!] EQU [YES] (echo    - No 'libvips' library found. Please refer installation manual:)
-	if /i [!verbose!] EQU [YES] (echo      https://libvips.github.io/libvips/install.html )
+	echo ERROR! No 'libvips' library found. Please refer installation manual:
+	echo https://libvips.github.io/libvips/install.html 
+	echo If you are sure that library was installed - please check library version and 'path' environment variable.
 	goto stop
 ) else (
 	if /i [!verbose!] EQU [YES] (echo    - Library 'libvips' found.)
@@ -172,7 +175,7 @@ pushd "!path_to_compose!" || goto :deleted
 rd /q /s . 2> NUL
 popd
 :deleted
-python.exe "%script_dir%\compose.py" --use-all "%tileset_fork%\gfx\%tileset_name%" "!path_to_compose!"
+py.exe "%script_dir%\compose.py" --use-all "%tileset_fork%\gfx\%tileset_name%" "!path_to_compose!"
 if not errorlevel 1 (
 	if /i [!verbose!] EQU [YES] (echo.)
 
@@ -215,6 +218,9 @@ pause >nul
 exit /b 1
 
 :: Change log
+:: 1.13
+:: V fixed python launching command. Now it is 'py' everywhere. Sometimes py works, but python launches shortcut that tries to setup Python from Windows store.
+:: V fixed error message, now it appears even in quiet mode.
 :: 1.12
 :: + Added check for pyvips and libvips
 :: + Added installation of pyvips

--- a/tools/updtset.cmd
+++ b/tools/updtset.cmd
@@ -214,20 +214,3 @@ echo:
 echo (press any key to close this window)
 pause >nul
 exit /b 1
-
-:: Change log
-:: 1.13
-:: V fixed python launching command. Now it is 'py' everywhere. Sometimes py works, but python launches shortcut that tries to setup Python from Windows store.
-:: V fixed error message, now it appears even in quiet mode.
-:: 1.12
-:: + Added check for pyvips and libvips
-:: + Added installation of pyvips
-:: 1.11
-:: + Added support of paths with spaces
-:: ~ Changed behavior, now verbose is default mode
-:: ~ Changed /v key to /q - quiet mode
-:: 1.10
-:: + Now supports /v /d /s keys
-:: + Also can accept tileset name as argument so it can be provided via shortcut
-:: 1.01
-:: + Added manual reference for python (module+library)

--- a/tools/updtset.cmd
+++ b/tools/updtset.cmd
@@ -8,7 +8,7 @@ setlocal EnableExtensions
 :: - copy said composed tileset from the folder into the game so you can try in on the fly
 :: - copy layering json file from tileset source into the game
 ::
-:: PLEASE setup 5 variables below, put correct text inside a quotes
+:: PLEASE setup 5 variables below, put correct text between quotes
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/tools/updtset.cmd
+++ b/tools/updtset.cmd
@@ -32,7 +32,7 @@ set script_dir="T:\workshop"
 set composed_dir="T:\workshop\compiled"
 
 ::
-:: 5. Set path to the folder where the CDDA game located
+:: 5. Set path to CDDA game folder
 
 set the_game_dir="T:\cataclysm"
 

--- a/tools/updtset.cmd
+++ b/tools/updtset.cmd
@@ -3,7 +3,7 @@ setlocal EnableDelayedExpansion
 setlocal EnableExtensions
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::ver 1.13 / 2022-06-29::::
 :: this script does the following:
-:: - compose tileset from the source
+:: - compose tilesets from source
 :: - put composed tileset into some folder for future use
 :: - copy said composed tileset from the folder into the game so you can try in on the fly
 :: - copy layering json file from tileset source into the game

--- a/tools/updtset.cmd
+++ b/tools/updtset.cmd
@@ -2,7 +2,7 @@
 setlocal EnableDelayedExpansion
 setlocal EnableExtensions
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::ver 1.13 / 2022-06-29::::
-:: this script does following:
+:: this script does the following:
 :: - compose tileset from the source
 :: - put composed tileset into some folder for future use
 :: - copy said composed tileset from the folder into the game so you can try in on the fly

--- a/tools/updtset.cmd
+++ b/tools/updtset.cmd
@@ -12,7 +12,7 @@ setlocal EnableExtensions
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-:: 1. Set correct folder same as in github desktop repository local path
+:: 1. Set path to your local copy of the tileset repository
 
 set tileset_fork="T:\cdda-tilesets"
 

--- a/tools/updtset.cmd
+++ b/tools/updtset.cmd
@@ -90,7 +90,9 @@ if /i [!curarg1!] EQU [/] (
 )
 :continue
 if /i [!verbose!] EQU [YES] (echo.)
+if /i [!verbose!] EQU [YES] (echo    Edit top part for the first run.)
 if /i [!verbose!] EQU [YES] (echo    For advanced use please run %0 /?)
+if /i [!verbose!] EQU [YES] (echo    Autocloses if everything ok.)
 if /i [!verbose!] EQU [YES] (echo.)
 
 echo 1. Check if folders are correct.
@@ -200,10 +202,11 @@ if not errorlevel 1 (
 	if /i [!verbose!] EQU [YES] (echo.)
 	
 	echo.
-	echo All done... Refresh tileset in game. 
+	echo     All done... Refresh tileset in game. 
 ) else (
 	echo ERROR: Something went wrong! && goto stop
 )
+timeout /t 10 >nul
 exit /b 0
 :stop
 echo:

--- a/tools/updtset.cmd
+++ b/tools/updtset.cmd
@@ -23,8 +23,6 @@ set def_tileset="UltimateCataclysm"
 
 ::
 :: 3. Set path to compose.py file 
-::    if it is in cdda source local repository type full path to it
-::    or if it's in your workshop type this path
 
 set script_dir="T:\workshop"
 


### PR DESCRIPTION
Tool for the windows artists that wraps default multiplatform compose.py

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Infrastructure "Windows wrapper for compose.py"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, BLB, Chesthole, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
This batch script allows artists to set up variables and just doubleclick this file to get composed tileset and put it in game. So it can be tested on the fly.

There are also some checks and useful tips that helps setting artists environment up.
<!-- Explain what does this pull request contain. -->

#### Testing
Default run if everything is ok:
![image](https://user-images.githubusercontent.com/6676374/174978721-f8bcfbb1-9981-4813-9c3c-4567fd101e2c.png)
Quiet mode:
![image](https://user-images.githubusercontent.com/6676374/174978954-c9d345fb-2d5e-4217-a0f0-26fa5a7daf5c.png)

Some error handling:
![image](https://user-images.githubusercontent.com/6676374/174979934-126012bf-2c7f-4592-a45e-f004d8ccfd48.png)
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
It will also try to install pyvips once in case of installed python but missing module.