### PR TITLE
[RetroDays] Isherwood's forests, roads, and fields

### DIFF
--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road.json
@@ -1,5 +1,5 @@
 {
-    "id": "dirt_road",
+    "id": [ "dirt_road", "rural_road"],
     "fg": [
         "dirt_road_edge_ns",
         "dirt_road_edge_ew"

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_3way.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_3way.json
@@ -1,5 +1,5 @@
 {
-    "id": "dirt_road_3way",
+    "id": [ "dirt_road_3way", "rural_road_3way" ],
     "fg": [
         "dirt_road_t_connection_n",
         "dirt_road_t_connection_e",

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_3way_forest.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_3way_forest.json
@@ -1,5 +1,5 @@
 {
-    "id": "dirt_road_3way_forest",
+    "id": [ "dirt_road_3way_forest", "rural_road_3way_forest" ],
     "fg": [
         "dirt_road_t_connection_n",
         "dirt_road_t_connection_e",

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_forest.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_forest.json
@@ -1,5 +1,5 @@
 {
-    "id": "dirt_road_forest",
+    "id": [ "dirt_road_forest", "rural_road_forest" ],
     "fg": [
         "dirt_road_edge_ns",
         "dirt_road_edge_ew"

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_turn.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_turn.json
@@ -1,5 +1,5 @@
 {
-    "id": "dirt_road_turn",
+    "id": [ "dirt_road_turn", "rural_road_turn" ],
     "fg": [
         "dirt_road_corner_ne",
         "dirt_road_corner_se",

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_turn1.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_turn1.json
@@ -1,5 +1,5 @@
 {
-    "id": "dirt_road_turn1",
+    "id": [ "dirt_road_turn1", "rural_road_turn1" ],
     "fg": [
         "dirt_road_corner_nw",
         "dirt_road_corner_ne",

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_turn1_forest.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_turn1_forest.json
@@ -1,5 +1,5 @@
 {
-    "id": "dirt_road_turn1_forest",
+    "id": [ "dirt_road_turn1_forest", "rural_road_turn1_forest" ],
     "fg": [
         "dirt_road_corner_nw",
         "dirt_road_corner_ne",

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_turn_forest.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/dirt_road_turn_forest.json
@@ -1,5 +1,5 @@
 {
-    "id": "dirt_road_turn_forest",
+    "id": [ "dirt_road_turn_forest", "rural_road_turn_forest" ],
     "fg": [
         "dirt_road_corner_ne",
         "dirt_road_corner_se",

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/field.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/field.json
@@ -1,0 +1,4 @@
+{
+  "id": [ "field", "special_field" ],
+  "fg": "67_t_grass_0"
+}

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/field_0.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/field_0.json
@@ -1,1 +1,0 @@
-{"id": "field", "fg": ["67_t_grass_0"], "rotates": false, "bg": []}

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/forest.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/forest.json
@@ -1,0 +1,4 @@
+{
+  "id": [ "forest", "special_forest" ],
+  "fg": "3111_forest_0"
+}

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/forest_0.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/forest_0.json
@@ -1,1 +1,0 @@
-{"id": "forest", "fg": ["3111_forest_0"], "rotates": false, "bg": []}

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/forest_thick.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/forest_thick.json
@@ -1,0 +1,4 @@
+{
+  "id": [ "forest_thick", "special_forest_thick" ],
+  "fg": "3112_forest_thick_0"
+}

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/forest_thick_0.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/forest_thick_0.json
@@ -1,1 +1,0 @@
-{"id": "forest_thick", "fg": ["3112_forest_thick_0"], "rotates": false, "bg": []}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
RetroDays "Isherwood's special overmap tiles"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, IsoMSX, BLB, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
Isherwood's "special_forest*, "special_field", and "rural_road*" now inherit normal forest, field, and dirt road sprites.
Fixes #1433 
<!-- Explain what does this pull request contain. -->

#### Testing
Before:
![befretov](https://user-images.githubusercontent.com/32048635/178799956-a04c0310-cd17-4102-a241-488e610b9dd4.png)
After:
![aftretov](https://user-images.githubusercontent.com/32048635/178799947-c31ef0ee-a4fd-41b0-bd00-a3b539289510.png)
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
There are no equivalent sprites for the other tiles in this generation (farm fields, buildings, etc), so they will stay as the currently are.