### PR TITLE
[Larwick Overmap] Isherwoods and agricultural cleaning

### DIFF
--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/dirt_road/dirt_road.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/dirt_road/dirt_road.json
@@ -1,11 +1,11 @@
 [
   {
-    "id": [ "dirt_road", "dirt_road_forest" ],
+    "id": [ "dirt_road", "dirt_road_forest", "rural_road", "rural_road_forest" ],
     "fg": [ "dirt_road_edge_ns", "dirt_road_edge_ew", "dirt_road_edge_ns", "dirt_road_edge_ew" ],
     "rotates": true
   },
   {
-    "id": [ "dirt_road_3way", "dirt_road_3way_forest" ],
+    "id": [ "dirt_road_3way", "dirt_road_3way_forest", "rural_road_3way", "rural_road_3way_forest" ],
     "fg": [ "dirt_road_t_connection_n", "dirt_road_t_connection_e", "dirt_road_t_connection_s", "dirt_road_t_connection_w" ],
     "rotates": true
   },

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain.json
@@ -129,20 +129,8 @@
     "fg": "one_grass_brown"
   },
   {
-    "id": "cabin_isherwood",
-    "fg": "small_tree_light_green"
-  },
-  {
     "id": "riverside_dwelling",
     "fg": "cabin_yellow"
-  },
-  {
-    "id": "cabin_lake",
-    "fg": "small_tree_green"
-  },
-  {
-    "id": "cabin_lake_roof",
-    "fg": "small_tree_green"
   },
   {
     "id": "lake_cabin_boathouse",
@@ -170,84 +158,35 @@
     "fg": "small_tree_green"
   },
   {
-    "id": "cabin",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_roof",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_1",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_roof_1",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_2",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_roof_2",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_3",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_roof_3",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_4",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_roof_4",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_5",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_roof_5",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_6",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_roof_6",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_7",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_prepper",
+    "id": [
+      "cabin",
+      "cabin_roof",
+      "cabin_1",
+      "cabin_roof_1",
+      "cabin_2",
+      "cabin_roof_2",
+      "cabin_3",
+      "cabin_roof_3",
+      "cabin_4",
+      "cabin_roof_4",
+      "cabin_5",
+      "cabin_roof_5",
+      "cabin_6",
+      "cabin_roof_6",
+      "cabin_7",
+      "cabin_roof_7",
+      "cabin_lake",
+      "cabin_lake_roof",
+      "cabin_lapin",
+      "cabin_roof_lapin",
+      "cabin_isherwood",
+      "cabin_prepper"
+    ],
     "fg": "cabin_brown"
   },
   {
     "id": "cabin_prepper_shelter",
     "fg": "bunker_red"
-  },
-  {
-    "id": "cabin_roof_7",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_lapin",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "cabin_roof_lapin",
-    "fg": "cabin_brown"
   },
   {
     "id": "dirtroad1_aban1",

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_agricultural.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_agricultural.json
@@ -1,55 +1,50 @@
 [
   {
-    "id": "sugar_house",
+    "id": [
+      "sugar_house",
+      "sugar_house_roof"
+    ],
     "fg": "barn_brown"
   },
   {
-    "id": "sugar_house_roof",
+    "id": [
+      "farm_1",
+      "farm_4",
+      "farm_5",
+      "farm_6",
+      "farm_7",
+      "farm_8",
+      "farm_9"
+    ],
+    "fg": "two_grass_brown"
+  },
+  {
+    "id": [
+      "farm_1_greenhouse",
+      "farm_1_greenhouse_roof"
+    ],
+    "fg": "barn_green"
+  },
+  {
+    "id": [
+      "farm_1_coop",
+      "farm_1_coop_roof"
+    ],
     "fg": "barn_brown"
   },
   {
-    "id": "farm_1",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "farm_2",
+    "id": [
+      "farm_2",
+      "farm_2_roof"
+    ],
     "fg": "cabin_brown"
   },
   {
-    "id": "farm_2_roof",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "farm_3",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "farm_3_roof",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "farm_4",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "farm_5",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "farm_6",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "farm_7",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "farm_8",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "farm_9",
-    "fg": "two_grass_brown"
+    "id": [
+      "farm_3",
+      "farm_3_roof"
+    ],
+    "fg": "barn_brown"
   },
   {
     "id": "2farm_1",
@@ -228,212 +223,143 @@
     "fg": "shop_light_green"
   },
   {
-    "id": "dairy_farm_NW",
+    "id": [
+      "dairy_farm_NW",
+      "dairy_farm_NE"
+    ],
     "fg": "two_grass_brown"
   },
   {
-    "id": "dairy_farm_NE",
+    "id": [
+      "dairy_farm_SE",
+      "dairy_farm_SE_roof"
+    ],
+    "fg": "barn_brown"
+  },
+  {
+    "id": [
+      "dairy_farm_SW",
+      "dairy_farm_SW_roof"
+    ],
+    "fg": "cabin_brown"
+  },
+  {
+    "id": [
+      "dairy_farm_isherwood_W",
+      "dairy_farm_isherwood_E",
+      "dairy_farm_isherwood_NW",
+      "dairy_farm_isherwood_NE"
+    ],
     "fg": "two_grass_brown"
   },
   {
-    "id": "dairy_farm_SE",
+    "id": [
+      "dairy_farm_isherwood_SE",
+      "dairy_farm_isherwood_SE_roof"
+    ],
     "fg": "barn_brown"
   },
   {
-    "id": "dairy_farm_SE_roof",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "dairy_farm_SW",
+    "id": [
+      "dairy_farm_isherwood_SW",
+      "dairy_farm_isherwood_SW_roof"
+    ],
     "fg": "cabin_brown"
   },
   {
-    "id": "dairy_farm_SW_roof",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "dairy_farm_isherwood_W",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "dairy_farm_isherwood_E",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "dairy_farm_isherwood_SE",
+    "id": [
+      "smokehouse",
+      "smokehouse_roof"
+    ],
     "fg": "barn_brown"
   },
   {
-    "id": "dairy_farm_isherwood_SE_roof",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "dairy_farm_isherwood_SW",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "dairy_farm_isherwood_SW_roof",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "smokehouse",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "smokehouse_roof",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "rural_outbuilding",
+    "id": [
+      "rural_outbuilding",
+      "rural_outbuilding_roof"
+    ],
     "fg": "garage_brown"
   },
   {
-    "id": "rural_outbuilding_roof",
-    "fg": "garage_brown"
-  },
-  {
-    "id": "farm_isherwood_1",
+    "id": [
+      "farm_isherwood_1",
+      "farm_isherwood_4",
+      "farm_isherwood_5",
+      "farm_isherwood_6",
+      "farm_isherwood_7",
+      "farm_isherwood_8",
+      "farm_isherwood_9"
+    ],
     "fg": "two_grass_brown"
   },
   {
-    "id": "farm_isherwood_2",
+    "id": [
+      "farm_isherwood_2",
+      "farm_isherwood_2_cellar",
+      "farm_isherwood_2_roof"
+    ],
     "fg": "cabin_brown"
   },
   {
-    "id": "farm_isherwood_2_cellar",
+    "id": [
+      "farm_isherwood_3",
+      "farm_isherwood_3_hayloft",
+      "farm_isherwood_3_roof"
+    ],
+    "fg": "barn_brown"
+  },
+  {
+    "id": [
+      "horse_farm_isherwood_1",
+      "horse_farm_isherwood_2",
+      "horse_farm_isherwood_3",
+      "horse_farm_isherwood_5",
+      "horse_farm_isherwood_6",
+      "horse_farm_isherwood_8",
+      "horse_farm_isherwood_11",
+      "horse_farm_isherwood_12",
+      "horse_farm_isherwood_14",
+      "horse_farm_isherwood_15",
+      "horse_farm_isherwood_16"
+    ],
+    "fg": "two_grass_green"
+  },
+  {
+    "id": [
+      "horse_farm_isherwood_4",
+      "horse_farm_isherwood_4_roof"
+    ],
     "fg": "cabin_brown"
   },
   {
-    "id": "farm_isherwood_2_roof",
+    "id": [
+      "horse_farm_isherwood_7",
+      "horse_farm_isherwood_7_hayloft",
+      "horse_farm_isherwood_7_roof"
+    ],
+    "fg": "barn_brown"
+  },
+  {
+    "id": [
+      "horse_farm_isherwood_9",
+      "horse_farm_isherwood_9_roof"
+    ],
+    "fg": "barn_green"
+  },
+  {
+    "id": [
+      "horse_farm_isherwood_10",
+      "horse_farm_isherwood_10_roof"
+    ],
+    "fg": "barn_brown"
+  },
+  {
+    "id": [
+      "horse_farm_isherwood_13",
+      "horse_farm_isherwood_13_2ndfloor",
+      "horse_farm_isherwood_13_roof"
+    ],
     "fg": "cabin_brown"
-  },
-  {
-    "id": "farm_isherwood_3",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "farm_isherwood_3_hayloft",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "farm_isherwood_3_roof",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "farm_isherwood_4",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "farm_isherwood_5",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "farm_isherwood_6",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "farm_isherwood_7",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "farm_isherwood_8",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "farm_isherwood_9",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_1",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_2",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_3",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_4",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_4_roof",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_5",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_6",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_7",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_7_hayloft",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_7_roof",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_8",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_9",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_9_roof",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_10",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_10_roof",
-    "fg": "barn_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_11",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_12",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_13",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_13_2ndfloor",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_13_roof",
-    "fg": "cabin_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_14",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_15",
-    "fg": "two_grass_brown"
-  },
-  {
-    "id": "horse_farm_isherwood_16",
-    "fg": "two_grass_brown"
   },
   {
     "id": "cemetery_small",

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_hardcoded.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_hardcoded.json
@@ -8,15 +8,24 @@
     "fg": "hole_red"
   },
   {
-    "id": "field",
+    "id": [
+      "field",
+      "special_field"
+    ],
     "fg": "one_grass_brown"
   },
   {
-    "id": "forest",
+    "id": [
+      "forest",
+      "special_forest"
+    ],
     "fg": "small_tree_green"
   },
   {
-    "id": "forest_thick",
+    "id": [
+      "forest_thick",
+      "special_forest_thick"
+    ],
     "fg": "big_tree_green"
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Larwick "Isherwoods with some misc. agricultural fixes"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, IsoMSX, BLB, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
Fixes various issues with the Isherwoods special terrain, including parity with non-Isherwoods farm variants; also including lake cabins, farm_* greenhouses, coops, and barns. Reorganized a few agricultural overmap tiles, and cabins
<!-- Explain what does this pull request contain. -->

#### Testing
Before:
![beflarish](https://user-images.githubusercontent.com/32048635/178811138-f529a97c-736b-4314-8927-77325f065157.png)
Isherwoods
![beflargrn](https://user-images.githubusercontent.com/32048635/178811141-267a5cfd-214c-4c0f-9a7a-6b09dc9d9a01.png)
Farm_*

After:
![aftlarish](https://user-images.githubusercontent.com/32048635/178811163-922185a2-ebfa-46da-9ff1-eb9251a871bf.png)
Isherwoods
![aftlargrn](https://user-images.githubusercontent.com/32048635/178811160-fbb0f398-da56-4868-90d0-b69cee80fd4e.png)
Farm_*
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
