### PR TITLE
[RetroDays/Larwick Overmap] Partially revert #1446 and #1447

### DIFF
--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_hardcoded.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_hardcoded.json
@@ -8,24 +8,15 @@
     "fg": "hole_red"
   },
   {
-    "id": [
-      "field",
-      "special_field"
-    ],
+    "id": "field",
     "fg": "one_grass_brown"
   },
   {
-    "id": [
-      "forest",
-      "special_forest"
-    ],
+    "id": "forest",
     "fg": "small_tree_green"
   },
   {
-    "id": [
-      "forest_thick",
-      "special_forest_thick"
-    ],
+    "id": "forest_thick",
     "fg": "big_tree_green"
   },
   {

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/field.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/field.json
@@ -1,4 +1,4 @@
 {
-  "id": [ "field", "special_field" ],
+  "id": "field",
   "fg": "67_t_grass_0"
 }

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/forest.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/forest.json
@@ -1,4 +1,4 @@
 {
-  "id": [ "forest", "special_forest" ],
+  "id": "forest",
   "fg": "3111_forest_0"
 }

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/forest_thick.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/forest_thick.json
@@ -1,4 +1,4 @@
 {
-  "id": [ "forest_thick", "special_forest_thick" ],
+  "id": "forest_thick",
   "fg": "3112_forest_thick_0"
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
RetroDays "Partially revert #1446 and #1447"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, IsoMSX, BLB, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
Revert changes relating to ```special_*``` terrain introduced in #1446 and #1447 in response to https://github.com/CleverRaven/Cataclysm-DDA/pull/59302, in which globally (mostly) fixes issue #1433 instead of needing to fix it for each tileset.
<!-- Explain what does this pull request contain. -->

#### Testing
See https://github.com/CleverRaven/Cataclysm-DDA/pull/59302
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
Rural roads are a bit strange, since I can't seem to find them explicitly spawned outside of Isherwoods, but they are copied from by dirt roads, used almost everywhere, so the changes relating to them in #1446 and #1447 have not been reverted and are not touched by https://github.com/CleverRaven/Cataclysm-DDA/pull/59302; this means for now tilesets will still need to connect them to sprites themselves.
Also, Ultica (and likely forks of it) seems to also have linked the ```special_*``` sprites based on testing; this is not touched here.