### PR TITLE
[NeoDays/RetroDays] Satellites not using sprite

### DIFF
--- a/gfx/NeoDays/pngs_tiles_10x10/items/directional_antenna_f_small_satelitte_dish_0.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/items/directional_antenna_f_small_satelitte_dish_0.json
@@ -1,1 +1,1 @@
-{"id": ["directional_antenna", "f_small_satelitte_dish"], "fg": ["731_directional_antenna_0"], "rotates": false, "bg": []}
+{"id": ["directional_antenna", "f_small_satellite_dish"], "fg": ["731_directional_antenna_0"], "rotates": false, "bg": []}

--- a/gfx/Retrodays/pngs_tiles_10x10/item/directional_antenna_f_small_satelitte_dish_0.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/item/directional_antenna_f_small_satelitte_dish_0.json
@@ -1,1 +1,1 @@
-{"id": ["directional_antenna", "f_small_satelitte_dish"], "fg": ["731_directional_antenna_0"], "rotates": false, "bg": []}
+{"id": ["directional_antenna", "f_small_satellite_dish"], "fg": ["731_directional_antenna_0"], "rotates": false, "bg": []}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
NeoDays "Fixed satellites not using their sprite"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, IsoMSX, BLB, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
Renamed satellites to their new correct name
<!-- Explain what does this pull request contain. -->

#### Testing
Before: 
![neobefsat](https://user-images.githubusercontent.com/32048635/179383524-32f60af0-f565-49d5-a338-30e19d79f85c.png)
![retbefsat](https://user-images.githubusercontent.com/32048635/179383525-fa020df9-da64-422a-99dc-6a681d758bf5.png)

After:
![neoaftsat](https://user-images.githubusercontent.com/32048635/179383530-6c38dad7-be18-40b9-b59b-126c0a05bb58.png)
![retaftsat1](https://user-images.githubusercontent.com/32048635/179383531-9d155fa7-4f30-449e-aaf9-7a766f054628.png)

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
It seems aliasing (or at least the one done for this change) doesn't work for sprites.