### PR TITLE
fix: missing msx tile entry warning

### DIFF
--- a/gfx/MShockXotto+/pngs_tiles_32x32/monster/zombie_fat/mon_zombie_fat.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/monster/zombie_fat/mon_zombie_fat.json
@@ -1,7 +1,7 @@
 {
   "id": "mon_zombie_fat",
   "fg": [
-    { "weight": 1, "sprite": "mon_zombie_fat_1" },
+    { "weight": 1, "sprite": "mon_zombie_fat" },
     { "weight": 1, "sprite": "mon_zombie_fat_1" },
     { "weight": 1, "sprite": "mon_zombie_fat_2" },
     { "weight": 1, "sprite": "mon_zombie_fat_3" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, IsoMSX, BLB, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
fix this warning https://github.com/I-am-Erk/CDDA-Tilesets/runs/7881324366?check_suite_focus=true#step:6:66
there was an unused sprite around, use it; one of the variants of the fat zombie to be specific
<!-- Explain what does this pull request contain. -->

#### Testing
ci pls test for me
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
