### PR TITLE
[Larwick Overmap] Occupied Lumbermill

### DIFF
--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_industrial.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_industrial.json
@@ -124,35 +124,20 @@
     "fg": "square_brown"
   },
   {
-    "id": "lumbermill_0_0",
-    "fg": "industry_brown"
-  },
-  {
-    "id": "lumbermill_0_1",
-    "fg": "industry_brown"
-  },
-  {
-    "id": "lumbermill_1_0",
-    "fg": "industry_brown"
-  },
-  {
-    "id": "lumbermill_1_1",
-    "fg": "industry_brown"
-  },
-  {
-    "id": "lumbermill_0_0_roof",
-    "fg": "industry_brown"
-  },
-  {
-    "id": "lumbermill_0_1_roof",
-    "fg": "industry_brown"
-  },
-  {
-    "id": "lumbermill_1_0_roof",
-    "fg": "industry_brown"
-  },
-  {
-    "id": "lumbermill_1_1_roof",
+    "id": [
+      "lumbermill_0_0",
+      "lumbermill_0_1",
+      "lumbermill_1_0",
+      "lumbermill_1_1",
+      "lumbermill_0_0_ocu",
+      "lumbermill_0_1_ocu",
+      "lumbermill_1_0_ocu",
+      "lumbermill_1_1_ocu",
+      "lumbermill_0_0_roof",
+      "lumbermill_0_1_roof",
+      "lumbermill_1_0_roof",
+      "lumbermill_1_1_roof"
+    ],
     "fg": "industry_brown"
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Larwick "Fixed the new occupied lumbermill tiles"
<!-- This section should consist of exactly one line, edit the one above.
Available categories are: Ultica, Ultica-iso, Chibi-Ultica, Altica, NeoDays, RetroDays, HitButton, NeoDays, MSX, IsoMSX, BLB, MD, HM, Smap, Larwick, Infrastructure.-->

#### Content of the change
Assigned ```lumbermill*_*_ocu``` the same sprites as lumbermill. Also cleans the lumbermill's entry in the json file.
<!-- Explain what does this pull request contain. -->

#### Testing
Before:
![beflumb](https://user-images.githubusercontent.com/32048635/185776510-3699e855-4f7e-482c-90f7-4cc9ece09c3e.png)
After:
![aftlumb](https://user-images.githubusercontent.com/32048635/185776513-8f724354-bc41-4850-aa91-4bf111d68417.png)

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
