### PR TITLE
Re-arrange ISO auto-tiles to ortho layout, and add height

### DIFF
--- a/doc/how-to/autotiles.md
+++ b/doc/how-to/autotiles.md
@@ -103,11 +103,11 @@ Before an autotile template can be used by the game, it needs to be sliced up in
 We use the `tools/slice_multitile.py` script to achieve this.
 
 To run the script, you will need [python](https://python.org) installed, as well as the libvips
-graphic library. Something like these commands should suffice to install them on Ubuntu:
+graphic library. Forther, numpy is required. Something like these commands should suffice to install them on Ubuntu:
 
 ```sh
 $ sudo apt install python3-pip libvips
-$ pip3 install pyvips
+$ pip3 install pyvips numpy
 ```
 
 If all goes well, you should be able to run the `slice_multitile.py` script and see the usage note:

--- a/doc/how-to/autotiles.md
+++ b/doc/how-to/autotiles.md
@@ -156,7 +156,7 @@ A rhomboid template like [multitile_grid_4x4_iso.png](../templates/multitile_gri
 #### Re-arranging for ISO with height
 
 Unfortunately, the approach explained in [Slicing isometric autotiles](#slicing-isometric-autotiles)
-does not for ISO sprites with a height (like walls etc.).
+does not work for ISO sprites with a height (like walls etc.).
 
 For working with ISO sprites with a height, options `--rearrange-top <height>` and `--rearrange-bottom <height>`
 of `slice_multitile.py` can be used. The workflow for walls would be:

--- a/doc/how-to/autotiles.md
+++ b/doc/how-to/autotiles.md
@@ -103,7 +103,7 @@ Before an autotile template can be used by the game, it needs to be sliced up in
 We use the `tools/slice_multitile.py` script to achieve this.
 
 To run the script, you will need [python](https://python.org) installed, as well as the libvips
-graphic library. Forther, numpy is required. Something like these commands should suffice to install them on Ubuntu:
+graphic library. Further, numpy is required. Something like these commands should suffice to install them on Ubuntu:
 
 ```sh
 $ sudo apt install python3-pip libvips
@@ -145,6 +145,26 @@ a JSON file with connection data, for example:
 - mud_t_connection_s.png
 - mud_t_connection_w.png
 - mud_unconnected.png
+
+#### Slicing isometric autotiles
+
+Isometric autotile is supported by `slice_multitile.py` using the `--iso` argument.
+A rhomboid template like [multitile_grid_4x4_iso.png](../templates/multitile_grid_4x4_iso.png) is uses as the basis.
+
+![ISO Multitile 4x4 Template](../templates/multitile_grid_4x4_iso.png)
+
+#### Re-arranging for ISO with height
+
+Unfortunately, the approach explained in [Slicing isometric autotiles](#slicing-isometric-autotiles)
+does not for ISO sprites with a height (like walls etc.).
+
+For working with ISO sprites with a height, options `--rearrange-top <height>` and `--rearrange-bottom <height>`
+of `slice_multitile.py` can be used. The workflow for walls would be:
+
+1. Draw wall tops on the flat ISO template
+2. Use `--rearrange-bottom` to give the sprites a height and arrange them in a usual ortho autotile layout
+3. Draw wall sides on that created layout
+4. Slice the result without using `--iso`
 
 ### Tall multitile template
 


### PR DESCRIPTION
#### Summary

Re-arrange ISO auto-tiles to ortho layout, and add height

#### Content of the change

Trying to make working with auto-tiling in ISO tilesets easier. Slicing from rhomboid ISO multitiles was added in #1543. 
However, isometric tiles with a height (like walls) are not possible with rhomboid autotile.

This PR adds options to `splice_autotile.py` that re-arranges ISO sprites into an orto autotile layout, and add a height to them.
Artist can now create the top of walls (or the floot for fences) in the rhomboid, seamless layout.
After using the script, the artist can continue with the sides of the walls in the orto layout.

Usage example:

```
python slice_autotile.py --rearrange-top 66 ...
```

#### Testing

Input:

![grafik](https://user-images.githubusercontent.com/44003176/188746866-04bd47a9-1f15-4155-b0c7-a8ecab189d14.png)

Output

![grafik](https://user-images.githubusercontent.com/44003176/188747004-4a13c557-e4df-4095-80bb-f722660549a5.png)

Thanks @vetall812 for providing the idea and the artwork!

#### Additional information

None