### PR TITLE
add a couple hours to the release schedule

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -1,12 +1,12 @@
 # Creates a release using compose.py from https://github.com/CleverRaven/Cataclysm-DDA
 #
-# This action is runs at 12:00 UTC Sunday
+# This action is runs at 20:00 UTC Sunday
 
 name: Make Release
 concurrency: release
 on:
   schedule:
-    - cron: '0 12 * * sun'
+    - cron: '0 20 * * sun'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Check if there is existing git tag
+      - name: Check if there is an existing git tag
         id: tag_check
         uses: mukunku/tag-exists-action@v1.0.0
         with:


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
+8 hours more before a release is generated

#### Content of the change
the only reason we spend 12 hours doing "nothing" after a release is uploaded is in short I made an ill advised decision, there's no reason to spend time doing nothing when we can just push more of the work done over the week

mostly I assumed if there are problems with a release we should have plenty of time to fix it, some time should be dedicated to this, not this much tho

at this point we'll have 3 hours to watch out for errors and make fixes if any are needed, should be plenty

after this many releases I have more trust in the systems we build time to remove the training wheels


<!-- Explain what does this pull request contain. -->

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
