### PR TITLE
more specific artifact names

### DIFF
--- a/.github/workflows/Altica_ci_build.yml
+++ b/.github/workflows/Altica_ci_build.yml
@@ -55,7 +55,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"

--- a/.github/workflows/Chibi_ci_build.yml
+++ b/.github/workflows/Chibi_ci_build.yml
@@ -75,7 +75,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"

--- a/.github/workflows/HitButton_iso_ci_build.yml
+++ b/.github/workflows/HitButton_iso_ci_build.yml
@@ -53,7 +53,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"

--- a/.github/workflows/Larwick_Overmap_ci_build.yml
+++ b/.github/workflows/Larwick_Overmap_ci_build.yml
@@ -53,7 +53,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"

--- a/.github/workflows/MD_ci_build.yml
+++ b/.github/workflows/MD_ci_build.yml
@@ -53,7 +53,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"

--- a/.github/workflows/Neodays_ci_build.yml
+++ b/.github/workflows/Neodays_ci_build.yml
@@ -53,7 +53,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"

--- a/.github/workflows/Retrodays_ci_build.yml
+++ b/.github/workflows/Retrodays_ci_build.yml
@@ -53,7 +53,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"

--- a/.github/workflows/SurveyorsMap_ci_build.yml
+++ b/.github/workflows/SurveyorsMap_ci_build.yml
@@ -53,7 +53,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"

--- a/.github/workflows/Ultica-iso_ci_build.yml
+++ b/.github/workflows/Ultica-iso_ci_build.yml
@@ -53,7 +53,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"

--- a/.github/workflows/Ultica_ci_build.yml
+++ b/.github/workflows/Ultica_ci_build.yml
@@ -53,7 +53,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"

--- a/.github/workflows/blb_ci_build.yml
+++ b/.github/workflows/blb_ci_build.yml
@@ -53,7 +53,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"

--- a/.github/workflows/hm_build.yml
+++ b/.github/workflows/hm_build.yml
@@ -53,7 +53,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"

--- a/.github/workflows/isomsx_ci_build.yml
+++ b/.github/workflows/isomsx_ci_build.yml
@@ -53,7 +53,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"

--- a/.github/workflows/msx_ci_build.yml
+++ b/.github/workflows/msx_ci_build.yml
@@ -53,7 +53,7 @@ jobs:
           python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
           [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
 
-          artifact_name="$TILESET-${GITHUB_SHA::7}"
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
 
           mkdir "$artifact_name"
           mv "${BUILD_DIR}"/*.png           "$artifact_name"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->

#### Content of the change
so the artifacts names as published by CI go like, `"tileset name"-"git hash"` now this is fine to anyone familiar with git a lot of stuff uses git hashes to display a "version" or point in history to most other people that's just a bunch of meaningless numbers

I wanna be a little more specific, I modified it to `"tileset name"-dev-git-"git hash"` I took most of this from how neovim does it's nightly release names `v0.8.0-dev-1152-g14610332b` for example this should be a little more clear; this artifact is a development build and that's the most important bit, for the more git accustomed adding a `git` before the hash is for tidiness, clear naming do be good

<!-- Explain what does this pull request contain. -->

#### Testing
looking at the artifacts generated by this commit
the ones generated by this commit should also be good <https://github.com/casswedson/CDDA-Tilesets/commit/e4743ca02a9e7a32ae1eddc9b6f864dcb0e5f8e5>
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
