### PR TITLE
[Ultica-ISO] Remove sidewalk height_3d

### DIFF
--- a/gfx/Ultica_iso/pngs_iso_flat_48x36/terrain/t_sidewalk/t_floor.json
+++ b/gfx/Ultica_iso/pngs_iso_flat_48x36/terrain/t_sidewalk/t_floor.json
@@ -1,5 +1,0 @@
-{
-    "id": "t_sidewalk",
-    "fg": "t_sidewalk",
-    "height_3d": 3
-}


### PR DESCRIPTION
#### Summary

Remove sidewalk height_3d

#### Content of the change

A few pixels of height for sidewalks would be nice, but they do things like this with vehicles:

![grafik](https://user-images.githubusercontent.com/44003176/192157273-42506881-b41b-45df-8b10-5139b065579a.png)

#### Testing

Tried in-game.

#### Additional information
