### PR TITLE
[Ultica-ISO] Re-introduce sidewalk height

### DIFF
--- a/gfx/Ultica_iso/pngs_iso_flat_48x36/terrain/t_sidewalk/t_sidewalk.json
+++ b/gfx/Ultica_iso/pngs_iso_flat_48x36/terrain/t_sidewalk/t_sidewalk.json
@@ -1,0 +1,5 @@
+{
+  "id": "t_sidewalk",
+  "fg": "t_sidewalk",
+  "height_3d": 3
+}


### PR DESCRIPTION
#### Summary
Re-introduce Ultica-ISO sidewalk height.

#### Content of the change

Sidewalk height was removed in #1611 due to it breaking vehicle look. With this fixed in https://github.com/CleverRaven/Cataclysm-DDA/pull/61396, it can be re-introduced.

#### Testing

Tried in-game,

#### Additional information
