### PR TITLE
[Altica] Fix layers and update symlinks

### DIFF
--- a/.github/workflows/Altica_ci_build.yml
+++ b/.github/workflows/Altica_ci_build.yml
@@ -61,6 +61,7 @@ jobs:
           mv "${BUILD_DIR}"/*.png           "$artifact_name"
           cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
+          cp "gfx/$TILESET/layering.json"   "$artifact_name"
 
           echo ::set-output name=artifact_name::"$artifact_name"
 

--- a/gfx/Altica/layering.json
+++ b/gfx/Altica/layering.json
@@ -1,0 +1,180 @@
+{
+"variants": [
+  {
+    "context": "f_flagpole",
+    "item_variants": [
+      {
+        "item": "american_flag",
+        "sprite": [{"id": "american_flag_hoisted", "weight": 1}],
+        "layer": 90,
+        "offset_x": 16,
+        "offset_y": -37
+      }
+    ]
+  },
+  {
+    "context": "f_wooden_flagpole",
+    "item_variants": [
+      {
+        "item": "american_flag",
+        "sprite": [{"id": "american_flag_hoisted", "weight": 1}],
+        "layer": 90,
+        "offset_x": 16,
+        "offset_y": -37
+      }
+    ]
+  },
+  {
+    "context": "f_desk",
+    "item_variants": [
+      {
+        "item": "laptop",
+        "sprite": [{"id": "desk_laptop", "weight": 1}],
+        "layer": 90
+      },
+      {
+        "item": "pen",
+        "sprite": [{"id": "desk_pen_1", "weight": 2}, {"id": "desk_pen_2", "weight": 2}],
+        "layer": 95
+      },
+      {
+        "item": "can_drink",
+        "sprite": [{"id": "desk_can_drink", "weight": 2}],
+        "layer": 100
+      }
+    ]
+  },
+  {
+    "context": "f_oven",
+    "item_variants": [
+      {
+        "item": "pan",
+        "sprite": [{"id": "oven_pan_1", "weight": 1}, {"id": "oven_pan_2", "weight": 1}],
+        "layer": 100
+      }
+    ]
+  },
+  {
+    "context": "f_brazier",
+    "item_variants": [
+      {
+        "item": "2x4",
+        "sprite": [{"id": "brazier_2x4", "weight": 1}],
+        "layer": 90
+      },
+      {
+        "item": "log",
+        "sprite": [{"id": "brazier_log", "weight": 1}],
+        "layer": 100
+      }
+    ],
+    "field_variants": [
+      {
+        "field": "fd_smoke",
+        "sprite": [{"id": "fd_smoke_overlay", "weight":2}]
+      }
+    ]    
+  },
+  {
+    "context": "f_toilet",
+    "item_variants": [
+      {
+        "item": "water",
+        "sprite": [{"id": "toilet_water", "weight": 1}],
+        "layer": 90
+      },
+      {
+        "item": "water_clean",
+        "sprite": [{"id": "toilet_water", "weight": 1}],
+        "layer": 90
+      }
+    ]
+  },
+  {
+    "context": "f_fireplace",
+    "item_variants": [
+      {
+        "item": "log",
+        "sprite": [{"id": "fireplace_log", "weight": 1}],
+        "layer": 100
+      }
+    ]
+  },
+  {
+    "context": "f_cupboard",
+    "item_variants": [
+      {
+        "item": "battery_charger",
+        "sprite": [{"id": "cupboard_battery_charger", "weight": 1}],
+        "layer": 90
+      },
+      {
+        "item": "box_small",
+        "sprite": [{"id": "cupboard_box_small", "weight": 1}],
+        "layer": 90
+      },
+      {
+        "item": "candle",
+        "sprite": [{"id": "cupboard_candle", "weight": 1}],
+        "layer": 90
+      },
+      {
+        "item": "matches",
+        "sprite": [{"id": "cupboard_matches", "weight": 1}],
+        "layer": 90
+      }
+    ]
+  },
+  {
+    "context": "f_sink",
+    "item_variants": [
+      {
+        "item": "box_small",
+        "sprite": [{"id": "sink_box_small", "weight": 1}],
+        "layer": 90
+      },
+      {
+        "item": "brush",
+        "sprite": [{"id": "sink_brush", "weight": 1}],
+        "layer": 90
+      },
+      {
+        "item": "dish_towel",
+        "sprite": [{"id": "sink_dish_towel", "weight": 1}],
+        "layer": 90
+      },
+      {
+        "item": "sponge",
+        "sprite": [{"id": "sink_sponge", "weight": 1}],
+        "layer": 90
+      }
+    ]
+  },
+  {
+    "context": "f_30gal_firebarrel",
+    "field_variants": [
+      {
+        "field": "fd_fire",
+        "sprite": [{"id": "f_30gal_firebarrel_fd_fire", "weight": 2}]
+      },
+      {
+        "field": "fd_smoke",
+        "sprite": [{"id": "fd_smoke_overlay", "weight":2}]
+      }
+    ]
+  },
+  {
+    "context": "f_55gal_firebarrel",
+    "field_variants": [
+      {
+        "field": "fd_fire",
+        "sprite": [{"id": "f_55gal_firebarrel_fd_fire", "weight": 2}]
+      },
+      {
+        "field": "fd_smoke",
+        "sprite": [{"id": "fd_smoke_overlay", "weight":2}]
+      }
+    ]
+  }  
+]
+}

--- a/gfx/Altica/pngs_human_body_32x36
+++ b/gfx/Altica/pngs_human_body_32x36
@@ -1,1 +1,1 @@
-../UltimateCataclysm/pngs_human_body_32x36/field
+../UltimateCataclysm/pngs_human_body_32x36

--- a/gfx/Altica/pngs_human_body_plus_32x48
+++ b/gfx/Altica/pngs_human_body_plus_32x48
@@ -1,0 +1,1 @@
+../UltimateCataclysm/pngs_human_body_plus_32x48

--- a/gfx/Altica/pngs_human_body_wielded_32x36
+++ b/gfx/Altica/pngs_human_body_wielded_32x36
@@ -1,1 +1,0 @@
-../UltimateCataclysm/pngs_human_body_32x36/overlay/wielded

--- a/gfx/Altica/pngs_monsters_plus_32x48
+++ b/gfx/Altica/pngs_monsters_plus_32x48
@@ -1,1 +1,0 @@
-../UltimateCataclysm/pngs_human_body_plus_32x48/monsters

--- a/gfx/Altica/pngs_tall_furniture_32x64
+++ b/gfx/Altica/pngs_tall_furniture_32x64
@@ -1,1 +1,0 @@
-../UltimateCataclysm/pngs_tall_32x64/furniture

--- a/gfx/Altica/pngs_tall_magiclysm_32x64
+++ b/gfx/Altica/pngs_tall_magiclysm_32x64
@@ -1,1 +1,0 @@
-../UltimateCataclysm/pngs_tall_32x64/magiclysm

--- a/gfx/Altica/pngs_tall_monsters_32x64
+++ b/gfx/Altica/pngs_tall_monsters_32x64
@@ -1,1 +1,0 @@
-../UltimateCataclysm/pngs_tall_32x64/monsters

--- a/gfx/Altica/pngs_tall_overmap_32x64
+++ b/gfx/Altica/pngs_tall_overmap_32x64
@@ -1,1 +1,0 @@
-../UltimateCataclysm/pngs_tall_32x64/overmap

--- a/gfx/Altica/pngs_tall_terrain_32x64
+++ b/gfx/Altica/pngs_tall_terrain_32x64
@@ -1,1 +1,0 @@
-../UltimateCataclysm/pngs_tall_32x64/terrain

--- a/gfx/Altica/pngs_tall_vehicle_32x64
+++ b/gfx/Altica/pngs_tall_vehicle_32x64
@@ -1,1 +1,0 @@
-../UltimateCataclysm/pngs_tall_32x64/vehicle

--- a/gfx/Altica/pngs_tall_wielded_32x64
+++ b/gfx/Altica/pngs_tall_wielded_32x64
@@ -1,1 +1,0 @@
-../UltimateCataclysm/pngs_tall_32x64/overlay/wielded

--- a/gfx/Altica/pngs_traps_plus_32x48
+++ b/gfx/Altica/pngs_traps_plus_32x48
@@ -1,1 +1,0 @@
-../UltimateCataclysm/pngs_human_body_plus_32x48/traps

--- a/gfx/Altica/pngs_ultica-tall_32x64
+++ b/gfx/Altica/pngs_ultica-tall_32x64
@@ -1,0 +1,1 @@
+../UltimateCataclysm/pngs_tall_32x64

--- a/gfx/Altica/pngs_vehicle_plus_32x48
+++ b/gfx/Altica/pngs_vehicle_plus_32x48
@@ -1,1 +1,0 @@
-../UltimateCataclysm/pngs_human_body_plus_32x48/vehicle

--- a/gfx/Altica/tile_info.json
+++ b/gfx/Altica/tile_info.json
@@ -14,52 +14,34 @@
     "small.png": { "sprite_width": 20, "sprite_height": 20, "sprite_offset_x": 6, "filler": true }
   },
   {
-    "normal.png": { "filler": true  }
+    "normal.png": { "filler": true }
   },
   {
-    "tall_furniture.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true  }
+    "ultica-tall.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true }
   },
   {
-    "tall_magiclysm.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true  }
+    "human_body.png": { "sprite_width": 32, "sprite_height": 36, "sprite_offset_y": -8, "filler": true }
   },
   {
-    "tall_monster.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true  }
+    "human_body_wielded.png": { "sprite_width": 32, "sprite_height": 36, "sprite_offset_y": -8, "filler": true }
   },
   {
-    "tall_terrain.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true  }
+    "monsters_plus.png": { "sprite_width": 32, "sprite_height": 48, "sprite_offset_y": -16, "filler": true }
   },
   {
-    "tall_overmap.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true  }
+    "traps_plus.png": { "sprite_width": 32, "sprite_height": 48, "sprite_offset_y": -16, "filler": true }
   },
   {
-    "tall_vehicle.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true  }
+    "vehicle_plus.png": { "sprite_width": 32, "sprite_height": 48, "sprite_offset_y": -16, "filler": true }
   },
   {
-    "tall_wielded.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true  }
+    "centered.png": { "sprite_width": 64, "sprite_height": 64, "sprite_offset_x": -16, "sprite_offset_y": -16, "filler": true }
   },
   {
-    "human_body.png": { "sprite_width": 32, "sprite_height": 36, "sprite_offset_y": -8, "filler": true  }
+    "large.png": { "sprite_width": 64, "sprite_height": 64, "sprite_offset_x": -16, "sprite_offset_y": -32, "filler": true }
   },
   {
-    "human_body_wielded.png": { "sprite_width": 32, "sprite_height": 36, "sprite_offset_y": -8, "filler": true  }
-  },
-  {
-    "monsters_plus.png": { "sprite_width": 32, "sprite_height": 48, "sprite_offset_y": -16, "filler": true  }
-  },
-  {
-    "traps_plus.png": { "sprite_width": 32, "sprite_height": 48, "sprite_offset_y": -16, "filler": true  }
-  },
-  {
-    "vehicle_plus.png": { "sprite_width": 32, "sprite_height": 48, "sprite_offset_y": -16, "filler": true  }
-  },
-  {
-    "centered.png": { "sprite_width": 64, "sprite_height": 64, "sprite_offset_x": -16, "sprite_offset_y": -16, "filler": true  }
-  },
-  {
-    "large.png": { "sprite_width": 64, "sprite_height": 64, "sprite_offset_x": -16, "sprite_offset_y": -32, "filler": true  }
-  },
-  {
-    "large_ridden.png": { "sprite_width": 64, "sprite_height": 64, "sprite_offset_x": -16, "sprite_offset_y": -27, "filler": true  }
+    "large_ridden.png": { "sprite_width": 64, "sprite_height": 64, "sprite_offset_x": -16, "sprite_offset_y": -27, "filler": true }
   },
   {
     "huge.png": { "sprite_width": 64, "sprite_height": 96, "sprite_offset_x": -16, "sprite_offset_y": -64, "filler": true }
@@ -80,13 +62,13 @@
     }
   },
   {
-    "filler.png": { "sprite_width": 32, "sprite_height": 32, "filler": true  }
+    "filler.png": { "sprite_width": 32, "sprite_height": 32, "filler": true }
   },
   {
-    "filler_tall.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true  }
+    "filler_tall.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true }
   },
   {
-    "fillergiant.png": { "sprite_width": 96, "sprite_height": 96, "sprite_offset_x": -32, "sprite_offset_y": -64, "filler": true  }
+    "fillergiant.png": { "sprite_width": 96, "sprite_height": 96, "sprite_offset_x": -32, "sprite_offset_y": -64, "filler": true }
   },
   {
     "fallback.png": {

--- a/gfx/Altica/tile_info.json
+++ b/gfx/Altica/tile_info.json
@@ -23,16 +23,16 @@
     "human_body.png": { "sprite_width": 32, "sprite_height": 36, "sprite_offset_y": -8, "filler": true }
   },
   {
+    "human_body_plus.png": {
+      "sprite_width": 32,
+      "sprite_height": 48,
+      "sprite_offset_y": -8,
+      "filler": true,
+      "exclude": [ "character", "mods/magiclysm/overlay/worn", "overlay/mutations", "overlay/skin", "overlay/worn" ]
+    }
+  },
+  {
     "human_body_wielded.png": { "sprite_width": 32, "sprite_height": 36, "sprite_offset_y": -8, "filler": true }
-  },
-  {
-    "monsters_plus.png": { "sprite_width": 32, "sprite_height": 48, "sprite_offset_y": -16, "filler": true }
-  },
-  {
-    "traps_plus.png": { "sprite_width": 32, "sprite_height": 48, "sprite_offset_y": -16, "filler": true }
-  },
-  {
-    "vehicle_plus.png": { "sprite_width": 32, "sprite_height": 48, "sprite_offset_y": -16, "filler": true }
   },
   {
     "centered.png": { "sprite_width": 64, "sprite_height": 64, "sprite_offset_x": -16, "sprite_offset_y": -16, "filler": true }

--- a/gfx/Altica/tile_info.json
+++ b/gfx/Altica/tile_info.json
@@ -20,7 +20,13 @@
     "ultica-tall.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true }
   },
   {
-    "human_body.png": { "sprite_width": 32, "sprite_height": 36, "sprite_offset_y": -8, "filler": true }
+    "human_body.png": {
+      "sprite_width": 32,
+      "sprite_height": 36,
+      "sprite_offset_y": -8,
+      "filler": true,
+      "exclude": [ "overlay/bionics", "overlay/facial_hair", "overlay/hair", "overlay/mutations", "overlay/skin", "overlay/worn" ]
+    }
   },
   {
     "human_body_plus.png": {
@@ -30,9 +36,6 @@
       "filler": true,
       "exclude": [ "character", "mods/magiclysm/overlay/worn", "overlay/mutations", "overlay/skin", "overlay/worn" ]
     }
-  },
-  {
-    "human_body_wielded.png": { "sprite_width": 32, "sprite_height": 36, "sprite_offset_y": -8, "filler": true }
   },
   {
     "centered.png": { "sprite_width": 64, "sprite_height": 64, "sprite_offset_x": -16, "sprite_offset_y": -16, "filler": true }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Update symlink and tilesheet of Altica to current Ultica

#### Content of the change

- Uses the `exclude` feature to simplify the setup
- Include some missing layering sprites which should fix the bug below
- Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/57009
- Add its own layering.json file copy pasted from Ultica as I think otherwise the one currently shipping with the game will not update

#### Testing
Compose without issue
No error message about pans
Pan over lay on oven does display properly

![image](https://user-images.githubusercontent.com/41293484/195358257-b11983e8-1b5f-4f21-a535-6c22ab945a0d.png)


#### Additional information
