### PR TITLE
[Ultica-ISO] More item and monster symlinks

### DIFF
--- a/gfx/Ultica_iso/pngs_incomplete_2x_32x32/monsters
+++ b/gfx/Ultica_iso/pngs_incomplete_2x_32x32/monsters
@@ -1,0 +1,1 @@
+../../UltimateCataclysm/pngs_incomplete_32x32/monsters

--- a/gfx/Ultica_iso/pngs_incomplete_32x32/items
+++ b/gfx/Ultica_iso/pngs_incomplete_32x32/items
@@ -1,0 +1,1 @@
+../../UltimateCataclysm/pngs_incomplete_32x32/items

--- a/gfx/Ultica_iso/pngs_normal_32x32/empty_32x32.png
+++ b/gfx/Ultica_iso/pngs_normal_32x32/empty_32x32.png
@@ -1,0 +1,1 @@
+../../UltimateCataclysm/pngs_normal_32x32/empty_32x32.png

--- a/gfx/Ultica_iso/tile_info.json
+++ b/gfx/Ultica_iso/tile_info.json
@@ -124,6 +124,16 @@
     }
   },
   {
+    "incomplete.png": { 
+      "//": "Items are offset already for placement on tables",
+      "sprite_width": 32,
+      "sprite_height": 32,
+      "sprite_offset_x": 8,
+      "sprite_offset_y": 0,
+      "filler": true
+    }
+  },
+  {
     "normal_offset.png": { 
       "//": "Furniture needs to be offset for iso",
       "sprite_width": 32,
@@ -135,6 +145,16 @@
   },
   {
     "normal_2x.png": { 
+      "sprite_width": 32,
+      "sprite_height": 32,
+      "sprite_offset_x": -6,
+      "sprite_offset_y": -44,
+      "pixelscale": 2,
+      "filler": true
+    }
+  },
+  {
+    "incomplete_2x.png": { 
       "sprite_width": 32,
       "sprite_height": 32,
       "sprite_offset_x": -6,


### PR DESCRIPTION
#### Summary
More item and monster symlinks in Ultica-ISO

#### Content of the change

Include items and monsters from `pngs_incomplete_32x32` via symlinks.

#### Testing

Tried in-game

#### Additional information
