### PR TITLE
upgrade "deprecated" workflow infrastructure

### DIFF
--- a/.github/workflows/Altica_ci_build.yml
+++ b/.github/workflows/Altica_ci_build.yml
@@ -63,13 +63,13 @@ jobs:
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
           cp "gfx/$TILESET/layering.json"   "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare

--- a/.github/workflows/Chibi_ci_build.yml
+++ b/.github/workflows/Chibi_ci_build.yml
@@ -83,13 +83,13 @@ jobs:
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
           cp "gfx/$TILESET/layering.json"   "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare

--- a/.github/workflows/HitButton_iso_ci_build.yml
+++ b/.github/workflows/HitButton_iso_ci_build.yml
@@ -60,13 +60,13 @@ jobs:
           cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare

--- a/.github/workflows/Larwick_Overmap_ci_build.yml
+++ b/.github/workflows/Larwick_Overmap_ci_build.yml
@@ -60,13 +60,13 @@ jobs:
           cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare

--- a/.github/workflows/MD_ci_build.yml
+++ b/.github/workflows/MD_ci_build.yml
@@ -60,13 +60,13 @@ jobs:
           cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare

--- a/.github/workflows/Neodays_ci_build.yml
+++ b/.github/workflows/Neodays_ci_build.yml
@@ -60,13 +60,13 @@ jobs:
           cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare

--- a/.github/workflows/Retrodays_ci_build.yml
+++ b/.github/workflows/Retrodays_ci_build.yml
@@ -60,13 +60,13 @@ jobs:
           cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare

--- a/.github/workflows/SurveyorsMap_ci_build.yml
+++ b/.github/workflows/SurveyorsMap_ci_build.yml
@@ -60,13 +60,13 @@ jobs:
           cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare

--- a/.github/workflows/Ultica-iso_ci_build.yml
+++ b/.github/workflows/Ultica-iso_ci_build.yml
@@ -60,13 +60,13 @@ jobs:
           cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare

--- a/.github/workflows/Ultica_ci_build.yml
+++ b/.github/workflows/Ultica_ci_build.yml
@@ -61,13 +61,13 @@ jobs:
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
           cp "gfx/$TILESET/layering.json"   "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare

--- a/.github/workflows/blb_ci_build.yml
+++ b/.github/workflows/blb_ci_build.yml
@@ -60,13 +60,13 @@ jobs:
           cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare

--- a/.github/workflows/hm_build.yml
+++ b/.github/workflows/hm_build.yml
@@ -60,13 +60,13 @@ jobs:
           cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare

--- a/.github/workflows/isomsx_ci_build.yml
+++ b/.github/workflows/isomsx_ci_build.yml
@@ -60,13 +60,13 @@ jobs:
           cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Generate environmental variables
         id: generate_env_vars
         run: |
-          echo "::set-output name=tag_name::${{ steps.get-timestamp.outputs.time }}"
-          echo "::set-output name=release_name::Tilesets Release ${{ steps.get-timestamp.outputs.time }}"
+          echo "TAG-NAME=${{ steps.get-timestamp.outputs.time }}"
+          echo "RELEASE-TITLE=Tilesets Release ${{ steps.get-timestamp.outputs.time }}"
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -37,7 +37,7 @@ jobs:
         id: tag_check
         uses: mukunku/tag-exists-action@v1.0.0
         with:
-          tag: ${{ steps.generate_env_vars.outputs.tag_name }}
+          tag: ${{ steps.generate_env_vars.outputs.TAG-NAME }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get Previous tag
@@ -53,7 +53,7 @@ jobs:
         if: ${{ steps.tag_check.outputs.exists == 'false' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ steps.generate_env_vars.outputs.tag_name }}
+          custom_tag: ${{ steps.generate_env_vars.outputs.TAG-NAME }}
           tag_prefix: ""
       - name: "Generate release notes"
         run: |
@@ -61,7 +61,7 @@ jobs:
             --method POST \
             -H "Accept: application/vnd.github.v3+json" \
             /repos/I-am-Erk/CDDA-Tilesets/releases/generate-notes \
-            -f tag_name='${{ steps.generate_env_vars.outputs.tag_name }}' \
+            -f tag_name='${{ steps.generate_env_vars.outputs.TAG-NAME }}' \
             -f target_commitish='master' \
             -q .body > CHANGELOG.md
       - name: Create release
@@ -71,8 +71,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.generate_env_vars.outputs.tag_name }}
-          release_name: ${{ steps.generate_env_vars.outputs.release_name }}
+          tag_name: ${{ steps.generate_env_vars.outputs.TAG-NAME }}
+          release_name: ${{ steps.generate_env_vars.outputs.RELEASE-TITLE }}
           body_path: ./CHANGELOG.md
           draft: false
           prerelease: false
@@ -167,7 +167,7 @@ jobs:
 
           zip -r $release_name.zip $release_name
 
-          echo ::set-output name=release_name::$release_name
+          echo "RELEASE-NAME=$release_name" >> $GITHUB_OUTPUT
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
@@ -175,6 +175,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: ${{ steps.build.outputs.release_name }}.zip
-          asset_name: ${{ steps.build.outputs.release_name }}.zip
+          asset_path: ${{ steps.build.outputs.RELEASE-NAME }}.zip
+          asset_name: ${{ steps.build.outputs.RELEASE-NAME }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/msx_ci_build.yml
+++ b/.github/workflows/msx_ci_build.yml
@@ -61,13 +61,13 @@ jobs:
           cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
           cp "gfx/$TILESET/layering.json"   "$artifact_name"
 
-          echo ::set-output name=artifact_name::"$artifact_name"
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ steps.build.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.artifact_name }}
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
 
       - name: Compare IDs with ${{ github.base_ref }}
         id: compare


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->

#### Content of the change
see https://github.com/I-am-Erk/CDDA-Tilesets/actions/runs/3243972705/jobs/5319472967#step:6:32 the github workflows complain about a soon to be deprecated command; just upgrade I guess

use what they recommend here:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


<!-- Explain what does this pull request contain. -->

#### Testing
check this commit's workflows https://github.com/casswedson/CDDA-Tilesets/commit/b35b0072f3e8c2b36bfa3fada81569c150367858
just a sample cause I disabled most composers in my fork

to be honest, I can't test the state of the release; like I don't know how I used to test it before, but I can't get it to work always some resource integration errors
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
