### PR TITLE
fix: release errors + run on workflow_dispatch

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -7,6 +7,7 @@ concurrency: release
 on:
   schedule:
     - cron: '0 20 * * sun'
+  workflow_dispatch:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -28,8 +29,8 @@ jobs:
       - name: Generate environmental variables
         id: generate_env_vars
         run: |
-          echo "TAG-NAME=${{ steps.get-timestamp.outputs.time }}"
-          echo "RELEASE-TITLE=Tilesets Release ${{ steps.get-timestamp.outputs.time }}"
+          echo "TAG-NAME=${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
+          echo "RELEASE-TITLE=Tilesets Release ${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->

#### Content of the change
I missed sending the output of a step into the runner's environment; send it so other jobs and steps can read data they need

I also added the trigger `workflow_dispatch` so we can run the workflow at any time, this would solve the potential missing release this week

since the workflow was at least successful at pushing a tag we'll get an incomplete changelog, it needs to be generated by hand later
<!-- Explain what does this pull request contain. -->

#### Testing
the interface to `workflow_dispatch` so actions > specific workflow > run
![Screenshot from 2022-10-16 15-41-51](https://user-images.githubusercontent.com/58050969/196057394-8ea5d2a8-18b7-4875-9524-32b5ee0f18dc.png)

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
