### PR TITLE
[Larwick Overmap] Mobile homes, strip malls, and other misc. fixes

### DIFF
--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain.json
@@ -121,19 +121,6 @@
     "id": "lake_cabin_water",
     "fg": "water_blue"
   },
-
-  {
-    "id": "cabin_strange",
-    "fg": "small_tree_green"
-  },
-  {
-    "id": "cabin_strange_b",
-    "fg": "small_tree_green"
-  },
-  {
-    "id": "cabin_strange_roof",
-    "fg": "small_tree_green"
-  },
   {
     "id": [
       "cabin",
@@ -152,6 +139,9 @@
       "cabin_roof_6",
       "cabin_7",
       "cabin_roof_7",
+      "cabin_strange",
+      "cabin_strange_b",
+      "cabin_strange_roof",
       "cabin_lake",
       "cabin_lake_roof",
       "cabin_lapin",

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_commercial.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_commercial.json
@@ -1016,52 +1016,21 @@
     "fg": "gas_light_blue"
   },
   {
-    "id": "hdwr_large_0_0_0",
+    "id": [
+      "hdwr_large_0_0_0",
+      "hdwr_large_1_0_0",
+      "hdwr_large_0_1_0",
+      "hdwr_large_1_1_0",
+      "hdwr_large_0_2_0",
+      "hdwr_large_1_2_0",
+      "hdwr_large_0_0_1",
+      "hdwr_large_1_0_1",
+      "hdwr_large_0_1_1",
+      "hdwr_large_1_1_1",
+      "hdwr_large_0_2_1",
+      "hdwr_large_1_2_1"
+    ],
     "fg": "big_building_light_green"
-  },
-  {
-    "id": "hdwr_large_1_0_0",
-    "fg": "big_building_light_green"
-  },
-  {
-    "id": "hdwr_large_0_1_0",
-    "fg": "big_building_light_green"
-  },
-  {
-    "id": "hdwr_large_1_1_0",
-    "fg": "big_building_light_green"
-  },
-  {
-    "id": "hdwr_large_0_2_0",
-    "fg": "big_building_light_green"
-  },
-  {
-    "id": "hdwr_large_1_2_0",
-    "fg": "big_building_light_green"
-  },
-  {
-    "id": "hdwr_large_0_0_1",
-    "fg": "open_air_brown"
-  },
-  {
-    "id": "hdwr_large_1_0_1",
-    "fg": "open_air_brown"
-  },
-  {
-    "id": "hdwr_large_0_1_1",
-    "fg": "open_air_brown"
-  },
-  {
-    "id": "hdwr_large_1_1_1",
-    "fg": "open_air_brown"
-  },
-  {
-    "id": "hdwr_large_0_2_1",
-    "fg": "open_air_brown"
-  },
-  {
-    "id": "hdwr_large_1_2_1",
-    "fg": "open_air_brown"
   },
   {
     "id": "garage_gas_1",

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_commercial.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_commercial.json
@@ -1719,5 +1719,26 @@
       "farm_supply_roof_4"
     ],
     "fg": "shop_yellow"
+  },
+  {
+    "id": [
+      "strip_mall_1",
+      "strip_mall_2",
+      "strip_mall_3",
+      "strip_mall_4",
+      "strip_mall_roof_1",
+      "strip_mall_roof_2",
+      "strip_mall_roof_3",
+      "strip_mall_roof_4"
+    ],
+    "fg": "shop_light_red"
+  },
+  {
+    "id": "strip_mall_5",
+    "fg": "parking_dark_gray"
+  },
+  {
+    "id": "strip_mall_roof_5",
+    "fg": "open_air_blue"
   }
 ]

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_hardcoded.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_hardcoded.json
@@ -40,27 +40,21 @@
     "fg": "building_columns_pink"
   },
   {
-    "id": "mine_entrance",
+    "id": [
+      "mine_entrance",
+      "mine_entrance_loading_zone",
+      "mine_entrance_roof",
+      "mine_entrance_loading_zone_roof"
+    ],
     "fg": "mine_magenta"
   },
   {
-    "id": "mine_entrance_roof",
-    "fg": "mine_magenta"
-  },
-  {
-    "id": "mine_entrance_loading_zone",
-    "fg": "mine_magenta"
-  },
-  {
-    "id": "mine_entrance_loading_zone_roof",
-    "fg": "mine_magenta"
-  },
-  {
-    "id": "mine_shaft_middle",
-    "fg": "mine_dark_gray"
-  },
-  {
-    "id": "mine_shaft_lower",
+    "id": [
+      "mine_shaft_middle",
+      "mine_shaft_middle_east",
+      "mine_shaft_lower",
+      "mine_shaft_lower_east"
+    ],
     "fg": "mine_dark_gray"
   },
   {

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_military.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_military.json
@@ -39,6 +39,8 @@
       "lmoe_under",
       "lmoe_under_empty",
       "lmoe_zombie_under_empty",
+      "lmoe_prepperquest",
+      "lmoe_under_empty_prepperquest",
       "bunker",
       "bunker_basement"
     ],

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_recreational.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_recreational.json
@@ -404,23 +404,56 @@
     "fg": "big_building_green"
   },
   {
-    "id": "stadium_0_0",
+    "id": [
+      "stadium_0_0",
+      "stadium_1_0",
+      "stadium_2_0",
+      "stadium_3_0"
+    ],
     "fg": "parking_dark_gray"
   },
   {
-    "id": "stadium_1_0",
-    "fg": "parking_dark_gray"
-  },
-  {
-    "id": "stadium_2_0",
-    "fg": "parking_dark_gray"
-  },
-  {
-    "id": "stadium_3_0",
-    "fg": "parking_dark_gray"
-  },
-  {
-    "id": "stadium_0_1",
+    "id": [
+      "stadium_0_1",
+      "stadium_2_1",
+      "stadium_3_1",
+      "stadium_0_2",
+      "stadium_3_2",
+      "stadium_0_3",
+      "stadium_3_3",
+      "stadium_1_4",
+      "stadium_2_4",
+
+      "stadium_0_1_1",
+      "stadium_1_1_1",
+      "stadium_2_1_1",
+      "stadium_3_1_1",
+      "stadium_0_2_1",
+      "stadium_3_2_1",
+      "stadium_0_3_1",
+      "stadium_3_3_1",
+      "stadium_0_4_1",
+      "stadium_1_4_1",
+      "stadium_2_4_1",
+      "stadium_3_4_1",
+
+      "stadium_0_1_2",
+      "stadium_1_1_2",
+      "stadium_2_1_2",
+      "stadium_3_1_2",
+      "stadium_0_2_2",
+      "stadium_3_2_2",
+      "stadium_0_3_2",
+      "stadium_3_3_2",
+      "stadium_0_4_2",
+      "stadium_1_4_2",
+      "stadium_2_4_2",
+      "stadium_3_4_2",
+
+      "stadium_1_1_3",
+      "stadium_2_1_3",
+      "stadium_0_3_3"
+    ],
     "fg": "big_building_white"
   },
   {
@@ -428,60 +461,34 @@
     "fg": "big_building_light_gray"
   },
   {
-    "id": "stadium_2_1",
-    "fg": "big_building_white"
-  },
-  {
-    "id": "stadium_3_1",
-    "fg": "big_building_white"
-  },
-  {
-    "id": "stadium_0_2",
-    "fg": "big_building_white"
-  },
-  {
-    "id": "stadium_1_2",
+    "id": [
+      "stadium_1_2",
+      "stadium_2_2",
+      "stadium_1_3",
+      "stadium_2_3"
+    ],
     "fg": "open_air_light_green"
-  },
-  {
-    "id": "stadium_2_2",
-    "fg": "open_air_light_green"
-  },
-  {
-    "id": "stadium_3_2",
-    "fg": "big_building_white"
-  },
-  {
-    "id": "stadium_0_3",
-    "fg": "big_building_white"
-  },
-  {
-    "id": "stadium_1_3",
-    "fg": "open_air_light_green"
-  },
-  {
-    "id": "stadium_2_3",
-    "fg": "open_air_light_green"
-  },
-  {
-    "id": "stadium_3_3",
-    "fg": "big_building_white"
   },
   {
     "id": "stadium_0_4",
     "fg": "garage_light_gray"
   },
   {
-    "id": "stadium_1_4",
-    "fg": "big_building_white"
-  },
-  {
-    "id": "stadium_2_4",
-    "fg": "big_building_white"
-  },
-  {
     "id": "stadium_3_4",
     "fg": "big_building_magenta"
+  },
+  {
+    "id": [
+      "stadium_1_2_1",
+      "stadium_2_2_1",
+      "stadium_1_3_1",
+      "stadium_2_3_1",
+      "stadium_1_2_2",
+      "stadium_2_2_2",
+      "stadium_1_3_2",
+      "stadium_2_3_2"
+    ],
+    "fg": "open_air_blue"
   },
   {
     "id": "natural_spring",

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
@@ -1239,5 +1239,19 @@
         "nursing_home_sh11"
       ],
     "fg": "parking_dark_gray"
+  },
+  {
+    "id": [
+      "trailer_hub_10",
+      "trailer_hub_10_roof"
+    ],
+    "fg": "house_cyan"
+  },
+  {
+    "id": [
+      "prefab",
+      "prefab_roof"
+    ],
+    "fg": "trailer_light_gray"
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Connects trailer park prefabs, strip malls, stadium z-levels, and other misc. fixes
<!-- Brief description  -->

#### Content of the change
Connects:
 - Trailer park mobile homes
 - Trailer park administration building
 - Strip malls
 - Stadium z-levels

Changes:
 - Home improvement superstore roof from ``open_air_magenta`` to ``big_building_light_green``
 - ``cabin_strange`` to be consistent with other cabins due to ascii variant working as so

Fixes:
 - ``mine_shaft*_east"``
 - ``lmoe_*prepperquest``
<!-- Explain what does this pull request contain. -->

#### Testing
_Strip mall_
![lar_strip](https://user-images.githubusercontent.com/32048635/196286359-a82a61c8-aeec-4ea8-b0d8-a1fcd85a8426.png)
_Stadium z-level_
![lar_stadiumz](https://user-images.githubusercontent.com/32048635/196286361-8baef95e-f0f6-4aab-aa4c-6eebeae1bf15.png)
_Mine shaft_
![lar_shaft](https://user-images.githubusercontent.com/32048635/196286362-ba8f5a82-1ca6-4b19-b7fb-eb45d421ab85.png)
_Home improvement superstore_
![lar_supstore](https://user-images.githubusercontent.com/32048635/196286364-5198f0dd-9a26-4ed1-8dbd-f57df6de3c8a.png)
_Trailer park_
![lar_tpark](https://user-images.githubusercontent.com/32048635/196286366-142008c4-ad5b-490c-95d3-e9141101b86b.png)

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
Roads were intentionally not fixed; they need a better solution.