### PR TITLE
bump tag exists action version

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
       - name: Check if there is an existing git tag
         id: tag_check
-        uses: mukunku/tag-exists-action@v1.0.0
+        uses: mukunku/tag-exists-action@v1.1.0
         with:
           tag: ${{ steps.generate_env_vars.outputs.TAG-NAME }}
         env:


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
This PR bumps the tag-exists-action version to v1.1.0 to get rid of _some of_ [these warnings](https://github.com/I-am-Erk/CDDA-Tilesets/actions/runs/3308398934):
![image](https://user-images.githubusercontent.com/4502154/198848961-6d26672b-23f0-4f91-a925-5948f2eb9318.png)

