### PR TITLE
[Larwick] Retirement community dump

### DIFF
--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
@@ -1228,7 +1228,21 @@
       "retirement_community_3f_19",
       "retirement_community_3f_22",
       "retirement_community_3f_23",
-      "retirement_community_3f_26"
+      "retirement_community_3f_26",
+
+      "retirement_community_b_1",
+      "retirement_community_b_2",
+      "retirement_community_b_3",
+      "retirement_community_b_4",
+      "retirement_community_b_5",
+      "retirement_community_b_6",
+      "retirement_community_b_7",
+      "retirement_community_b_15",
+      "retirement_community_b_18",
+      "retirement_community_b_19",
+      "retirement_community_b_22",
+      "retirement_community_b_23",
+      "retirement_community_b_26"
     ],
     "fg": "duplex_light_gray"
   },

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
@@ -1247,5 +1247,28 @@
       "retirement_community_33"
     ],
     "fg": "parking_dark_gray"
+  },
+  {
+    "id": [
+      "retirement_community_2f_8",
+      "retirement_community_2f_9",
+      "retirement_community_2f_10",
+      "retirement_community_2f_11",
+      "retirement_community_2f_12",
+      "retirement_community_2f_13",
+      "retirement_community_2f_14",
+      "retirement_community_2f_27",
+      "retirement_community_2f_28",
+      "retirement_community_2f_29",
+      "retirement_community_2f_30",
+      "retirement_community_2f_31",
+      "retirement_community_2f_32",
+      "retirement_community_2f_33",
+      "retirement_community_2f_37",
+
+      "retirement_community_park_2f_2",
+      "retirement_community_park_2f_5"
+    ],
+    "fg": "open_air_blue"
   }
 ]

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
@@ -1295,5 +1295,19 @@
       "retirement_community_b_38"
     ],
     "fg": "two_story_light_blue"
+  },
+  {
+    "id": [
+      "retirement_community_park_1",
+      "retirement_community_park_2",
+      "retirement_community_park_3",
+      "retirement_community_park_4",
+      "retirement_community_park_5",
+      "retirement_community_park_6",
+      "retirement_community_park_7",
+      "retirement_community_park_8",
+      "retirement_community_park_9"
+    ],
+    "fg": "small_tree_green"
   }
 ]

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
@@ -1,18 +1,11 @@
 [
   {
-    "id": "generic_city_house_basement",
-    "fg": "house_light_gray"
-  },
-  {
-    "id": "basement",
-    "fg": "house_light_gray"
-  },
-  {
-    "id": "basement_bionic",
-    "fg": "house_light_gray"
-  },
-  {
-    "id": "basement_hidden_lab_stairs",
+    "id":[
+      "generic_city_house_basement",
+      "basement",
+      "basement_bionic",
+      "basement_hidden_lab_stairs"
+    ],
     "fg": "house_light_gray"
   },
   {
@@ -1270,5 +1263,37 @@
       "retirement_community_park_2f_5"
     ],
     "fg": "open_air_blue"
+  },
+  {
+    "id": [
+      "retirement_community_34",
+      "retirement_community_35",
+
+      "retirement_community_2f_34",
+      "retirement_community_2f_35"
+    ],
+    "fg":"shop_magenta"
+  },
+  {
+    "id": [
+      "retirement_community_36",
+      "retirement_community_2f_36"
+    ],
+    "fg": "pool_blue"
+  },
+  {
+    "id": [
+      "retirement_community_38",
+      "retirement_community_39",
+      "retirement_community_40",
+
+      "retirement_community_2f_38",
+      "retirement_community_2f_39",
+      "retirement_community_2f_40",
+
+      "retirement_community_b_37",
+      "retirement_community_b_38"
+    ],
+    "fg": "two_story_light_blue"
   }
 ]

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
@@ -44,91 +44,30 @@
     "fg": "house_light_gray"
   },
   {
-    "id": "duplex",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "duplex_roof",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex2",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex2_roof",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex3",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex3_roof",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex4",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex4_roof",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex5",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex5_roof",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex6",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex6_roof",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex7",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex7_roof",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex8",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex8_roof",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex9",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex9_roof",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex10",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex10_roof",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex11",
-    "fg": "duplex_light_gray"
-  },
-  {
-    "id": "house_duplex11_roof",
+    "id": [
+      "duplex",
+      "house_duplex2",
+      "house_duplex3",
+      "house_duplex4",
+      "house_duplex5",
+      "house_duplex6",
+      "house_duplex7",
+      "house_duplex8",
+      "house_duplex9",
+      "house_duplex10",
+      "house_duplex11",
+      "duplex_roof",
+      "house_duplex2_roof",
+      "house_duplex3_roof",
+      "house_duplex4_roof",
+      "house_duplex5_roof",
+      "house_duplex6_roof",
+      "house_duplex7_roof",
+      "house_duplex8_roof",
+      "house_duplex9_roof",
+      "house_duplex10_roof",
+      "house_duplex11_roof"
+    ],
     "fg": "duplex_light_gray"
   },
   {
@@ -1253,5 +1192,60 @@
       "prefab_roof"
     ],
     "fg": "trailer_light_gray"
+  },
+  {
+    "id": [
+      "retirement_community_1",
+      "retirement_community_2",
+      "retirement_community_3",
+      "retirement_community_4",
+      "retirement_community_5",
+      "retirement_community_6",
+      "retirement_community_7",
+      "retirement_community_15",
+      "retirement_community_18",
+      "retirement_community_19",
+      "retirement_community_22",
+      "retirement_community_23",
+      "retirement_community_26",
+
+      "retirement_community_2f_1",
+      "retirement_community_2f_2",
+      "retirement_community_2f_3",
+      "retirement_community_2f_4",
+      "retirement_community_2f_5",
+      "retirement_community_2f_6",
+      "retirement_community_2f_7",
+      "retirement_community_2f_15",
+      "retirement_community_2f_18",
+      "retirement_community_2f_19",
+      "retirement_community_2f_22",
+      "retirement_community_2f_23",
+      "retirement_community_2f_26",
+
+      "retirement_community_3f_1",
+      "retirement_community_3f_2",
+      "retirement_community_3f_3",
+      "retirement_community_3f_4",
+      "retirement_community_3f_5",
+      "retirement_community_3f_6",
+      "retirement_community_3f_7",
+      "retirement_community_3f_15",
+      "retirement_community_3f_18",
+      "retirement_community_3f_19",
+      "retirement_community_3f_22",
+      "retirement_community_3f_23",
+      "retirement_community_3f_26"
+    ],
+    "fg": "duplex_light_gray"
+  },
+  {
+    "id": [
+      "retirement_community_8",
+      "retirement_community_14",
+      "retirement_community_27",
+      "retirement_community_33"
+    ],
+    "fg": "parking_dark_gray"
   }
 ]

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_waste_junk.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_waste_junk.json
@@ -108,7 +108,10 @@
     "fg": "industry_blue"
   },
   {
-    "id": "dumpsite",
+    "id": [
+      "dumpsite",
+      "dumpsite_edge"
+    ],
     "fg": "hive_brown"
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Connects most of the retirement community tiles and some dumpsite tiles
<!-- Brief description  -->

#### Content of the change
Connects:
 - [Retirement community]:
 - Houses with duplex
 - Parking lots
 - Community building with magenta shop and blue pool
 - Administration building with light blue two story building
 - Dumpsite edge with brown hive

<!-- Explain what does this pull request contain. -->

#### Testing
_Before_
![lar_retirebef](https://user-images.githubusercontent.com/32048635/206006216-3f47b8c9-81dd-4ffe-b8e7-5f0c2c0b71eb.png)
![lar_dumpbef](https://user-images.githubusercontent.com/32048635/206006220-393e32ca-b489-42ba-b7ea-72ae84ce1198.png)
_After_
![lar_retireaft](https://user-images.githubusercontent.com/32048635/206006301-294daf93-2cfe-4430-ab98-2c53cb66654b.png)
![lar_dumpaft](https://user-images.githubusercontent.com/32048635/206006303-baf1c3d9-d52a-41a6-ac29-6a10f90124be.png)

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
