### PR TITLE
[MSX] Hoistable National Flags

### DIFF
--- a/gfx/MShockXotto+/layering.json
+++ b/gfx/MShockXotto+/layering.json
@@ -23,6 +23,13 @@
         "layer": 90,
         "offset_x": 18,
         "offset_y": -47
+      },
+      {
+        "item": "national_flag",
+        "sprite": [{"id": "national_flag", "weight": 1}],
+        "layer": 90,
+        "offset_x": 18,
+        "offset_y": -47
       }
     ]
   },
@@ -46,6 +53,13 @@
       {
         "item": "american_flag",
         "sprite": [{"id": "american_flag", "weight": 1}],
+        "layer": 90,
+        "offset_x": 18,
+        "offset_y": -47
+      },
+      {
+        "item": "national_flag",
+        "sprite": [{"id": "national_flag", "weight": 1}],
         "layer": 90,
         "offset_x": 18,
         "offset_y": -47


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Looks like the national flags can't seem to be hoisted unlike the states, pride, and american flag. This fixes it.
 
#### Content of the change
added the necessary json entries in Layering.json


#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->
![Screenshot_20230519-231229](https://github.com/I-am-Erk/CDDA-Tilesets/assets/78019001/ef8f51d4-7c7a-42cf-a857-fedf02992910)
![Screenshot_20230519-231536](https://github.com/I-am-Erk/CDDA-Tilesets/assets/78019001/88a9f3b0-0284-41d2-96c8-d99af998bf7f)


#### Additional information
