### PR TITLE
[MSX] Clean t_hole

### DIFF
--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_hole_0.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_hole_0.json
@@ -1,1 +1,5 @@
-{"id": "t_hole", "fg": ["3092_t_hole_0"], "multitile": true, "additional_tiles": [{"id": "unconnected", "fg": ["3092_t_hole_0"], "bg": []}, {"id": "center", "fg": ["3093_t_hole_1"], "bg": []}, {"id": "corner", "fg": ["3094_t_hole_2"], "bg": []}, {"id": "edge", "fg": ["3095_t_hole_3"], "bg": []}, {"id": "end_piece", "fg": ["3096_t_hole_4"], "bg": []}, {"id": "t_connection", "fg": ["3097_t_hole_5"], "bg": []}], "bg": []}
+{
+  "id": "t_hole",
+  "fg": "t_open_air",
+  "bg": []
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
The `t_hole` doesnt looks good when it's between roofs. Since (i made) the `t_hole` behave basically the same as `t_open_air` in the main repo, it might aswell have similar sprite to it.

#### Content of the change

change it's json to use `t_open_air`'s empty transparent sprite.

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
