### PR TITLE
[Ultica] Fix skin images in documentation

### DIFF
--- a/doc/style/image/skin-female.png
+++ b/doc/style/image/skin-female.png
@@ -1,1 +1,1 @@
-../../../gfx/UltimateCataclysm/pngs_tall_32x64/overlay/skin/skin_light_f.png
+../../../gfx/UltimateCataclysm/pngs_human_body_32x36/overlay/skin/skin_light_f.png

--- a/doc/style/image/skin-male.png
+++ b/doc/style/image/skin-male.png
@@ -1,1 +1,1 @@
-../../../gfx/UltimateCataclysm/pngs_tall_32x64/overlay/skin/skin_light_m.png
+../../../gfx/UltimateCataclysm/pngs_human_body_32x36/overlay/skin/skin_light_m.png


### PR DESCRIPTION
#### Summary
Fix broken image of female/male sprite in the documentation

#### Content of the change
I've updated symlinks to the actual sprites. Apparently, those sprites moved ages ago, but not in the documentation. 

#### Testing
None.

#### Additional information
AFAIR the doc CI uses my fork of mdBook which should be able handle symlinks
