### PR TITLE
refactor: reusable workflows for tileset composers

### DIFF
--- a/.github/workflows/ASCII_Overmap_ci_build.yml
+++ b/.github/workflows/ASCII_Overmap_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/ASCII_Overmap folder
 name: ASCII_Overmap composer
-
-env:
-  TILESET: ASCII_Overmap
-  COMPOSE_ARGS: --use-all
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,60 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: ASCII_Overmap
+      composer-args: --use-all

--- a/.github/workflows/Altica_ci_build.yml
+++ b/.github/workflows/Altica_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/Altica folder
 name: Altica composer
-
-env:
-  TILESET: Altica
-  COMPOSE_ARGS: --use-all --obsolete-fillers
-  BUILD_DIR: build
 
 on:
   push:
@@ -29,61 +18,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-          cp "gfx/$TILESET/layering.json"   "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: Altica
+      composer-args: --use-all --obsolete-fillers

--- a/.github/workflows/Chibi_ci_build.yml
+++ b/.github/workflows/Chibi_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/UltimateCataclysm, gfx/MShockXotto+/ or gfx/Chibi_Ultica/ folders
 name: Chibi_Ultica composer
-
-env:
-  TILESET: Chibi_Ultica
-  COMPOSE_ARGS: --use-all
-  BUILD_DIR: build
 
 on:
   push:
@@ -53,61 +42,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-          cp "gfx/$TILESET/layering.json"   "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: Chibi_Ultica
+      composer-args: --use-all

--- a/.github/workflows/HitButton_iso_ci_build.yml
+++ b/.github/workflows/HitButton_iso_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/HitButton_iso folder
 name: HitButton iso composer
-
-env:
-  TILESET: HitButton_iso
-  COMPOSE_ARGS: --use-all
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,60 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: HitButton_iso
+      composer-args: --use-all

--- a/.github/workflows/Larwick_Overmap_ci_build.yml
+++ b/.github/workflows/Larwick_Overmap_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/Larwick_Overmap folder
 name: Larwick_Overmap composer
-
-env:
-  TILESET: Larwick_Overmap
-  COMPOSE_ARGS: --use-all
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,60 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: Larwick_Overmap
+      composer-args: --use-all

--- a/.github/workflows/MD_ci_build.yml
+++ b/.github/workflows/MD_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/Mushroom-Dream folder
 name: Mushroom-Dream composer
-
-env:
-  TILESET: Mushroom-Dream
-  COMPOSE_ARGS: --use-all --obsolete-fillers
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,60 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: Mushroom-Dream
+      composer-args: --use-all --obsolete-fillers

--- a/.github/workflows/Neodays_ci_build.yml
+++ b/.github/workflows/Neodays_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/NeoDays folder
 name: NeoDays composer
-
-env:
-  TILESET: NeoDays
-  COMPOSE_ARGS: --use-all
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,60 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: NeoDays
+      composer-args: --use-all

--- a/.github/workflows/Retrodays_ci_build.yml
+++ b/.github/workflows/Retrodays_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggerd by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/RetroDays folder
 name: RetroDays composer
-
-env:
-  TILESET: Retrodays
-  COMPOSE_ARGS: --use-all
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,60 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: Retrodays
+      composer-args: --use-all

--- a/.github/workflows/SurveyorsMap_ci_build.yml
+++ b/.github/workflows/SurveyorsMap_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/SurveyorsMap folder
 name: SurveyorsMap composer
-
-env:
-  TILESET: SurveyorsMap
-  COMPOSE_ARGS: --use-all
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,60 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: SurveyorsMap
+      composer-args: --use-all

--- a/.github/workflows/Ultica-iso_ci_build.yml
+++ b/.github/workflows/Ultica-iso_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/Ultica_iso folder
 name: Ultica_iso composer
-
-env:
-  TILESET: Ultica_iso
-  COMPOSE_ARGS: --use-all --obsolete-fillers
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,60 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: Ultica_iso
+      composer-args: --use-all --obsolete-fillers

--- a/.github/workflows/Ultica_ci_build.yml
+++ b/.github/workflows/Ultica_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/UltimateCataclysm folder
 name: UltimateCataclysm composer
-
-env:
-  TILESET: UltimateCataclysm
-  COMPOSE_ARGS: --use-all --obsolete-fillers
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,61 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-          cp "gfx/$TILESET/layering.json"   "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: UltimateCataclysm
+      composer-args: --use-all --obsolete-fillers

--- a/.github/workflows/blb_ci_build.yml
+++ b/.github/workflows/blb_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/BrownLikeBears folder
 name: BrownLikeBears composer
-
-env:
-  TILESET: BrownLikeBears
-  COMPOSE_ARGS: --use-all --obsolete-fillers
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,60 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: BrownLikeBears
+      composer-args: --use-all --obsolete-fillers

--- a/.github/workflows/composer_template.yml
+++ b/.github/workflows/composer_template.yml
@@ -1,0 +1,72 @@
+name: Tileset composer template
+
+on:
+  workflow_call:
+    inputs:
+      tileset:
+        type: string
+        required: true
+      composer-args:
+        type: string
+        required: true
+
+env:
+  BUILD_DIR: build
+  TILESET: ${{ inputs.tileset }}
+  COMPOSE_ARGS: ${{ inputs.composer-args }}
+
+jobs:
+  build:
+    name: CI Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: musl python3 python3-pip libvips42
+
+      - run: sudo apt-get update; sudo apt-get install libvips42
+      - run: pip3 install pyvips
+
+      - uses: actions/checkout@v3
+
+      - name: Build
+        id: build
+        run: |
+          mkdir "$BUILD_DIR"
+          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py
+
+          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
+          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
+
+          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
+
+          mkdir "$artifact_name"
+          mv "${BUILD_DIR}"/*.png           "$artifact_name"
+          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
+          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
+
+          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
+          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
+
+      - name: Compare IDs with ${{ github.base_ref }}
+        id: compare
+        if: github.base_ref
+        run: |
+          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
+          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
+          git checkout origin/${{ github.base_ref }}
+
+          mkdir "$BUILD_DIR/base_json/"
+          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
+
+          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
+          || echo "Error: Failed to get list_tileset_ids.py"
+
+          echo -e "\nDifferences in IDs:"
+          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3

--- a/.github/workflows/giantdays_ci_build.yml
+++ b/.github/workflows/giantdays_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggerd by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/RetroDays folder
 name: GiantDays composer
-
-env:
-  TILESET: GiantDays
-  COMPOSE_ARGS: --use-all
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,60 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: GiantDays
+      composer-args: --use-all

--- a/.github/workflows/hm_build.yml
+++ b/.github/workflows/hm_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/HollowMoon folder
 name: HollowMoon composer
-
-env:
-  TILESET: HollowMoon
-  COMPOSE_ARGS: --use-all --obsolete-fillers
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,60 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: HollowMoon
+      composer-args: --use-all --obsolete-fillers

--- a/.github/workflows/isomsx_ci_build.yml
+++ b/.github/workflows/isomsx_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/IsoMSX+ folder
 name: IsoMSX+ composer
-
-env:
-  TILESET: IsoMSX+
-  COMPOSE_ARGS: --use-all
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,60 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: IsoMSX+
+      composer-args: --use-all

--- a/.github/workflows/msx_ci_build.yml
+++ b/.github/workflows/msx_ci_build.yml
@@ -1,15 +1,4 @@
-# performs CI builds using compose.py from
-# https://github.com/CleverRaven/Cataclysm-DDA
-#
-# This action is triggered by any PR against the master branch as well
-# as on any push to the master branch itself
-# that changes any file in gfx/MShockXotto+ folder
 name: MShockXotto+ composer
-
-env:
-  TILESET: MShockXotto+
-  COMPOSE_ARGS: --use-all
-  BUILD_DIR: build
 
 on:
   push:
@@ -27,61 +16,7 @@ on:
 
 jobs:
   build:
-    name: CI Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: musl python3 python3-pip libvips42
-
-        # re-installing libvips; caching it won't set it up the way we need it
-        # still cache it because we'll make it work somehow
-      - run: sudo apt-get update; sudo apt-get install libvips42
-      - run: pip3 install pyvips
-
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Build
-        id: build
-        run: |
-          mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
-          || echo "Error: Failed to get compose.py"
-
-          python3 "$BUILD_DIR/compose.py" --feedback CONCISE --loglevel INFO $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"
-          [ -f "gfx/$TILESET/fallback.png" ] && cp "gfx/$TILESET/fallback.png" "$BUILD_DIR/"
-
-          artifact_name="$TILESET-dev-git-${GITHUB_SHA::7}"
-
-          mkdir "$artifact_name"
-          mv "${BUILD_DIR}"/*.png           "$artifact_name"
-          cp "$BUILD_DIR/tile_config.json"  "$artifact_name"
-          cp "gfx/$TILESET/tileset.txt"     "$artifact_name"
-          cp "gfx/$TILESET/layering.json"   "$artifact_name"
-
-          echo "ARTIFACT-NAME=$artifact_name" >> $GITHUB_OUTPUT
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ steps.build.outputs.ARTIFACT-NAME }}
-          path: ${{ steps.build.outputs.ARTIFACT-NAME }}
-
-      - name: Compare IDs with ${{ github.base_ref }}
-        id: compare
-        if: github.base_ref
-        run: |
-          echo "Switching to the target branch ${{ github.base_ref }} to get differences between ID lists"
-          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
-
-          mkdir "$BUILD_DIR/base_json/"
-          python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS --only-json "gfx/$TILESET" "$BUILD_DIR/base_json/"
-
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/list_tileset_ids.py \
-          || echo "Error: Failed to get list_tileset_ids.py"
-
-          echo -e "\nDifferences in IDs:"
-          (diff -u0 <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/base_json/") <(python3 "$BUILD_DIR/list_tileset_ids.py" "$BUILD_DIR/")) | tail -n +3
+    uses: ./.github/workflows/composer_template.yml
+    with:
+      tileset: MShockXotto+
+      composer-args: --use-all


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
reduce the amount of code needed to set up new tilesets

this also makes it easier to maintain all the workflows, they now share a file where all the logic and commands are stored


<!-- Brief description  -->

#### Content of the change
now setting up a tileset testing workflow looks like this:
- where we set the most important parts, like the event triggers and path filtering

after that we call a workflow template, similar to a github action with inputs etc. the file has all the code needed to compile a tileset for testing and pushing the result artifact

```yml
name: GiantDays composer

on:
  push:
    branches:
      - master
    paths:
      - 'gfx/GiantDays/**'
      - '.github/workflows/giantdays_ci_build.yml'
  pull_request:
    branches:
      - master
    paths:
      - 'gfx/GiantDays/**'
      - '.github/workflows/giantdays_ci_build.yml'

jobs:
  build:
    uses: ./.github/workflows/composer_template.yml
    with:
      tileset: GiantDays
      composer-args: --use-all
```
<!-- Explain what does this pull request contain. -->

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
