### PR TITLE
[Ultica] make calibers optional and turned off by default

### DIFF
--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.223rem/223.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.223rem/223.json
@@ -2,6 +2,11 @@
   
   {
     "id": [ "223_casing" ],
+    "bg": [ "" ],
+    "fg": [ "5_casing" ]
+  }, 
+  {
+    "id": [ "223_casing_transparent" ],
     "bg": [ "223_b" ],
     "fg": [ "5_casing" ]
   }, 

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.22lr/22.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.22lr/22.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "22_casing", "22_casing_new" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "22_casing_transparent", "22_casing_new_transparent" ],
     "bg": [ "22_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.270win/270win.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.270win/270win.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "270win_casing" ],
+    "bg": [ "" ],
+    "fg": [ "5_casing" ]
+  },
+  {
+    "id": [ "270win_casing_transparent" ],
     "bg": [ "270win_b" ],
     "fg": [ "5_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.30-06/3006.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.30-06/3006.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "3006_casing" ],
+    "bg": [ "" ],
+    "fg": [ "5_casing" ]
+  },
+  {
+    "id": [ "3006_casing_transparent" ],
     "bg": [ "3006_b" ],
     "fg": [ "5_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.300aac/300blk.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.300aac/300blk.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "300blk_casing" ],
+    "bg": [ "" ],
+    "fg": [ "5_casing" ]
+  },
+  {
+    "id": [ "300blk_casing_transparent" ],
     "bg": [ "300blk_b" ],
     "fg": [ "5_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.300win/300win.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.300win/300win.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "300_casing" ],
+    "bg": [ "" ],
+    "fg": [ "5_casing" ]
+  },
+  {
+    "id": [ "300_casing_transparent" ],
     "bg": [ "300win_b" ],
     "fg": [ "5_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.308win/308.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.308win/308.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "308_casing" ],
+    "bg": [ "" ],
+    "fg": [ "5_casing" ]
+  },
+  {
+    "id": [ "308_casing_transparent" ],
     "bg": [ "308_b" ],
     "fg": [ "5_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.32acp/32_acp.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.32acp/32_acp.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "32_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "32_casing_transparent" ],
     "bg": [ "32_acp_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.357mag/357mag.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.357mag/357mag.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "357mag_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "357mag_casing_transparent" ],
     "bg": [ "357mag_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.357sig/357sig.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.357sig/357sig.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "357sig_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "357sig_casing_transparent" ],
     "bg": [ "357sig_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.38/38.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.38/38.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "38_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "38_casing_transparent" ],
     "bg": [ "38_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.380acp/380acp.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.380acp/380acp.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "380_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "380_casing_transparent" ],
     "bg": [ "380acp_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.40s&w/40sw.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.40s&w/40sw.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "40_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "40_casing_transparent" ],
     "bg": [ "40sw_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.44mag/44.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.44mag/44.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "44_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "44_casing_transparent" ],
     "bg": [ "44_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.45-70/4570.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.45-70/4570.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "4570_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "4570_casing_transparent" ],
     "bg": [ "4570_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.454/454.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.454/454.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "454_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "454_casing_transparent" ],
     "bg": [ "454_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.45acp/45acp.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.45acp/45acp.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "45_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "45_casing_transparent" ],
     "bg": [ "45acp_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.45colt/45colt.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.45colt/45colt.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "45colt_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "45colt_casing_transparent" ],
     "bg": [ "45colt_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.460rwl/460.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.460rwl/460.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "460_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "460_casing_transparent" ],
     "bg": [ "460_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.500s&w/500.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.500s&w/500.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "500_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "500_casing_transparent" ],
     "bg": [ "500_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.50bmg/50bmg.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.50bmg/50bmg.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "50_casing" ],
+    "bg": [ "" ],
+    "fg": [ "6_casing" ]
+  },
+  {
+    "id": [ "50_casing_transparent" ],
     "bg": [ "50bmg_b" ],
     "fg": [ "6_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.700nx/700nx.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/.700nx/700nx.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "700nx_casing" ],
+    "bg": [ "" ],
+    "fg": [ "6_casing" ]
+  },
+  {
+    "id": [ "700nx_casing_transparent" ],
     "bg": [ "700nx_b" ],
     "fg": [ "6_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/10mm/10mm.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/10mm/10mm.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "10mm_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "10mm_casing_transparent" ],
     "bg": [ "10mm_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/12.3ln/123ln.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/12.3ln/123ln.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "123ln_casing" ],
+    "bg": [ "" ],
+    "fg": [ "6_casing" ]
+  },
+  {
+    "id": [ "123ln_casing_transparent" ],
     "bg": [ "123ln_b" ],
     "fg": [ "6_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/4.6x30mm/46mm.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/4.6x30mm/46mm.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "46mm_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "46mm_casing_transparent" ],
     "bg": [ "46_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/40x46mm/40x46.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/40x46mm/40x46.json
@@ -2,32 +2,63 @@
 
   {
     "id": [ "40x46mm_hornets_nest_22lr_casing" ],
-    "bg": [ "40x46_b" ],
+    "bg": [ "" ],
     "fg": [ "40mm_red_casing" ]
   },
   {
     "id": [ "40x46mm_hornets_nest_410_casing" ],
-    "bg": [ "40x46_b" ],
+    "bg": [ "" ],
     "fg": [ "40mm_black_casing" ]
   },
 
   {
     "id": [ "40x46mm_m118_casing" ],
-    "bg": [ "40x46_b" ],
+    "bg": [ "" ],
     "fg": [ "40mm_118_casing" ]
   },
   {
     "id": [ "40x46mm_m195_casing" ],
-    "bg": [ "40x46_b" ],
+    "bg": [ "" ],
     "fg": [ "40mm_195_casing" ]
   },
   {
     "id": [ "40x46mm_m199_casing" ],
-    "bg": [ "40x46_b" ],
+    "bg": [ "" ],
     "fg": [ "40mm_199_casing" ]
   },
   {
     "id": [ "40x46mm_m212_casing" ],
+    "bg": [ "" ],
+    "fg": [ "40mm_212_casing" ]
+  },
+  {
+    "id": [ "40x46mm_hornets_nest_22lr_casing_transparent" ],
+    "bg": [ "40x46_b" ],
+    "fg": [ "40mm_red_casing" ]
+  },
+  {
+    "id": [ "40x46mm_hornets_nest_410_casing_transparent" ],
+    "bg": [ "40x46_b" ],
+    "fg": [ "40mm_black_casing" ]
+  },
+
+  {
+    "id": [ "40x46mm_m118_casing_transparent" ],
+    "bg": [ "40x46_b" ],
+    "fg": [ "40mm_118_casing" ]
+  },
+  {
+    "id": [ "40x46mm_m195_casing_transparent" ],
+    "bg": [ "40x46_b" ],
+    "fg": [ "40mm_195_casing" ]
+  },
+  {
+    "id": [ "40x46mm_m199_casing_transparent" ],
+    "bg": [ "40x46_b" ],
+    "fg": [ "40mm_199_casing" ]
+  },
+  {
+    "id": [ "40x46mm_m212_casing_transparent" ],
     "bg": [ "40x46_b" ],
     "fg": [ "40mm_212_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/40x53mm/40x53.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/40x53mm/40x53.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "40x53mm_m169_casing" ],
+    "bg": [ "" ],
+    "fg": [ "40mm_169_casing" ]
+  },
+  {
+    "id": [ "40x53mm_m169_casing_transparent" ],
     "bg": [ "40x53_b" ],
     "fg": [ "40mm_169_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/5.45x39mm/545x39.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/5.45x39mm/545x39.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "545_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4E_casing" ]
+  },
+  {
+    "id": [ "545_casing_transparent" ],
     "bg": [ "545x39_b" ],
     "fg": [ "4E_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/5.7x28mm/57x28.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/5.7x28mm/57x28.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "57mm_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "57mm_casing_transparent" ],
     "bg": [ "57x28_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/5x50mm/5x50.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/5x50mm/5x50.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "5x50_hull" ],
+    "bg": [ "" ],
+    "fg": [ "6R_casing" ]
+  },
+  {
+    "id": [ "5x50_hull_transparent" ],
     "bg": [ "5x50_b" ],
     "fg": [ "6R_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/7.62x25mm/762x25.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/7.62x25mm/762x25.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "762_25_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4E_casing" ]
+  },
+  {
+    "id": [ "762_25_casing_transparent" ],
     "bg": [ "762x25_b" ],
     "fg": [ "4E_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/7.62x39mm/762x39.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/7.62x39mm/762x39.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "762_casing" ],
+    "bg": [ "" ],
+    "fg": [ "5E_casing" ]
+  },
+  {
+    "id": [ "762_casing_transparent" ],
     "bg": [ "762x39_b" ],
     "fg": [ "5E_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/7.62x51mm/762x51.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/7.62x51mm/762x51.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "762_51_casing" ],
+    "bg": [ "" ],
+    "fg": [ "5_casing" ]
+  },
+  {
+    "id": [ "762_51_casing_transparent" ],
     "bg": [ "762x51_b" ],
     "fg": [ "5_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/7.62x54mm/762x54.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/7.62x54mm/762x54.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "762R_casing" ],
+    "bg": [ "" ],
+    "fg": [ "5E_casing" ]
+  },
+  {
+    "id": [ "762R_casing_transparent" ],
     "bg": [ "762x54_b" ],
     "fg": [ "5E_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/9x18mm/9x18mm.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/9x18mm/9x18mm.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "9x18mm_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4E_casing" ]
+  },
+  {
+    "id": [ "9x18mm_casing_transparent" ],
     "bg": [ "9x18mm_b" ],
     "fg": [ "4E_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/9x19mm/9x19mm.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/9x19mm/9x19mm.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "9mm_casing" ],
+    "bg": [ "" ],
+    "fg": [ "4_casing" ]
+  },
+  {
+    "id": [ "9mm_casing_transparent" ],
     "bg": [ "9x19mm_b" ],
     "fg": [ "4_casing" ]
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/shot.410/410shot.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/shot.410/410shot.json
@@ -2,10 +2,14 @@
 
   {
     "id": [ "410shot_hull" ],
+    "bg": [ "" ],
+    "fg": [ "shot_hull" ]
+  },
+  {
+    "id": [ "410shot_hull_transparent" ],
     "bg": [ "410shot_b" ],
     "fg": [ "shot_hull" ]
   },
-
 
   {
     "id": [ "410shot_000" ],

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/shot12ga/12ga.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/items/ammunition/shot12ga/12ga.json
@@ -2,6 +2,11 @@
 
   {
     "id": [ "shot_hull" ],
+    "bg": [ "" ],
+    "fg": [ "shot_hull" ]
+  },
+  {
+    "id": [ "shot_hull_transparent" ],
     "bg": [ "12ga_b" ],
     "fg": [ "shot_hull" ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->

#### Content of the change
By default Ultica will show casings without calibers but it can be changed in `debug\occlusion` settings or even binded on the key.
<!-- Explain what does this pull request contain. -->

#### Testing
![image](https://github.com/I-am-Erk/CDDA-Tilesets/assets/6676374/3a7a3049-d896-499b-8d21-302328dea59c)
![image](https://github.com/I-am-Erk/CDDA-Tilesets/assets/6676374/f3501d7e-79b3-46e2-95ef-742449e517ea)

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
