### PR TITLE
Add Nix support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+if ! has nix_direnv_version || ! nix_direnv_version 2.1.1; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.1.1/direnvrc" "sha256-b6qJ4r34rbE23yWjMqbmu3ia2z4b2wIlZUksBke/ol0="
+fi
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 desktop.ini
 __pycache__
-.direnv
 # generated on build
 gfx/*/tile_config.json
 
@@ -14,4 +13,10 @@ book
 # Krita
 *.png-autosave.kra
 *.kra
+*.kra~
 *.png~
+
+# Direnv & Nix
+.direnv
+result
+.local

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -2,6 +2,7 @@
 
 - [Installation & Building](installation.md)
   - [Windows guide](installation_windows.md)
+  - [Nix](installation_nix.md)
 - [Style guidelines](style/summary.md)
     - [General](style/general.md)
     - [Items](style/items.md)

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -27,10 +27,9 @@ You will need:
 - Python 3
 - [Libvips](https://libvips.github.io/libvips/install.html)
 - pyvips (install it via python pip: `pip install pyvips`) 
-- [compose.py](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/tools/gfx_tools/compose.py) script from the main [Cataclysm-DDA](https://github.com/CleverRaven/Cataclysm-DDA) repository
 
 Once you have everything ready, you can build the tileset:
 ```sh
 # Assuming that you are in the root of the tileset repository
-$ python3 <path-to-compose-py-script>/compose.py gfx/UltimateCataclysm
+$ python3 tools/compose.py gfx/UltimateCataclysm
 ```

--- a/doc/installation_nix.md
+++ b/doc/installation_nix.md
@@ -1,0 +1,31 @@
+# Nix Installation
+
+Documentation of developing tileset with [Nix](https://nixos.org/). 
+
+## Build
+
+As this repository uses flakes, it's possible to build any of the tileset (not only UlitCa) using `nix build .#{name}` command. For example:
+
+```sh
+# This will build UltiCa
+nix build .#UltimateCataclysm
+
+# But this will build Mushroom Dream
+nix build .#Mushroom-Dream
+```
+
+And the result will be in *result* directory, ready to put into the game. If you want to link the result to the different directory, use `--out-link {path}` argument.
+
+## Devshell
+
+Tileset flake also provide a simple devshell with python and vips to run tools such as `compose.py` or `generate_preview.py`.
+
+```sh
+# Enter the devshell
+nix develop .
+
+# This now works
+python3 tools/compose.py --use-all gfx/UltimateCataclysm out
+```
+
+Or if you have [direnv](https://direnv.net/) enabled, it will automatically enter the devshell upon opening the repository.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1692463654,
+        "narHash": "sha256-F8hZmsQINI+S6UROM4jyxAMbQLtzE44pI8Nk6NtMdao=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ca3c9ac9f4cdd4bea19f592b32bb59b74ab7d783",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  inputs = {
+    nixpkgs = {
+      url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    };
+    utils = {
+      url = "github:numtide/flake-utils";
+    };
+  };
+
+  outputs = { self, nixpkgs, utils }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system;  };
+
+        requires = with pkgs; [
+          (python311.withPackages(ps: [ ps.pyvips ]))
+          vips
+        ];
+      in
+      rec {
+        # `nix build`
+        packages = (pkgs.lib.mapAttrs' (name: _: 
+          pkgs.lib.nameValuePair name (pkgs.stdenv.mkDerivation {
+            inherit name;
+            version = "master";
+            src = ./gfx/${name};
+            buildInputs = requires;
+
+            dontCheck = true;
+            dontPatch = true;
+            dontConfigure = true;
+
+            buildPhase = ''
+              python3 ${./tools/compose.py} --use-all --feedback CONCISE . compiled
+            '';
+            installPhase = ''
+              mkdir -p $out
+              cp compiled/* $out
+              for file in [ "fallback.png" "layering.json" "tileset.txt" ]; do
+                [ -f "$file" ] && cp "$file" $out ||:
+              done
+            '';
+          })
+        ) (builtins.readDir ./gfx));
+
+        # `nix develop`
+        devShell = pkgs.mkShell rec {
+          nativeBuildInputs = requires;
+        };
+      });
+}


### PR DESCRIPTION
#### Summary
Add support for [nix](https://nixos.org/) in the repository in form of a flake.

#### Content of the change
Add `flake.nix` with ability to build tilesets and enter a devshell.

#### Testing
```sh
nix build .#UltimateCataclysm
cat result/tileset.txt
````
Produces a working tileset.

#### Additional information
It's what I use to comfortably work with tilesets, figured it wouldn't hurt to have this in the repo if there are other madlads who use nix. It's also possible to run reproducible nix builds in the CI now.

Ah. I should probably also add a book building package. Someday..