### PR TITLE
[ChibiUltica] Add symlink to filler folder

### DIFF
--- a/gfx/Chibi_Ultica/pngs_filler_32x32
+++ b/gfx/Chibi_Ultica/pngs_filler_32x32
@@ -1,0 +1,1 @@
+../UltimateCataclysm/pngs_filler_32x32


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Add symlink to filler folder

#### Content of the change

Weirdly enough there is an entry for a filler.png tilesheet but not symlink to the filler folder in Ultica

#### Testing

Filler leech sprites from Ultica are now used in Chibi
![image](https://github.com/I-am-Erk/CDDA-Tilesets/assets/41293484/6ab5bd92-b3f6-4e21-9845-2ba5b94611b2)

#### Additional information
