### PR TITLE
[MSX] Give the skylight frame blue tint open air background

### DIFF
--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_window_empty/t_window_empty.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_window_empty/t_window_empty.json
@@ -7,6 +7,7 @@
   },
   {
     "id": "t_skylight_frame",
-    "fg": "t_window_empty"
+    "fg": "t_window_empty",
+    "bg": "t_open_air"
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
I forgot to give skylight frame the t_open_air sprite as its bg. This fixes it.

#### Content of the change

- t_open_air bg for skylight frame
<!-- Explain what does this pull request contain. -->

#### Testing

Before
![Screenshot_2023-09-14_17-30-29_1](https://github.com/I-am-Erk/CDDA-Tilesets/assets/78019001/659b5bf4-69e0-4ae7-b371-315bbbcb6f91)

After
![Screenshot_2023-09-14_17-32-18_1](https://github.com/I-am-Erk/CDDA-Tilesets/assets/78019001/80083780-f40f-4d28-a4c7-d471faff6548)


#### Additional information
