### PR TITLE
make use-all the default behavior when running compose.py

### DIFF
--- a/tools/compose.py
+++ b/tools/compose.py
@@ -6,7 +6,7 @@ a tile_config.json and tilesheet .png file(s) ready for use in CDDA.
 Examples:
 
     %(prog)s ../CDDA-Tilesets/gfx/Retrodays/
-    %(prog)s --use-all ../CDDA-Tilesets/gfx/UltimateCataclysm/
+    %(prog)s --no-use-all ../CDDA-Tilesets/gfx/UltimateCataclysm/
 
 By default, output is written back to the source directory. Pass an output
 directory as the last argument to place output files there instead. The
@@ -225,7 +225,7 @@ class Tileset:
         self,
         source_dir: Path,
         output_dir: Path,
-        use_all: bool = False,
+        no_use_all: bool = False,
         obsolete_fillers: bool = False,
         palette_copies: bool = False,
         palette: bool = False,
@@ -234,7 +234,7 @@ class Tileset:
     ) -> None:
         self.source_dir = source_dir
         self.output_dir = output_dir
-        self.use_all = use_all
+        self.no_use_all = no_use_all
         self.obsolete_fillers = obsolete_fillers
         self.palette_copies = palette_copies
         self.palette = palette
@@ -370,7 +370,7 @@ class Tileset:
             unused: list,
             fillers: bool,
         ) -> None:
-            # the list must be empty without use_all
+            # the list must be on no_use_all
             mode = unused if no_tqdm or run_silent else tqdm(unused)
             for unused_png in mode:
                 if unused_png in self.processed_ids:
@@ -494,21 +494,23 @@ class Tileset:
         '''
         Either warn about unused sprites or return the list
         '''
-        if self.use_all:
-            return self.unreferenced_pngnames[sheet_type]
 
-        for pngname in self.unreferenced_pngnames[sheet_type]:
-            if pngname in self.processed_ids:
-                log.error(
-                    '%(1)s.png not used when %(1)s ID '
-                    'is mentioned in a tile entry',
-                    {'1': pngname})
+        if self.no_use_all:
+            for pngname in self.unreferenced_pngnames[sheet_type]:
+                if pngname in self.processed_ids:
+                    log.error(
+                        '%(1)s.png not used when %(1)s ID '
+                        'is mentioned in a tile entry',
+                        {'1': pngname})
 
-            else:
-                log.warning(
-                    'sprite filename %s was not used in any %s %s entries',
-                    pngname, sheet_type, self.output_conf_file)
-        return []
+                else:
+                    log.warning(
+                        'sprite filename %s was not used in any %s %s entries',
+                        pngname, sheet_type, self.output_conf_file)
+            return []
+
+        return self.unreferenced_pngnames[sheet_type]
+
 
 
 class Tilesheet:
@@ -923,7 +925,7 @@ def main() -> Union[int, ComposingException]:
         'output_dir', nargs='?', type=Path,
         help='Output directory path')
     arg_parser.add_argument(
-        '--use-all', dest='use_all', action='store_true',
+        '--no-use-all', dest='no_use_all', action='store_true',
         help='Add unused images with id being their basename')
     arg_parser.add_argument(
         '--obsolete-fillers', dest='obsolete_fillers', action='store_true',
@@ -991,7 +993,7 @@ def main() -> Union[int, ComposingException]:
                 args_dict.get('output_dir') or
                 args_dict.get('source_dir')
             ),
-            use_all=args_dict.get('use_all', False),
+            no_use_all=args_dict.get('no_use_all', False),
             obsolete_fillers=args_dict.get('obsolete_fillers', False),
             palette_copies=args_dict.get('palette_copies', False),
             palette=args_dict.get('palette', False),

--- a/tools/compose.py
+++ b/tools/compose.py
@@ -928,6 +928,9 @@ def main() -> Union[int, ComposingException]:
         '--no-use-all', dest='no_use_all', action='store_true',
         help='Add unused images with id being their basename')
     arg_parser.add_argument(
+        '--use-all', dest='use_all', action='store_true',
+        help='Legacy argument for script compatability, enabled by default')
+    arg_parser.add_argument(
         '--obsolete-fillers', dest='obsolete_fillers', action='store_true',
         help='Warn about obsoleted fillers')
     arg_parser.add_argument(


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->

make use-all the default behavior when running compose.py

#### Content of the change

<!-- Explain what does this pull request contain. -->

As use-all is the preferred outcome when running compose.py, invert the logic to instead present a `--no-use-all` argument instead, in the event that the user does not want the behavior.

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

1/ Run script with default arguments, no warning generated and all tiles included.
2/ Run script with `--no-use-all`, get `WARNING handle_unreferenced_sprites` messages

#### Additional information
