### PR TITLE
[Tools] Added ability to install specific versions of Python and LibVIPS

### DIFF
--- a/tools/updtset.cmd
+++ b/tools/updtset.cmd
@@ -179,6 +179,9 @@ if errorlevel 1 (
         if errorlevel 1 (
             echo ERROR: No Python found!
             echo If you are sure that Python is installed - please check 'path' environment variable.
+            echo Script will try to install Python 3.12, try to run this script again after this.
+            echo.
+            winget install Python.Python.3.12 --disable-interactivity
             goto stop
         ) else (
             set APP=python
@@ -209,6 +212,12 @@ if errorlevel 1 (
     echo ERROR! No 'libvips' library found. Please refer installation manual:
     echo https://libvips.github.io/libvips/install.html
     echo If you are sure that library was installed - please check library version and 'path' environment variable.
+    echo Script will try to download libvips 8.15 into your home directory, try to run this script again after this.
+    echo.
+    curl https://github.com/libvips/build-win64-mxe/releases/download/v8.15.0/vips-dev-w64-web-8.15.0.zip -L -o %HOMEDRIVE%%HOMEPATH%\vips-dev-w64-web-8.15.0.zip
+
+    call :UnZipFile "%HOMEDRIVE%%HOMEPATH%\vips" "%HOMEDRIVE%%HOMEPATH%\vips-dev-w64-web-8.15.0.zip"
+    call set_vips_path.cmd %HOMEDRIVE%%HOMEPATH%\vips\vips-dev-8.15\
     goto stop
 ) else (
     if /i [!verbose!] EQU [YES] (echo    - Library 'libvips' found.)
@@ -263,3 +272,18 @@ echo.
 echo (press any key to close this window^)
 pause >nul
 exit /b 1
+
+:UnZipFile <ExtractTo> <newzipfile>
+set vbs="%temp%\_.vbs"
+if exist %vbs% del /f /q %vbs%
+>%vbs%  echo Set fso = CreateObject("Scripting.FileSystemObject")
+>>%vbs% echo If NOT fso.FolderExists(%1) Then
+>>%vbs% echo fso.CreateFolder(%1)
+>>%vbs% echo End If
+>>%vbs% echo set objShell = CreateObject("Shell.Application")
+>>%vbs% echo set FilesInZip=objShell.NameSpace(%2).items
+>>%vbs% echo objShell.NameSpace(%1).CopyHere(FilesInZip)
+>>%vbs% echo Set fso = Nothing
+>>%vbs% echo Set objShell = Nothing
+cscript //nologo %vbs%
+if exist %vbs% del /f /q %vbs%

--- a/tools/updtset.cmd
+++ b/tools/updtset.cmd
@@ -224,6 +224,9 @@ if errorlevel 1 (
 )
 if /i [!verbose!] EQU [YES] (echo.)
 
+set PATH=%LIBVIPS_PATH%;%PATH%
+set PATH=%LIBVIPS_PATH%\bin;%PATH%
+
 echo 3. Lets compose %tileset_name%. Be patient it takes some time.
 pushd "!path_to_compose!" || goto :deleted
 rd /q /s . 2> NUL


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->
the main wrapper 'updtset.cmd' changed to install specific version of Python and lib-vips if they werent in the system.

#### Content of the change
First time tileset repository cloned allow you to run updtset.cmd and it will check for Python, pyvips module and libvips.
If any of this part absent in system script will try to download and install them
<!-- Explain what does this pull request contain. -->

#### Testing
![image](https://github.com/I-am-Erk/CDDA-Tilesets/assets/6676374/1f925b9c-8d37-4e9d-80db-3ea55c9a6629)

Known bugs:
on windows 10/11 user may have to manually disable app execution alias in system setting. This happens if python was installed via script.
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
