### PR TITLE
[Ultica] Fixes and tweaks to the overmap

### DIFF
--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cabin/cabin.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cabin/cabin.json
@@ -17,7 +17,7 @@
     "cabin_strange_b",
     "riverside_dwelling"
   ],
-  "fg": [ "cabin_faceN", "cabin_faceE", "cabin_faceS", "cabin_faceW" ],
+  "fg": [ "cabin_faceN", "cabin_faceW", "cabin_faceS", "cabin_faceE" ],
   "bg": "field",
   "rotates": true
 },{
@@ -35,7 +35,7 @@
     "cabin_lake_roof",
     "lake_cabin_boathouse_roof"
   ],
-  "fg": [ "cabin_faceN", "cabin_faceE", "cabin_faceS", "cabin_faceW" ],
+  "fg": [ "cabin_faceN", "cabin_faceW", "cabin_faceS", "cabin_faceE" ],
   "bg": "open_air",
   "rotates": true
 }]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cs_private_park/cs_private_park.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cs_private_park/cs_private_park.json
@@ -3,9 +3,9 @@
 	"id": "cs_private_park_roof",
 	"fg": [
 	  "cs_private_park_rot_N",
-	  "cs_private_park_rot_E",
+	  "cs_private_park_rot_W",
 	  "cs_private_park_rot_S",
-	  "cs_private_park_rot_W"
+	  "cs_private_park_rot_E"
 	],
 	"bg": "open_air",
 	"rotates": true
@@ -14,9 +14,9 @@
 	"id": "cs_private_park",
 	"fg": [
 	  "cs_private_park_rot_N",
-	  "cs_private_park_rot_E",
+	  "cs_private_park_rot_W",
 	  "cs_private_park_rot_S",
-	  "cs_private_park_rot_W"
+	  "cs_private_park_rot_E"
 	],
 	"bg": "field",
 	"rotates": true

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cs_public_art_piece/cs_public_art_piece.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cs_public_art_piece/cs_public_art_piece.json
@@ -3,9 +3,9 @@
 	"id": "cs_public_art_piece",
 	"fg": [
 	  "cs_public_art_piece_rot_N",
-	  "cs_public_art_piece_rot_E",
+	  "cs_public_art_piece_rot_W",
 	  "cs_public_art_piece_rot_S",
-	  "cs_public_art_piece_rot_W"
+	  "cs_public_art_piece_rot_E"
 	],
 	"bg": "field",
 	"rotates": true

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cs_public_space/cs_public_space.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cs_public_space/cs_public_space.json
@@ -3,9 +3,9 @@
 	"id": "cs_public_space",
 	"fg": [
 	  "cs_public_space_rot_N",
-	  "cs_public_space_rot_E",
+	  "cs_public_space_rot_W",
 	  "cs_public_space_rot_S",
-	  "cs_public_space_rot_W"
+	  "cs_public_space_rot_E"
 	],
 	"bg": "field",
 	"rotates": true

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/dirt_road/dirt_road.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/dirt_road/dirt_road.json
@@ -1,19 +1,31 @@
 [
-{
-	"id": [ "dirt_road", "dirt_road_forest" ],
-	"fg": [ "dirt_road_edge_ns", "dirt_road_edge_ew" ],
-	"rotates": true
-},{
-	"id": [ "dirt_road_3way", "dirt_road_3way_forest" ],
-	"fg": [ "dirt_road_t_connection_n", "dirt_road_t_connection_e", "dirt_road_t_connection_s", "dirt_road_t_connection_w" ],
-	"rotates": true
-},{
-	"id": [ "dirt_road_turn", "dirt_road_turn_forest" ],
-	"fg": [ "dirt_road_corner_ne", "dirt_road_corner_se", "dirt_road_corner_sw", "dirt_road_corner_nw" ],
-	"rotates": true
-},{
-	"id": [ "dirt_road_turn1", "dirt_road_turn1_forest" ],
-	"fg": [ "dirt_road_corner_nw", "dirt_road_corner_ne", "dirt_road_corner_se", "dirt_road_corner_sw" ],
-	"rotates": true
-}
+  {
+  	"id": [ "dirt_road", "dirt_road_forest" ],
+  	"fg": [ "dirt_road_edge_ns", "dirt_road_edge_ew" ],
+  	"rotates": true
+  },
+  {
+    "id": [ "dirt_road_turnback", "trailhead" ],
+    "fg": [ "dirt_road_end_piece_s", "dirt_road_end_piece_e", "dirt_road_end_piece_n", "dirt_road_end_piece_w" ],
+    "rotates": true
+  },
+  {
+  	"id": [ "dirt_road_3way", "dirt_road_3way_forest" ],
+  	"fg": [ "dirt_road_t_connection_n", "dirt_road_t_connection_w", "dirt_road_t_connection_s", "dirt_road_t_connection_e" ],
+  	"rotates": true
+  },
+  {
+  	"id": [ "dirt_road_turn", "dirt_road_turn_forest" ],
+  	"fg": [ "dirt_road_corner_ne", "dirt_road_corner_nw", "dirt_road_corner_sw", "dirt_road_corner_se" ],
+  	"rotates": true
+  },
+  {
+  	"id": [ "dirt_road_turn1", "dirt_road_turn1_forest" ],
+  	"fg": [ "dirt_road_corner_nw", "dirt_road_corner_ne", "dirt_road_corner_se", "dirt_road_corner_sw" ],
+  	"rotates": true
+  },
+  {
+    "id": "dirt_road_4way",
+    "fg": "dirt_road_center"
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/evac_shelters/evac_shelters.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/evac_shelters/evac_shelters.json
@@ -1,28 +1,35 @@
 [
   {
     "id": [
-	  "shelter",
-	  "shelter_1",
-	  "shelter_2",
-	  "shelter_vandal",
-	  "shelter_1_vandal",
-	  "shelter_2_vandal"
-	],
-    "fg": [ "otr_evac_shelter_1_faceN", "otr_evac_shelter_1_faceE", "otr_evac_shelter_1_faceS", "otr_evac_shelter_1_faceW" ],
+	    "shelter",
+	    "shelter_1",
+	    "shelter_2",
+	    "shelter_vandal",
+	    "shelter_1_vandal",
+	    "shelter_2_vandal",
+      "shelter_1b"
+	  ],
+    "fg": [ "otr_evac_shelter_1_faceN", "otr_evac_shelter_1_faceW", "otr_evac_shelter_1_faceS", "otr_evac_shelter_1_faceE" ],
     "bg": "field",
     "rotates": true
-  },{
+  },
+  {
 	  "id": [
-	     "shelter_roof",
+	   "shelter_roof",
 		 "shelter_roof_1",
-		 "shelter_roof_2"
+		 "shelter_roof_2",
+     "shelter_roof_1b"
 		],
-	  "fg": [ "otr_evac_shelter_1_faceN", "otr_evac_shelter_1_faceE", "otr_evac_shelter_1_faceS", "otr_evac_shelter_1_faceW" ],
+	  "fg": [ "otr_evac_shelter_1_faceN", "otr_evac_shelter_1_faceW", "otr_evac_shelter_1_faceS", "otr_evac_shelter_1_faceE" ],
 	  "bg": "open_air",
 	  "rotates": true
-  },{
-	  "id": "shelter_under",
-	  "fg": [ "otr_evac_shelter_1_faceN", "otr_evac_shelter_1_faceE", "otr_evac_shelter_1_faceS", "otr_evac_shelter_1_faceW" ],
+  },
+  {
+	  "id": [
+      "shelter_under",
+      "shelter_under_1b"
+    ],
+	  "fg": [ "otr_evac_shelter_1_faceN", "otr_evac_shelter_1_faceW", "otr_evac_shelter_1_faceS", "otr_evac_shelter_1_faceE" ],
 	  "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/gas/omt_gasstations.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/gas/omt_gasstations.json
@@ -6,7 +6,7 @@
       "garage_gas_1", "garage_gas_2", "garage_gas_3",
       "garage_gas_roof_1", "garage_gas_roof_2", "garage_gas_roof_3"
     ],
-    "fg": [ "gas_small_faceN", "gas_small_faceE", "gas_small_faceS", "gas_small_faceW" ], 
+    "fg": [ "gas_small_faceN", "gas_small_faceW", "gas_small_faceS", "gas_small_faceE" ], 
     "bg": "field"
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/missile_silo/missile_silo.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/missile_silo/missile_silo.json
@@ -1,19 +1,19 @@
 [
   {
 	"id": "silo",
-	"fg": [ "silo_rot_N", "silo_rot_E", "silo_rot_S", "silo_rot_W" ],
+	"fg": [ "silo_rot_N", "silo_rot_W", "silo_rot_S", "silo_rot_E" ],
 	"bg": "field",
 	"rotates": true
   },
   {
 	"id": "silo_1",
-	"fg": [ "silo_rot_N", "silo_rot_E", "silo_rot_S", "silo_rot_W" ],
+	"fg": [ "silo_rot_N", "silo_rot_W", "silo_rot_S", "silo_rot_E" ],
 	"bg": "t_soil_center",
 	"rotates": true
   },
   {
   "id": [ "silo_2", "silo_3", "silo_4", "silo_finale" ],
-	"fg": [ "silo_rot_N", "silo_rot_E", "silo_rot_S", "silo_rot_W" ],
+	"fg": [ "silo_rot_N", "silo_rot_W", "silo_rot_S", "silo_rot_E" ],
 	"bg": "t_rock_center",
 	"rotates": true
   }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/pasture/pasture.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/pasture/pasture.json
@@ -1,53 +1,124 @@
-[{
-	"id": "2farm_4",
-	"fg": [ "pasture_end_n", "pasture_end_e", "pasture_end_s", "pasture_end_w" ],
-	"rotates": true
-},{
-	"id": "2farm_8",
-	"fg": [ "pasture_end_s", "pasture_end_w", "pasture_end_n", "pasture_end_e" ],
-	"rotates": true
-},{
-	"id": "dairy_farm_NW",
-	"fg": [ "pasture_end_w", "pasture_end_n", "pasture_end_e", "pasture_end_s" ],
-	"rotates": true
-},{
-	"id": "dairy_farm_NE",
-	"fg": [ "pasture_end_e", "pasture_end_s", "pasture_end_w", "pasture_end_n" ],
-	"rotates": true
-},{
-	"id": "ranch_camp_1",
-	"fg": [ "pasture_corner_nw", "pasture_corner_ne", "pasture_corner_se", "pasture_corner_sw" ],
-	"rotates": true
-},{
-	"id": [ "ranch_camp_2", "ranch_camp_3", "ranch_camp_4", "ranch_camp_5", "ranch_camp_6", "ranch_camp_7", "ranch_camp_8" ],
-	"fg": [ "pasture_not_n", "pasture_not_e", "pasture_not_s", "pasture_not_w" ],
-	"rotates": true
-},{
-	"id": "ranch_camp_9",
-	"fg": [ "pasture_corner_ne", "pasture_corner_se", "pasture_corner_sw", "pasture_corner_nw" ],
-	"rotates": true
-},{
-	"id": [ "ranch_camp_10", "ranch_camp_19", "ranch_camp_28", "ranch_camp_37", "ranch_camp_46", "ranch_camp_55", "ranch_camp_64" ],
-	"fg": [ "pasture_not_w", "pasture_not_n", "pasture_not_e", "pasture_not_s" ],
-	"rotates": true
-},{
-	"id": [ "ranch_camp_11", "ranch_camp_12", "ranch_camp_13", "ranch_camp_14", "ranch_camp_15", "ranch_camp_16", "ranch_camp_20", "ranch_camp_21", "ranch_camp_22", "ranch_camp_23", "ranch_camp_24", "ranch_camp_25", "ranch_camp_26", "ranch_camp_29", "ranch_camp_30", "ranch_camp_31", "ranch_camp_32", "ranch_camp_33", "ranch_camp_34", "ranch_camp_35", "ranch_camp_38", "ranch_camp_39", "ranch_camp_40", "ranch_camp_41", "ranch_camp_42", "ranch_camp_43", "ranch_camp_44", "ranch_camp_47", "ranch_camp_48", "ranch_camp_49", "ranch_camp_50", "ranch_camp_51", "ranch_camp_52", "ranch_camp_53", "ranch_camp_56", "ranch_camp_58", "ranch_camp_59", "ranch_camp_60", "ranch_camp_61", "ranch_camp_62", "ranch_camp_65", "ranch_camp_69", "ranch_camp_70", "ranch_camp_71" ],
-	"fg": "pasture_center",
-	"rotates": true
-},{
-	"id": [ "ranch_camp_18", "ranch_camp_27", "ranch_camp_36", "ranch_camp_45", "ranch_camp_54", "ranch_camp_63", "ranch_camp_72" ],
-	"fg": [ "pasture_not_e", "pasture_not_s", "pasture_not_w", "pasture_not_n" ],
-	"rotates": true
-},{
-	"id": [ "ranch_camp_73", "ranch_camp_78" ],
-	"fg": [ "pasture_corner_sw", "pasture_corner_nw", "pasture_corner_ne", "pasture_corner_se" ],
-	"rotates": true
-},{
-	"id": [ "ranch_camp_74", "ranch_camp_79", "ranch_camp_80" ],
-	"fg": [ "pasture_not_s", "pasture_not_w", "pasture_not_n", "pasture_not_e" ],
-	"rotates": true
-},{
-	"id": [ "ranch_camp_75", "ranch_camp_81" ],
-	"fg": [ "pasture_corner_se", "pasture_corner_sw", "pasture_corner_nw", "pasture_corner_ne" ],
-	"rotates": true
-}]
+[
+  {
+	  "id": "2farm_4",
+	  "fg": [ "pasture_end_n", "pasture_end_e", "pasture_end_s", "pasture_end_w" ],
+  	"rotates": true
+  },
+  {
+	  "id": "2farm_8",
+	  "fg": [ "pasture_end_s", "pasture_end_w", "pasture_end_n", "pasture_end_e" ],
+  	"rotates": true
+  },
+  {
+	  "id": "dairy_farm_NW",
+	  "fg": [ "pasture_end_w", "pasture_end_s", "pasture_end_e", "pasture_end_n" ],
+	  "rotates": true
+  },
+  {
+	  "id": "dairy_farm_NE",
+	  "fg": [ "pasture_end_e", "pasture_end_n", "pasture_end_w", "pasture_end_s" ],
+	  "rotates": true
+  },
+  {
+	  "id": "ranch_camp_1",
+	  "fg": [ "pasture_corner_nw", "pasture_corner_ne", "pasture_corner_se", "pasture_corner_sw" ],
+	  "rotates": true
+  },
+  {
+	  "id": [ "ranch_camp_2", "ranch_camp_3", "ranch_camp_4", "ranch_camp_5", "ranch_camp_6", "ranch_camp_7", "ranch_camp_8" ],
+	  "fg": [ "pasture_not_n", "pasture_not_e", "pasture_not_s", "pasture_not_w" ],
+	  "rotates": true
+  },
+  {
+	  "id": "ranch_camp_9",
+	  "fg": [ "pasture_corner_ne", "pasture_corner_se", "pasture_corner_sw", "pasture_corner_nw" ],
+	  "rotates": true
+  },
+  {
+  	"id": [ "ranch_camp_10", "ranch_camp_19", "ranch_camp_28", "ranch_camp_37", "ranch_camp_46", "ranch_camp_55", "ranch_camp_64" ],
+  	"fg": [ "pasture_not_w", "pasture_not_n", "pasture_not_e", "pasture_not_s" ],
+	  "rotates": true
+  },
+  {
+	  "id": [ "ranch_camp_11", "ranch_camp_12", "ranch_camp_13", "ranch_camp_14", "ranch_camp_15", "ranch_camp_16", "ranch_camp_20", "ranch_camp_21", "ranch_camp_22", "ranch_camp_23", "ranch_camp_24", "ranch_camp_25", "ranch_camp_26", "ranch_camp_29", "ranch_camp_30", "ranch_camp_31", "ranch_camp_32", "ranch_camp_33", "ranch_camp_34", "ranch_camp_35", "ranch_camp_38", "ranch_camp_39", "ranch_camp_40", "ranch_camp_41", "ranch_camp_42", "ranch_camp_43", "ranch_camp_44", "ranch_camp_47", "ranch_camp_48", "ranch_camp_49", "ranch_camp_50", "ranch_camp_51", "ranch_camp_52", "ranch_camp_53", "ranch_camp_56", "ranch_camp_58", "ranch_camp_59", "ranch_camp_60", "ranch_camp_61", "ranch_camp_62", "ranch_camp_65", "ranch_camp_69", "ranch_camp_70", "ranch_camp_71" ],
+  	"fg": "pasture_center",
+  	"rotates": true
+  },
+  {
+  	"id": [ "ranch_camp_18", "ranch_camp_27", "ranch_camp_36", "ranch_camp_45", "ranch_camp_54", "ranch_camp_63", "ranch_camp_72" ],
+  	"fg": [ "pasture_not_e", "pasture_not_s", "pasture_not_w", "pasture_not_n" ],
+  	"rotates": true
+  },
+  {
+	  "id": [ "ranch_camp_73", "ranch_camp_78" ],
+	  "fg": [ "pasture_corner_sw", "pasture_corner_nw", "pasture_corner_ne", "pasture_corner_se" ],
+  	"rotates": true
+  },
+  {
+  	"id": [ "ranch_camp_74", "ranch_camp_79", "ranch_camp_80" ],
+  	"fg": [ "pasture_not_s", "pasture_not_w", "pasture_not_n", "pasture_not_e" ],
+  	"rotates": true
+  },
+  {
+  	"id": [ "ranch_camp_75", "ranch_camp_81" ],
+  	"fg": [ "pasture_corner_se", "pasture_corner_sw", "pasture_corner_nw", "pasture_corner_ne" ],
+  	"rotates": true
+  },
+  {
+    "id": [ "paddock", "paddock_R_gap" ],
+    "fg": "pasture_unconnected"
+  },
+  {
+    "id": [ "paddock_trailhead_2", "paddock_trailhead_8" ],
+    "fg": "pasture_connection_ew"
+  },
+  {
+    "id": "paddock_DR",
+    "fg": "pasture_end_n"
+  },
+  {
+    "id": [ "paddock_trailhead_5", "paddock_R_butt" ],
+    "fg": "pasture_end_w"
+  },
+  {
+    "id": [ "paddock_L_butt", "paddock_C" ],
+    "fg": "pasture_end_e"
+  },
+  {
+    "id": "paddock_trailhead_3",
+    "fg": "pasture_corner_se"
+  },
+  {
+    "id": [ "splitrail_fence_DL", "paddock_trailhead_7" ],
+    "fg": "pasture_corner_nw"
+  },
+  {
+    "id": "paddock_trailhead_1",
+    "fg": "pasture_corner_ne"
+  },
+  {
+    "id": "splitrail_fence_UL",
+    "fg": [ "pasture_corner_se", "pasture_corner_ne" ],
+    "rotates": true
+  },
+  {
+    "id": "paddock_trailhead_4",
+    "fg": "pasture_not_n"
+  },
+  {
+    "id": "splitrail_fence_butt",
+    "fg": "pasture_not_e"
+  },
+  {
+    "id": "paddock_trailhead_6",
+    "fg": "pasture_not_s"
+  },
+  {
+    "id": "splitrail_fence_gap",
+    "fg": "pasture_not_w"
+  },
+  {
+    "id": [ "splitrail_fence_UR", "paddock_trailhead_9" ],
+    "fg": "pasture_corner_sw"
+  }
+]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/pools/pools.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/pools/pools.json
@@ -7,12 +7,12 @@
 	  "pool_3",
 	  "pool_4"
 	],
-	"fg": [ "pool_2_faceN", "pool_2_faceE", "pool_2_faceS", "pool_2_faceW" ],
+	"fg": [ "pool_2_faceN", "pool_2_faceW", "pool_2_faceS", "pool_2_faceE" ],
 	"bg": "field",
 	"rotates": true
 },{
 	"id": [ "pool_5", "pool_6" ],
-	"fg": [ "pool_5_faceN", "pool_5_faceE", "pool_5_faceS", "pool_5_faceW" ],
+	"fg": [ "pool_5_faceN", "pool_5_faceW", "pool_5_faceS", "pool_5_faceE" ],
 	"bg": "field",
 	"rotates": true
 },{
@@ -23,7 +23,7 @@
 	  "pool_roof_3",
 	  "pool_roof_4"
 	],
-	"fg": [ "pool_2_faceN", "pool_2_faceE", "pool_2_faceS", "pool_2_faceW" ],
+	"fg": [ "pool_2_faceN", "pool_2_faceW", "pool_2_faceS", "pool_2_faceE" ],
 	"bg": "open_air",
 	"rotates": true
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/public_pond/public_pond.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/public_pond/public_pond.json
@@ -1,9 +1,12 @@
-[{
-	"id": "PublicPond_1a",
-	"fg": [ "public_pond_w", "public_pond_n", "public_pond_e", "public_pond_s" ],
-	"rotates": true
-},{
-	"id": "PublicPond_1b",
-	"fg": [ "public_pond_e", "public_pond_s", "public_pond_w", "public_pond_n" ],
-	"rotates": true
-}]
+[
+  {
+  	"id": "PublicPond_1a",
+	  "fg": [ "public_pond_w", "public_pond_s", "public_pond_e", "public_pond_n" ],
+  	"rotates": true
+  },
+  {
+  	"id": "PublicPond_1b",
+  	"fg": [ "public_pond_e", "public_pond_n", "public_pond_w", "public_pond_s" ],
+  	"rotates": true
+  }
+]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/residential.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/residential.json
@@ -115,16 +115,8 @@
       "urban_1_3",
       "urban_1_4",
       "urban_1_6",
-      "urban_2_1",
-      "urban_2_2",
       "urban_3_1",
       "urban_3_2",
-      "urban_4_3",
-      "urban_4_4",
-      "urban_5_1",
-      "urban_5_2",
-      "urban_6_1",
-      "urban_6_2",
       "urban_7_1",
       "urban_7_2",
       "urban_8_1",
@@ -151,26 +143,10 @@
       "urban_29_8",
       "urban_29_9",
       "urban_29_10",
-      "urban_2_3",
-      "urban_2_4",
-      "urban_2_5",
-      "urban_2_6",
       "urban_3_3",
       "urban_3_4",
       "urban_3_5",
       "urban_3_6",
-      "urban_4_5",
-      "urban_4_6",
-      "urban_4_7",
-      "urban_4_8",
-      "urban_5_3",
-      "urban_5_4",
-      "urban_5_5",
-      "urban_5_6",
-      "urban_6_3",
-      "urban_6_4",
-      "urban_6_5",
-      "urban_6_6",
       "urban_7_3",
       "urban_7_4",
       "urban_7_5",
@@ -219,8 +195,32 @@
       "urban_13_11",
       "urban_13_12"
     ],
-    "fg": [ "otr_house_1_faceN", "otr_house_1_faceE", "otr_house_1_faceS", "otr_house_1_faceW" ], 
+    "fg": [ "otr_house_1_faceN", "otr_house_1_faceW", "otr_house_1_faceS", "otr_house_1_faceE" ], 
     "bg": "field",
+    "rotates": true
+  },
+  {
+    "id": [ "urban_4_3", "urban_4_4", "urban_2_1", "urban_2_2" ],
+    "fg": [ "otr_house_1_faceS", "otr_house_1_faceE", "otr_house_1_faceN", "otr_house_1_faceW" ],
+    "bg": "field",
+    "rotates": true
+  },
+  {
+    "id": [ "urban_5_1", "urban_5_2", "urban_6_1", "urban_6_2" ],
+    "fg": [ "otr_house_1_faceN", "otr_house_1_faceE", "otr_house_1_faceS", "otr_house_1_faceW" ],
+    "bg": "field",
+    "rotates": true
+  },
+  {
+    "id": [ "urban_4_5", "urban_4_6", "urban_4_7", "urban_4_8", "urban_2_3", "urban_2_4", "urban_2_5", "urban_2_6" ],
+    "fg": [ "otr_house_1_faceS", "otr_house_1_faceE", "otr_house_1_faceN", "otr_house_1_faceW" ],
+    "bg": "open_air",
+    "rotates": true
+  },
+  {
+    "id": [ "urban_5_3", "urban_5_4", "urban_5_5", "urban_5_6", "urban_6_3", "urban_6_4", "urban_6_5", "urban_6_6" ],
+    "fg": [ "otr_house_1_faceN", "otr_house_1_faceE", "otr_house_1_faceS", "otr_house_1_faceW" ],
+    "bg": "open_air",
     "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/river/river.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/river/river.json
@@ -1,71 +1,62 @@
-[{
-  "id": "river_nw",
-  "fg": "river_nw",
-  "bg": "field",
-  "rotates": false
-},{
-  "id": "river_sw",
-  "fg": "river_sw",
-  "bg": "field",
-  "rotates": false
-},{
-  "id": "river_se",
-  "fg": "river_se",
-  "bg": "field",
-  "rotates": false
-},{
-  "id": "river_ne",
-  "fg": "river_ne",
-  "bg": "field",
-  "rotates": false
-},{
-  "id": "river_north",
-  "fg": "river_north",
-  "bg": "field",
-  "rotates": false
-},{
-  "id": "river_west",
-  "fg": "river_west",
-  "bg": "field",
-  "rotates": false
-},{
-  "id": "river_east",
-  "fg": "river_east",
-  "bg": "field",
-  "rotates": false
-},{
-  "id": "river_south",
-  "fg": "river_south",
-  "bg": "field",
-  "rotates": false
-},{
-  "id": "river_center",
-  "fg": "river_center",
-  "bg": "field",
-  "rotates": false
-},{
-  "id": "river",
-  "fg": ["river_north", "river_east", "river_south", "river_west"],
-  "bg": "field",
-  "rotates": true
-},{
-  "id": "river_c_not_nw",
-  "fg": "river_c_not_nw",
-  "bg": "field",
-  "rotates": false
-},{
-  "id": "river_c_not_ne",
-  "fg": "river_c_not_ne",
-  "bg": "field",
-  "rotates": false
-},{
-  "id": "river_c_not_sw",
-  "fg": "river_c_not_sw",
-  "bg": "field",
-  "rotates": false
-},{
-  "id": "river_c_not_se",
-  "fg": "river_c_not_se",
-  "bg": "field",
-  "rotates": false
-}]
+[
+  {
+    "id": "river_nw",
+    "fg": "river_nw",
+    "bg": "field",
+    "rotates": false
+  },
+  {
+    "id": "river_sw",
+    "fg": "river_sw",
+    "bg": "field",
+    "rotates": false
+  },
+  {
+    "id": "river_se",
+    "fg": "river_se",
+    "bg": "field",
+    "rotates": false
+  },
+  {
+    "id": "river_ne",
+    "fg": "river_ne",
+    "bg": "field",
+    "rotates": false
+  },
+  {
+    "id": "river_center",
+    "fg": "river_center",
+    "bg": "field",
+    "rotates": false
+  },
+  {
+    "id": "river",
+    "fg": ["river_north", "river_west", "river_south", "river_east"],
+    "bg": "field",
+    "rotates": true
+  },
+  {
+    "id": "river_c_not_nw",
+    "fg": "river_c_not_nw",
+    "bg": "field",
+    "rotates": false
+  },
+  {
+    "id": "river_c_not_ne",
+    "fg": "river_c_not_ne",
+    "bg": "field",
+    "rotates": false
+  },
+  {
+    "id": "river_c_not_sw",
+    "fg": "river_c_not_sw",
+    "bg": "field",
+    "rotates": false
+  },
+  {
+    "id": "river_c_not_se",
+    "fg": "river_c_not_se",
+    "bg": "field",
+    "rotates": false
+  }
+]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/road/road.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/road/road.json
@@ -1,54 +1,80 @@
-{
-  "id": "road",
-  "fg": "road_unconnected",
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "road_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "road_corner_nw",
-        "road_corner_sw",
-        "road_corner_se",
-        "road_corner_ne"
-      ],
-      "bg": "field"
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "road_t_connection_n",
-        "road_t_connection_w",
-        "road_t_connection_s",
-        "road_t_connection_e"
-      ]
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "road_edge_ns",
-        "road_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "road_end_piece_n",
-        "road_end_piece_w",
-        "road_end_piece_s",
-        "road_end_piece_e"
-      ]
-    },
-    {
-      "id": "unconnected",
-      "fg": [
-        "road_unconnected",
-        "road_unconnected"
-      ],
-      "bg": "field"
-    }
-  ]
-}
+[
+  {
+    "id": "road",
+    "fg": "road_unconnected",
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "road_center"
+      },
+      {
+        "id": "corner",
+        "fg": [
+          "road_corner_nw",
+          "road_corner_sw",
+          "road_corner_se",
+          "road_corner_ne"
+        ],
+        "bg": "field"
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "road_t_connection_n",
+          "road_t_connection_w",
+          "road_t_connection_s",
+          "road_t_connection_e"
+        ]
+      },
+      {
+        "id": "edge",
+        "fg": [
+          "road_edge_ns",
+          "road_edge_ew"
+        ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [
+          "road_end_piece_n",
+          "road_end_piece_w",
+          "road_end_piece_s",
+          "road_end_piece_e"
+        ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [
+          "road_unconnected",
+          "road_unconnected"
+        ],
+        "bg": "field"
+      }
+    ]
+  },
+  {
+    "id": "trailer_hub_01",
+    "fg": "road_center"
+  },
+  {
+    "id": "trailer_hub_11",
+    "fg": [ "road_edge_ew", "road_edge_ns" ],
+    "rotates": true
+  },
+  {
+    "id": [ "trailer_road", "trailer_road_1parkway", "trailer_road_2parkway" ],
+    "fg": [ "road_edge_ns", "road_edge_ew" ],
+    "rotates": true
+  },
+  {
+    "id": "trailer_road_turn",
+    "fg": [ "road_corner_ne", "road_corner_nw", "road_corner_sw", "road_corner_se" ],
+    "bg": "field",
+    "rotates": true
+  },
+  {
+    "id": "trailer_road_3way",
+    "fg": "road_center"
+  }
+]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/road_nesw_manhole/road_nesw_manhole.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/road_nesw_manhole/road_nesw_manhole.json
@@ -1,7 +1,7 @@
 [
-{
-    "id": "road_nesw_manhole",
+  {
+    "id": [ "road_nesw_manhole", "city_center" ],
     "fg": "road_nesw_manhole",
     "bg": "road_center"
-}
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/rural_house/rural_house.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/rural_house/rural_house.json
@@ -5,7 +5,7 @@
     "farm_isherwood_2",
     "2farm_11"
   ],
-  "fg": [ "rural_house_faceN", "rural_house_faceE", "rural_house_faceS", "rural_house_faceW" ],
+  "fg": [ "rural_house_faceN", "rural_house_faceW", "rural_house_faceS", "rural_house_faceE" ],
   "bg": "field",
   "rotates": true
 },{
@@ -13,7 +13,7 @@
     "dairy_farm_SW",
     "ranch_camp_68"
   ],
-  "fg": [ "rural_house_faceS", "rural_house_faceW", "rural_house_faceN", "rural_house_faceE" ],
+  "fg": [ "rural_house_faceS", "rural_house_faceE", "rural_house_faceN", "rural_house_faceW" ],
   "bg": "field",
   "rotates": true
 },{
@@ -23,7 +23,7 @@
     "farm_isherwood_2_roof",
     "2farm_roof_11"
   ],
-  "fg": [ "rural_house_faceN", "rural_house_faceE", "rural_house_faceS", "rural_house_faceW" ],
+  "fg": [ "rural_house_faceN", "rural_house_faceW", "rural_house_faceS", "rural_house_faceE" ],
   "bg": "open_air",
   "rotates": true
 },{
@@ -31,11 +31,11 @@
     "dairy_farm_SW_roof",
     "ranch_camp_68_roof"
   ],
-  "fg": [ "rural_house_faceS", "rural_house_faceW", "rural_house_faceN", "rural_house_faceE" ],
+  "fg": [ "rural_house_faceS", "rural_house_faceE", "rural_house_faceN", "rural_house_faceW" ],
   "bg": "open_air",
   "rotates": true
 },{
   "id": "farm_isherwood_2_cellar",
-  "fg": [ "rural_house_faceN", "rural_house_faceE", "rural_house_faceS", "rural_house_faceW" ],
+  "fg": [ "rural_house_faceN", "rural_house_faceW", "rural_house_faceS", "rural_house_faceE" ],
   "rotates": true
 }]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/sub_station/sub_station.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/sub_station/sub_station.json
@@ -1,7 +1,7 @@
 [
   {
 	"id": [ "sub_station_roof", "sub_station", "sewer_sub_station", "underground_sub_station" ],
-	"fg": [ "sub_station_rot_N", "sub_station_rot_E", "sub_station_rot_S", "sub_station_rot_W" ],
+	"fg": [ "sub_station_rot_N", "sub_station_rot_W", "sub_station_rot_S", "sub_station_rot_E" ],
 	"rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/swamp_shack/swamp_shacks.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/swamp_shack/swamp_shacks.json
@@ -5,17 +5,17 @@
 	"rotates": true
 },{
 	"id": "hunter_shack_1",
-	"fg": [ "hunter_shack_1_faceS", "hunter_shack_1_faceE", "hunter_shack_1_faceN", "hunter_shack_1_faceW" ],
+	"fg": [ "hunter_shack_1_faceS", "hunter_shack_1_faceW", "hunter_shack_1_faceN", "hunter_shack_1_faceE" ],
 	"bg": "field",
 	"rotates": true
 },{
 	"id": "hunter_shack_roof",
-	"fg": [ "hunter_shack_faceN", "hunter_shack_faceE", "hunter_shack_faceS", "hunter_shack_faceW" ],
+	"fg": [ "hunter_shack_faceS", "hunter_shack_faceE", "hunter_shack_faceN", "hunter_shack_faceW" ],
 	"bg": "open_air",
 	"rotates": true
 },{
 	"id": "hunter_shack_roof_1",
-	"fg": [ "hunter_shack_1_faceS", "hunter_shack_1_faceE", "hunter_shack_1_faceN", "hunter_shack_1_faceW" ],
+	"fg": [ "hunter_shack_1_faceS", "hunter_shack_1_faceW", "hunter_shack_1_faceN", "hunter_shack_1_faceE" ],
 	"bg": "open_air",
 	"rotates": true
 }]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/trail_small/trail_small.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/trail_small/trail_small.json
@@ -3,9 +3,9 @@
 	"id": "small_wooded_trail",
 	"fg": [
 	  "small_wooded_trail_rot_N",
-	  "small_wooded_trail_rot_E",
+	  "small_wooded_trail_rot_W",
 	  "small_wooded_trail_rot_S",
-	  "small_wooded_trail_rot_W"
+	  "small_wooded_trail_rot_E"
 	],
 	"bg": "field",
 	"rotates": true
@@ -14,9 +14,9 @@
 	"id": "small_wooded_trail_2",
 	"fg": [
 	  "small_wooded_trail_2_rot_N",
-	  "small_wooded_trail_2_rot_E",
+	  "small_wooded_trail_2_rot_W",
 	  "small_wooded_trail_2_rot_S",
-	  "small_wooded_trail_2_rot_W"
+	  "small_wooded_trail_2_rot_E"
 	],
 	"bg": "field",
 	"rotates": true

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/wind_turbine/wind_turbine.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/wind_turbine/wind_turbine.json
@@ -6,13 +6,13 @@
 	  "wind_turbine_nacelle",
 	  "wind_turbine_roof"
 	],
-	"fg": [ "wind_turbine_rot_N", "wind_turbine_rot_E", "wind_turbine_rot_S", "wind_turbine_rot_W" ],
+	"fg": [ "wind_turbine_rot_N", "wind_turbine_rot_W", "wind_turbine_rot_S", "wind_turbine_rot_E" ],
 	"bg": "open_air_tall",
 	"rotates": true
   },
   {
 	"id": "wind_turbine_ground",
-	"fg": [ "wind_turbine_rot_N", "wind_turbine_rot_E", "wind_turbine_rot_S", "wind_turbine_rot_W" ],
+	"fg": [ "wind_turbine_rot_N", "wind_turbine_rot_W", "wind_turbine_rot_S", "wind_turbine_rot_E" ],
 	"bg": "field_tall",
 	"rotates": true
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->
Fixes rotation to some of the overmap JSONs and adds placeholder to others
#### Content of the change

Added placeholder JSON to the trailer/mobile home road
Added placeholder JSON to the paddock overmap
Fixed dirt road rotation issues and added the missing center sprite ( It was unused "Sorry" )
Fixed rotation to several city building and added JSON to some of them due to different face origin
Fixed rotation of the swamp shack and the wind turbine
Maybe other fixes and tweaks I forgot about
<!-- Explain what does this pull request contain. -->

#### Testing

Tested every change so trust me :)
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
Noticed that some players are still interested in that overmap tileset while it's lacking heavily "Shrug emoji"