### PR TITLE
[NeoDays] Adds some missing books to the appropriate files

### DIFF
--- a/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_blue.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_blue.json
@@ -12,7 +12,15 @@
     "novel_tragedy",
     "ZSG",
     "textbook_armeast",
-    "brewing_cookbook"
+    "brewing_cookbook",
+    "distilling_cookbook",
+    "cookbook_liverforkids",
+    "baking_book",
+    "alloy_book",
+    "concrete_book",
+    "reference_firstaid1",
+    "reference_firstaid2",
+    "sa_cryptology_key"
   ],
   "fg": "manual_blue"
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_gray.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_gray.json
@@ -19,7 +19,10 @@
     "holybook_bible3",
     "scots_cookbook",
     "holybook_kojiki",
-    "holybook_havamal"
+    "holybook_havamal",
+    "survivalflavor_book",
+    "sweets_book",
+    "isherwood_herbal_remedies"
   ],
   "fg": ["manual_gray"]
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_green.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_green.json
@@ -50,7 +50,11 @@
     "manual_fencing",
     "manual_silat",
     "manual_sojutsu",
-    "ic_reference_electronics"
+    "ic_reference_electronics",
+    "fermenting_book",
+    "offalcooking",
+    "vinegar_maker",
+    "book_lockpick"
   ],
   "fg": "manual_green"
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_light_green.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_light_green.json
@@ -12,7 +12,8 @@
     "cookbook_sushi",
     "holybook_granth",
     "holybook_scientology",
-    "robofac_yrax_deactivation_manual"
+    "robofac_yrax_deactivation_manual",
+    "exodii_wiring_kit_reference"
   ],
   "fg": "manual_light_green"
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_red.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_red.json
@@ -27,7 +27,9 @@
     "manual_scorpion",
     "manual_toad",
     "manual_lizard",
-    "manual_venom_snake"
+    "manual_venom_snake",
+    "winemaking_beginner",
+    "tailor_japanese"
   ],
   "fg": "manual_red"
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_white.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_white.json
@@ -15,7 +15,8 @@
     "recipe_medicalmut",
     "holybook_upanishads",
     "novel_coa2",
-    "mag_barter"
+    "mag_barter",
+    "dairy_book"
   ],
   "fg": "manual_white"
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_yellow.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/items/reading/manual_yellow.json
@@ -20,7 +20,8 @@
     "holybook_vedas",
     "holybook_sutras",
     "mag_animecon",
-    "catalytic_cracking_handbook"
+    "catalytic_cracking_handbook",
+    "cookbook_indian"
   ],
   "fg": "manual_yellow"
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Adds some books to the appropriate files.

#### Content of the change
Connects:
"alloy_book", "concrete_book", "reference_firstaid1", "reference_firstaid2", "sa_cryptology_key", "baking_book", "cookbook_liverforkids" and "distilling_cookbook" to manual_blue.json

"sweet_book", "isherwood_herbal_remedies" and "survivalflavor_book" to manual_gray.json

"book_lockpick","vinegar_maker", "offalcooking" and "fermenting_book" to manual_green.json

"tailor_japanese" and "winemaking_beginner" to manual_red.json

"dairy_book" to manual_white.json

"cookbook_indian" to manual_yellow.json

"exodii_wiring_kit_reference" to manual_light_green.json

#### Testing
Before
![booksbefore](https://github.com/I-am-Erk/CDDA-Tilesets/assets/149837811/6fd458e0-bf4a-42a1-a0f3-b45143ad2289)
After
![booksafter](https://github.com/I-am-Erk/CDDA-Tilesets/assets/149837811/6105f75d-3d1a-4bd5-8d6c-15237b9858d4)


#### Additional information
