### PR TITLE
[MSX] Fix missing military card reader

### DIFF
--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_card_reader/t_card_science.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_card_reader/t_card_science.json
@@ -1,1 +1,13 @@
-{"id": "t_card_science", "fg": ["t_card_military"], "bg": ["993_t_missile_exploded_3"], "rotates": false}
+{
+  "id": [
+    "t_card_science",
+    "t_card_military"
+  ],
+  "fg": [
+    "t_card_military"
+  ],
+  "bg": [
+    "993_t_missile_exploded_3"
+  ],
+  "rotates": false
+}

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_card_reader/t_card_science.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_card_reader/t_card_science.json
@@ -5,9 +5,5 @@
   ],
   "fg": [
     "t_card_military"
-  ],
-  "bg": [
-    "993_t_missile_exploded_3"
-  ],
-  "rotates": false
+  ]
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Fixes #2233

#### Content of the change

Fix the json to use the card reader sprite for science *and* military card reader

#### Testing

![image](https://github.com/I-am-Erk/CDDA-Tilesets/assets/41293484/e7003a68-acd6-4f81-b204-a0f1caecac94)

#### Additional information
Basically there was a mistake in #2162 that attributed the `t_card_military` sprite to `t_card_science` but forgot to also include `t_card_military` itself in the list of id. I've made that mistake before, `--use-all` doesn't work if the sprite is mentionned for something in json, then it needs to list all of the id it will be used for