### PR TITLE
[GiantDays] Re-add hair

### DIFF
--- a/gfx/GiantDays/pngs_large_40x40/mutations/hair/black/overlay_mutation_hair_black.json
+++ b/gfx/GiantDays/pngs_large_40x40/mutations/hair/black/overlay_mutation_hair_black.json
@@ -1,77 +1,77 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_black_fro",
+      "overlay_mutation_hair_fro_var_black",
       "overlay_mutation_fro_var_black"
     ],
     "fg": "overlay_mutation_hair_black_fro"
   },
   {
     "id": [
-      "overlay_mutation_hair_black_long",
+      "overlay_mutation_hair_long_var_black",
       "overlay_mutation_long_var_black"
     ],
     "fg": "overlay_mutation_hair_black_long"
   },
   {
     "id": [
-      "overlay_mutation_hair_black_medium",
+      "overlay_mutation_hair_medium_var_black",
       "overlay_mutation_medium_var_black"
     ],
     "fg": "overlay_mutation_hair_black_medium"
   },
   {
     "id": [
-      "overlay_mutation_hair_black_mohawk",
+      "overlay_mutation_hair_mohawk_var_black",
       "overlay_mutation_mohawk_var_black"
     ],
     "fg": "overlay_mutation_hair_black_mohawk"
   },
   {
     "id": [
-      "overlay_mutation_hair_black_short",
+      "overlay_mutation_hair_short_var_black",
       "overlay_mutation_short_var_black"
     ],
     "fg": "overlay_mutation_hair_black_short"
   },
   {
     "id": [
-      "overlay_mutation_hair_black_long_over_eye",
+      "overlay_mutation_hair_long_over_eye_var_black",
       "overlay_mutation_long_over_eye_var_black"
     ],
     "fg": "overlay_mutation_long_over_eye_var_black"
   },
   {
     "id": [
-      "overlay_mutation_hair_black_messy",
+      "overlay_mutation_hair_messy_var_black",
       "overlay_mutation_messy_var_black"
     ],
     "fg": "overlay_mutation_messy_var_black"
   },
   {
     "id": [
-      "overlay_mutation_hair_black_mullet",
+      "overlay_mutation_hair_mullet_var_black",
       "overlay_mutation_mullet_var_black"
     ],
     "fg": "overlay_mutation_mullet_var_black"
   },
   {
     "id": [
-      "overlay_mutation_hair_black_ponytail",
+      "overlay_mutation_hair_var_black_var_ponytail",
       "overlay_mutation_ponytail_var_black"
     ],
     "fg": "overlay_mutation_ponytail_var_black"
   },
   {
     "id": [
-      "overlay_mutation_hair_black_short_no_fringe",
+      "overlay_mutation_hair_short_no_fringe_var_black",
       "overlay_mutation_short_no_fringe_var_black"
     ],
     "fg": "overlay_mutation_short_no_fringe_var_black"
   },
   {
     "id": [
-      "overlay_mutation_hair_black_short_over_eye",
+      "overlay_mutation_hair_short_over_eye_var_black",
       "overlay_mutation_short_over_eye_var_black"
     ],
     "fg": "overlay_mutation_short_over_eye_var_black"

--- a/gfx/GiantDays/pngs_large_40x40/mutations/hair/blond/overlay_mutation_hair_blond.json
+++ b/gfx/GiantDays/pngs_large_40x40/mutations/hair/blond/overlay_mutation_hair_blond.json
@@ -1,77 +1,77 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_blond_fro",
+      "overlay_mutation_hair_fro_var_blond",
       "overlay_mutation_fro_var_blond"
     ],
     "fg": "overlay_mutation_hair_blond_fro"
   },
   {
     "id": [
-      "overlay_mutation_hair_blond_long",
+      "overlay_mutation_hair_long_var_blond",
       "overlay_mutation_long_var_blond"
     ],
     "fg": "overlay_mutation_hair_blond_long"
   },
   {
     "id": [
-      "overlay_mutation_hair_blond_medium",
+      "overlay_mutation_hair_medium_var_blond",
       "overlay_mutation_medium_var_blond"
     ],
     "fg": "overlay_mutation_hair_blond_medium"
   },
   {
     "id": [
-      "overlay_mutation_hair_blond_mohawk",
+      "overlay_mutation_hair_mohawk_var_blond",
       "overlay_mutation_mohawk_var_blond"
     ],
     "fg": "overlay_mutation_hair_blond_mohawk"
   },
   {
     "id": [
-      "overlay_mutation_hair_blond_short",
+      "overlay_mutation_hair_short_var_blond",
       "overlay_mutation_short_var_blond"
     ],
     "fg": "overlay_mutation_hair_blond_short"
   },
   {
     "id": [
-      "overlay_mutation_hair_blond_long_over_eye",
+      "overlay_mutation_hair_long_over_eye_var_blond",
       "overlay_mutation_long_over_eye_var_blond"
     ],
     "fg": "overlay_mutation_long_over_eye_var_blond"
   },
   {
     "id": [
-      "overlay_mutation_hair_blond_messy",
+      "overlay_mutation_hair_messy_var_blond",
       "overlay_mutation_messy_var_blond"
     ],
     "fg": "overlay_mutation_messy_var_blond"
   },
   {
     "id": [
-      "overlay_mutation_hair_blond_mullet",
+      "overlay_mutation_hair_mullet_var_blond",
       "overlay_mutation_mullet_var_blond"
     ],
     "fg": "overlay_mutation_mullet_var_blond"
   },
   {
     "id": [
-      "overlay_mutation_hair_blond_ponytail",
+      "overlay_mutation_hair_ponytail_var_blond",
       "overlay_mutation_ponytail_var_blond"
     ],
     "fg": "overlay_mutation_ponytail_var_blond"
   },
   {
     "id": [
-      "overlay_mutation_hair_blond_short_no_fringe",
+      "overlay_mutation_hair_short_no_fringe_var_blond",
       "overlay_mutation_short_no_fringe_var_blond"
     ],
     "fg": "overlay_mutation_short_no_fringe_var_blond"
   },
   {
     "id": [
-      "overlay_mutation_hair_blond_short_over_eye",
+      "overlay_mutation_hair_short_over_eye_var_blond",
       "overlay_mutation_short_over_eye_var_blond"
     ],
     "fg": "overlay_mutation_short_over_eye_var_blond"

--- a/gfx/GiantDays/pngs_large_40x40/mutations/hair/blue/overlay_mutation_hair_blue.json
+++ b/gfx/GiantDays/pngs_large_40x40/mutations/hair/blue/overlay_mutation_hair_blue.json
@@ -1,77 +1,77 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_blue_fro",
+      "overlay_mutation_hair_fro_var_blue",
       "overlay_mutation_fro_var_blue"
     ],
     "fg": "overlay_mutation_hair_blue_fro"
   },
   {
     "id": [
-      "overlay_mutation_hair_blue_long",
+      "overlay_mutation_hair_long_var_blue",
       "overlay_mutation_long_var_blue"
     ],
     "fg": "overlay_mutation_hair_blue_long"
   },
   {
     "id": [
-      "overlay_mutation_hair_blue_medium",
+      "overlay_mutation_hair_medium_var_blue",
       "overlay_mutation_medium_var_blue"
     ],
     "fg": "overlay_mutation_hair_blue_medium"
   },
   {
     "id": [
-      "overlay_mutation_hair_blue_mohawk",
+      "overlay_mutation_hair_mohawk_var_blue",
       "overlay_mutation_mohawk_var_blue"
     ],
     "fg": "overlay_mutation_hair_blue_mohawk"
   },
   {
     "id": [
-      "overlay_mutation_hair_blue_short",
+      "overlay_mutation_hair_short_var_blue",
       "overlay_mutation_short_var_blue"
     ],
     "fg": "overlay_mutation_hair_blue_short"
   },
   {
     "id": [
-      "overlay_mutation_hair_blue_long_over_eye",
+      "overlay_mutation_hair_long_over_eye_var_blue",
       "overlay_mutation_long_over_eye_var_blue"
     ],
     "fg": "overlay_mutation_long_over_eye_var_blue"
   },
   {
     "id": [
-      "overlay_mutation_hair_blue_messy",
+      "overlay_mutation_hair_messy_var_blue",
       "overlay_mutation_messy_var_blue"
     ],
     "fg": "overlay_mutation_messy_var_blue"
   },
   {
     "id": [
-      "overlay_mutation_hair_blue_mullet",
+      "overlay_mutation_hair_mullet_var_blue",
       "overlay_mutation_mullet_var_blue"
     ],
     "fg": "overlay_mutation_mullet_var_blue"
   },
   {
     "id": [
-      "overlay_mutation_hair_blue_ponytail",
+      "overlay_mutation_hair_ponytail_var_blue",
       "overlay_mutation_ponytail_var_blue"
     ],
     "fg": "overlay_mutation_ponytail_var_blue"
   },
   {
     "id": [
-      "overlay_mutation_hair_blue_short_no_fringe",
+      "overlay_mutation_hair_short_no_fringe_var_blue",
       "overlay_mutation_short_no_fringe_var_blue"
     ],
     "fg": "overlay_mutation_short_no_fringe_var_blue"
   },
   {
     "id": [
-      "overlay_mutation_hair_blue_short_over_eye",
+      "overlay_mutation_hair_short_over_eye_var_blue",
       "overlay_mutation_short_over_eye_var_blue"
     ],
     "fg": "overlay_mutation_short_over_eye_var_blue"

--- a/gfx/GiantDays/pngs_large_40x40/mutations/hair/brown/overlay_mutation_hair_brown.json
+++ b/gfx/GiantDays/pngs_large_40x40/mutations/hair/brown/overlay_mutation_hair_brown.json
@@ -1,77 +1,77 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_brown_fro",
+      "overlay_mutation_hair_fro_var_brown",
       "overlay_mutation_fro_var_brown"
     ],
     "fg": "overlay_mutation_hair_brown_fro"
   },
   {
     "id": [
-      "overlay_mutation_hair_brown_long",
+      "overlay_mutation_hair_long_var_brown",
       "overlay_mutation_long_var_brown"
     ],
     "fg": "overlay_mutation_hair_brown_long"
   },
   {
     "id": [
-      "overlay_mutation_hair_brown_medium",
+      "overlay_mutation_hair_medium_var_brown",
       "overlay_mutation_medium_var_brown"
     ],
     "fg": "overlay_mutation_hair_brown_medium"
   },
   {
     "id": [
-      "overlay_mutation_hair_brown_mohawk",
+      "overlay_mutation_hair_mohawk_var_brown",
       "overlay_mutation_mohawk_var_brown"
     ],
     "fg": "overlay_mutation_hair_brown_mohawk"
   },
   {
     "id": [
-      "overlay_mutation_hair_brown_short",
+      "overlay_mutation_hair_short_var_brown",
       "overlay_mutation_short_var_brown"
     ],
     "fg": "overlay_mutation_hair_brown_short"
   },
   {
     "id": [
-      "overlay_mutation_hair_brown_long_over_eye",
+      "overlay_mutation_hair_long_over_eye_var_brown",
       "overlay_mutation_long_over_eye_var_brown"
     ],
     "fg": "overlay_mutation_long_over_eye_var_brown"
   },
   {
     "id": [
-      "overlay_mutation_hair_brown_messy",
+      "overlay_mutation_hair_messy_var_brown",
       "overlay_mutation_messy_var_brown"
     ],
     "fg": "overlay_mutation_messy_var_brown"
   },
   {
     "id": [
-      "overlay_mutation_hair_brown_mullet",
+      "overlay_mutation_hair_mullet_var_brown",
       "overlay_mutation_mullet_var_brown"
     ],
     "fg": "overlay_mutation_mullet_var_brown"
   },
   {
     "id": [
-      "overlay_mutation_hair_brown_ponytail",
+      "overlay_mutation_hair_ponytail_var_brown",
       "overlay_mutation_ponytail_var_brown"
     ],
     "fg": "overlay_mutation_ponytail_var_brown"
   },
   {
     "id": [
-      "overlay_mutation_hair_brown_short_no_fringe",
+      "overlay_mutation_hair_short_no_fringe_var_brown",
       "overlay_mutation_short_no_fringe_var_brown"
     ],
     "fg": "overlay_mutation_short_no_fringe_var_brown"
   },
   {
     "id": [
-      "overlay_mutation_hair_brown_short_over_eye",
+      "overlay_mutation_hair_short_over_eye_var_brown",
       "overlay_mutation_short_over_eye_var_brown"
     ],
     "fg": "overlay_mutation_short_over_eye_var_brown"

--- a/gfx/GiantDays/pngs_large_40x40/mutations/hair/gray/overlay_mutation_hair_gray.json
+++ b/gfx/GiantDays/pngs_large_40x40/mutations/hair/gray/overlay_mutation_hair_gray.json
@@ -1,77 +1,77 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_gray_fro",
+      "overlay_mutation_hair_fro_var_gray",
       "overlay_mutation_fro_var_gray"
     ],
     "fg": "overlay_mutation_hair_gray_fro"
   },
   {
     "id": [
-      "overlay_mutation_hair_gray_long",
+      "overlay_mutation_hair_long_var_gray",
       "overlay_mutation_long_var_gray"
     ],
     "fg": "overlay_mutation_hair_gray_long"
   },
   {
     "id": [
-      "overlay_mutation_hair_gray_medium",
+      "overlay_mutation_hair_medium_var_gray",
       "overlay_mutation_medium_var_gray"
     ],
     "fg": "overlay_mutation_hair_gray_medium"
   },
   {
     "id": [
-      "overlay_mutation_hair_gray_mohawk",
+      "overlay_mutation_hair_mohawk_var_gray",
       "overlay_mutation_mohawk_var_gray"
     ],
     "fg": "overlay_mutation_hair_gray_mohawk"
   },
   {
     "id": [
-      "overlay_mutation_hair_gray_short",
+      "overlay_mutation_hair_short_var_gray",
       "overlay_mutation_short_var_gray"
     ],
     "fg": "overlay_mutation_hair_gray_short"
   },
   {
     "id": [
-      "overlay_mutation_hair_gray_long_over_eye",
+      "overlay_mutation_hair_long_over_eye_var_gray",
       "overlay_mutation_long_over_eye_var_gray"
     ],
     "fg": "overlay_mutation_long_over_eye_var_gray"
   },
   {
     "id": [
-      "overlay_mutation_hair_gray_messy",
+      "overlay_mutation_hair_messy_var_gray",
       "overlay_mutation_messy_var_gray"
     ],
     "fg": "overlay_mutation_messy_var_gray"
   },
   {
     "id": [
-      "overlay_mutation_hair_gray_mullet",
+      "overlay_mutation_hair_mullet_var_gray",
       "overlay_mutation_mullet_var_gray"
     ],
     "fg": "overlay_mutation_mullet_var_gray"
   },
   {
     "id": [
-      "overlay_mutation_hair_gray_ponytail",
+      "overlay_mutation_hair_ponytail_var_gray",
       "overlay_mutation_ponytail_var_gray"
     ],
     "fg": "overlay_mutation_ponytail_var_gray"
   },
   {
     "id": [
-      "overlay_mutation_hair_gray_short_no_fringe",
+      "overlay_mutation_hair_short_no_fringe_var_gray",
       "overlay_mutation_short_no_fringe_var_gray"
     ],
     "fg": "overlay_mutation_short_no_fringe_var_gray"
   },
   {
     "id": [
-      "overlay_mutation_hair_gray_short_over_eye",
+      "overlay_mutation_hair_short_over_eye_var_gray",
       "overlay_mutation_short_over_eye_var_gray"
     ],
     "fg": "overlay_mutation_short_over_eye_var_gray"

--- a/gfx/GiantDays/pngs_large_40x40/mutations/hair/green/overlay_mutation_hair_green.json
+++ b/gfx/GiantDays/pngs_large_40x40/mutations/hair/green/overlay_mutation_hair_green.json
@@ -1,77 +1,77 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_green_fro",
+      "overlay_mutation_hair_fro_var_green",
       "overlay_mutation_fro_var_green"
     ],
     "fg": "overlay_mutation_hair_green_fro"
   },
   {
     "id": [
-      "overlay_mutation_hair_green_long",
+      "overlay_mutation_hair_long_var_green",
       "overlay_mutation_long_var_green"
     ],
     "fg": "overlay_mutation_hair_green_long"
   },
   {
     "id": [
-      "overlay_mutation_hair_green_medium",
+      "overlay_mutation_hair_medium_var_green",
       "overlay_mutation_medium_var_green"
     ],
     "fg": "overlay_mutation_hair_green_medium"
   },
   {
     "id": [
-      "overlay_mutation_hair_green_mohawk",
+      "overlay_mutation_hair_mohawk_var_green",
       "overlay_mutation_mohawk_var_green"
     ],
     "fg": "overlay_mutation_hair_green_mohawk"
   },
   {
     "id": [
-      "overlay_mutation_hair_green_short",
+      "overlay_mutation_hair_short_var_green",
       "overlay_mutation_short_var_green"
     ],
     "fg": "overlay_mutation_hair_green_short"
   },
   {
     "id": [
-      "overlay_mutation_hair_green_long_over_eye",
+      "overlay_mutation_hair_long_over_eye_var_green",
       "overlay_mutation_long_over_eye_var_green"
     ],
     "fg": "overlay_mutation_long_over_eye_var_green"
   },
   {
     "id": [
-      "overlay_mutation_hair_green_messy",
+      "overlay_mutation_hair_messy_var_green",
       "overlay_mutation_messy_var_green"
     ],
     "fg": "overlay_mutation_messy_var_green"
   },
   {
     "id": [
-      "overlay_mutation_hair_green_mullet",
+      "overlay_mutation_hair_mullet_var_green",
       "overlay_mutation_mullet_var_green"
     ],
     "fg": "overlay_mutation_mullet_var_green"
   },
   {
     "id": [
-      "overlay_mutation_hair_green_ponytail",
+      "overlay_mutation_hair_ponytail_var_green",
       "overlay_mutation_ponytail_var_green"
     ],
     "fg": "overlay_mutation_ponytail_var_green"
   },
   {
     "id": [
-      "overlay_mutation_hair_green_short_no_fringe",
+      "overlay_mutation_hair_short_no_fringe_var_green",
       "overlay_mutation_short_no_fringe_var_green"
     ],
     "fg": "overlay_mutation_short_no_fringe_var_green"
   },
   {
     "id": [
-      "overlay_mutation_hair_green_short_over_eye",
+      "overlay_mutation_hair_short_over_eye_var_green",
       "overlay_mutation_short_over_eye_var_green"
     ],
     "fg": "overlay_mutation_short_over_eye_var_green"

--- a/gfx/GiantDays/pngs_large_40x40/mutations/hair/pink/overlay_mutation_hair_pink.json
+++ b/gfx/GiantDays/pngs_large_40x40/mutations/hair/pink/overlay_mutation_hair_pink.json
@@ -1,77 +1,77 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_pink_fro",
+      "overlay_mutation_hair_fro_var_pink",
       "overlay_mutation_fro_var_pink"
     ],
     "fg": "overlay_mutation_hair_pink_fro"
   },
   {
     "id": [
-      "overlay_mutation_hair_pink_long",
+      "overlay_mutation_hair_long_var_pink",
       "overlay_mutation_long_var_pink"
     ],
     "fg": "overlay_mutation_hair_pink_long"
   },
   {
     "id": [
-      "overlay_mutation_hair_pink_medium",
+      "overlay_mutation_hair_medium_var_pink",
       "overlay_mutation_medium_var_pink"
     ],
     "fg": "overlay_mutation_hair_pink_medium"
   },
   {
     "id": [
-      "overlay_mutation_hair_pink_mohawk",
+      "overlay_mutation_hair_mohawk_var_pink",
       "overlay_mutation_mohawk_var_pink"
     ],
     "fg": "overlay_mutation_hair_pink_mohawk"
   },
   {
     "id": [
-      "overlay_mutation_hair_pink_short",
+      "overlay_mutation_hair_short_var_pink",
       "overlay_mutation_short_var_pink"
     ],
     "fg": "overlay_mutation_hair_pink_short"
   },
   {
     "id": [
-      "overlay_mutation_hair_pink_long_over_eye",
+      "overlay_mutation_hair_long_over_eye_var_pink",
       "overlay_mutation_long_over_eye_var_pink"
     ],
     "fg": "overlay_mutation_long_over_eye_var_pink"
   },
   {
     "id": [
-      "overlay_mutation_hair_pink_messy",
+      "overlay_mutation_hair_messy_var_pink",
       "overlay_mutation_messy_var_pink"
     ],
     "fg": "overlay_mutation_messy_var_pink"
   },
   {
     "id": [
-      "overlay_mutation_hair_pink_mullet",
+      "overlay_mutation_hair_mullet_var_pink",
       "overlay_mutation_mullet_var_pink"
     ],
     "fg": "overlay_mutation_mullet_var_pink"
   },
   {
     "id": [
-      "overlay_mutation_hair_pink_ponytail",
+      "overlay_mutation_hair_ponytail_var_pink",
       "overlay_mutation_ponytail_var_pink"
     ],
     "fg": "overlay_mutation_ponytail_var_pink"
   },
   {
     "id": [
-      "overlay_mutation_hair_pink_short_no_fringe",
+      "overlay_mutation_hair_short_no_fringe_var_pink",
       "overlay_mutation_short_no_fringe_var_pink"
     ],
     "fg": "overlay_mutation_short_no_fringe_var_pink"
   },
   {
     "id": [
-      "overlay_mutation_hair_pink_short_over_eye",
+      "overlay_mutation_hair_short_over_eye_var_pink",
       "overlay_mutation_short_over_eye_var_pink"
     ],
     "fg": "overlay_mutation_short_over_eye_var_pink"

--- a/gfx/GiantDays/pngs_large_40x40/mutations/hair/purple/overlay_mutation_hair_purple.json
+++ b/gfx/GiantDays/pngs_large_40x40/mutations/hair/purple/overlay_mutation_hair_purple.json
@@ -1,77 +1,77 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_purple_fro",
+      "overlay_mutation_hair_fro_var_purple",
       "overlay_mutation_fro_var_purple"
     ],
     "fg": "overlay_mutation_hair_purple_fro"
   },
   {
     "id": [
-      "overlay_mutation_hair_purple_long",
+      "overlay_mutation_hair_long_var_purple",
       "overlay_mutation_long_var_purple"
     ],
     "fg": "overlay_mutation_hair_purple_long"
   },
   {
     "id": [
-      "overlay_mutation_hair_purple_medium",
+      "overlay_mutation_hair_medium_var_purple",
       "overlay_mutation_medium_var_purple"
     ],
     "fg": "overlay_mutation_hair_purple_medium"
   },
   {
     "id": [
-      "overlay_mutation_hair_purple_mohawk",
+      "overlay_mutation_hair_mohawk_var_purple",
       "overlay_mutation_mohawk_var_purple"
     ],
     "fg": "overlay_mutation_hair_purple_mohawk"
   },
   {
     "id": [
-      "overlay_mutation_hair_purple_short",
+      "overlay_mutation_hair_short_var_purple",
       "overlay_mutation_short_var_purple"
     ],
     "fg": "overlay_mutation_hair_purple_short"
   },
   {
     "id": [
-      "overlay_mutation_hair_purple_long_over_eye",
+      "overlay_mutation_hair_long_over_eye_var_purple",
       "overlay_mutation_long_over_eye_var_purple"
     ],
     "fg": "overlay_mutation_long_over_eye_var_purple"
   },
   {
     "id": [
-      "overlay_mutation_hair_purple_messy",
+      "overlay_mutation_hair_messy_var_purple",
       "overlay_mutation_messy_var_purple"
     ],
     "fg": "overlay_mutation_messy_var_purple"
   },
   {
     "id": [
-      "overlay_mutation_hair_purple_mullet",
+      "overlay_mutation_hair_mullet_var_purple",
       "overlay_mutation_mullet_var_purple"
     ],
     "fg": "overlay_mutation_mullet_var_purple"
   },
   {
     "id": [
-      "overlay_mutation_hair_purple_ponytail",
+      "overlay_mutation_hair_ponytail_var_purple",
       "overlay_mutation_ponytail_var_purple"
     ],
     "fg": "overlay_mutation_ponytail_var_purple"
   },
   {
     "id": [
-      "overlay_mutation_hair_purple_short_no_fringe",
+      "overlay_mutation_hair_short_no_fringe_var_purple",
       "overlay_mutation_short_no_fringe_var_purple"
     ],
     "fg": "overlay_mutation_short_no_fringe_var_purple"
   },
   {
     "id": [
-      "overlay_mutation_hair_purple_short_over_eye",
+      "overlay_mutation_hair_short_over_eye_var_purple",
       "overlay_mutation_short_over_eye_var_purple"
     ],
     "fg": "overlay_mutation_short_over_eye_var_purple"

--- a/gfx/GiantDays/pngs_large_40x40/mutations/hair/red/overlay_mutation_hair_red.json
+++ b/gfx/GiantDays/pngs_large_40x40/mutations/hair/red/overlay_mutation_hair_red.json
@@ -1,77 +1,77 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_red_fro",
+      "overlay_mutation_hair_fro_var_red",
       "overlay_mutation_fro_var_red"
     ],
     "fg": "overlay_mutation_hair_red_fro"
   },
   {
     "id": [
-      "overlay_mutation_hair_red_long",
+      "overlay_mutation_hair_long_var_red",
       "overlay_mutation_long_var_red"
     ],
     "fg": "overlay_mutation_hair_red_long"
   },
   {
     "id": [
-      "overlay_mutation_hair_red_medium",
+      "overlay_mutation_hair_medium_var_red",
       "overlay_mutation_medium_var_red"
     ],
     "fg": "overlay_mutation_hair_red_medium"
   },
   {
     "id": [
-      "overlay_mutation_hair_red_mohawk",
+      "overlay_mutation_hair_mohawk_var_red",
       "overlay_mutation_mohawk_var_red"
     ],
     "fg": "overlay_mutation_hair_red_mohawk"
   },
   {
     "id": [
-      "overlay_mutation_hair_red_short",
+      "overlay_mutation_hair_short_var_red",
       "overlay_mutation_short_var_red"
     ],
     "fg": "overlay_mutation_hair_red_short"
   },
   {
     "id": [
-      "overlay_mutation_hair_red_long_over_eye",
+      "overlay_mutation_hair_long_over_eye_var_red",
       "overlay_mutation_long_over_eye_var_red"
     ],
     "fg": "overlay_mutation_long_over_eye_var_red"
   },
   {
     "id": [
-      "overlay_mutation_hair_red_messy",
+      "overlay_mutation_hair_messy_var_red",
       "overlay_mutation_messy_var_red"
     ],
     "fg": "overlay_mutation_messy_var_red"
   },
   {
     "id": [
-      "overlay_mutation_hair_red_mullet",
+      "overlay_mutation_hair_mullet_var_red",
       "overlay_mutation_mullet_var_red"
     ],
     "fg": "overlay_mutation_mullet_var_red"
   },
   {
     "id": [
-      "overlay_mutation_hair_red_ponytail",
+      "overlay_mutation_hair_ponytail_var_red",
       "overlay_mutation_ponytail_var_red"
     ],
     "fg": "overlay_mutation_ponytail_var_red"
   },
   {
     "id": [
-      "overlay_mutation_hair_red_short_no_fringe",
+      "overlay_mutation_hair_short_no_fringe_var_red",
       "overlay_mutation_short_no_fringe_var_red"
     ],
     "fg": "overlay_mutation_short_no_fringe_var_red"
   },
   {
     "id": [
-      "overlay_mutation_hair_red_short_over_eye",
+      "overlay_mutation_hair_short_over_eye_var_red",
       "overlay_mutation_short_over_eye_var_red"
     ],
     "fg": "overlay_mutation_short_over_eye_var_red"

--- a/gfx/GiantDays/pngs_large_40x40/mutations/hair/white/overlay_mutation_hair_white.json
+++ b/gfx/GiantDays/pngs_large_40x40/mutations/hair/white/overlay_mutation_hair_white.json
@@ -1,77 +1,77 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_white_fro",
+      "overlay_mutation_hair_fro_var_white",
       "overlay_mutation_fro_var_white"
     ],
     "fg": "overlay_mutation_hair_white_fro"
   },
   {
     "id": [
-      "overlay_mutation_hair_white_long",
+      "overlay_mutation_hair_long_var_white",
       "overlay_mutation_long_var_white"
     ],
     "fg": "overlay_mutation_hair_white_long"
   },
   {
     "id": [
-      "overlay_mutation_hair_white_medium",
+      "overlay_mutation_hair_medium_var_white",
       "overlay_mutation_medium_var_white"
     ],
     "fg": "overlay_mutation_hair_white_medium"
   },
   {
     "id": [
-      "overlay_mutation_hair_white_mohawk",
+      "overlay_mutation_hair_mohawk_var_white",
       "overlay_mutation_mohawk_var_white"
     ],
     "fg": "overlay_mutation_hair_white_mohawk"
   },
   {
     "id": [
-      "overlay_mutation_hair_white_short",
+      "overlay_mutation_hair_short_var_white",
       "overlay_mutation_short_var_white"
     ],
     "fg": "overlay_mutation_hair_white_short"
   },
   {
     "id": [
-      "overlay_mutation_hair_white_long_over_eye",
+      "overlay_mutation_hair_long_over_eye_var_white",
       "overlay_mutation_long_over_eye_var_white"
     ],
     "fg": "overlay_mutation_long_over_eye_var_white"
   },
   {
     "id": [
-      "overlay_mutation_hair_white_messy",
+      "overlay_mutation_hair_messy_var_white",
       "overlay_mutation_messy_var_white"
     ],
     "fg": "overlay_mutation_messy_var_white"
   },
   {
     "id": [
-      "overlay_mutation_hair_white_mullet",
+      "overlay_mutation_hair_mullet_var_white",
       "overlay_mutation_mullet_var_white"
     ],
     "fg": "overlay_mutation_mullet_var_white"
   },
   {
     "id": [
-      "overlay_mutation_hair_white_ponytail",
+      "overlay_mutation_hair_ponytail_var_white",
       "overlay_mutation_ponytail_var_white"
     ],
     "fg": "overlay_mutation_ponytail_var_white"
   },
   {
     "id": [
-      "overlay_mutation_hair_white_short_no_fringe",
+      "overlay_mutation_hair_short_no_fringe_var_white",
       "overlay_mutation_short_no_fringe_var_white"
     ],
     "fg": "overlay_mutation_short_no_fringe_var_white"
   },
   {
     "id": [
-      "overlay_mutation_hair_white_short_over_eye",
+      "overlay_mutation_hair_short_over_eye_var_white",
       "overlay_mutation_short_over_eye_var_white"
     ],
     "fg": "overlay_mutation_short_over_eye_var_white"

--- a/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/black/overlay_mutation_hair_black.json
+++ b/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/black/overlay_mutation_hair_black.json
@@ -1,14 +1,14 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_black_buzzcut",
+      "overlay_mutation_hair_buzzcut_var_black",
       "overlay_mutation_buzzcut_var_black"
     ],
     "fg": "overlay_mutation_buzzcut_var_black"
   },
   {
     "id": [
-      "overlay_mutation_hair_black_crewcut",
+      "overlay_mutation_hair_crewcut_var_black",
       "overlay_mutation_crewcut_var_black"
     ],
     "fg": "overlay_mutation_hair_black_crewcut"

--- a/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/blond/overlay_mutation_hair_blond.json
+++ b/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/blond/overlay_mutation_hair_blond.json
@@ -1,14 +1,14 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_blond_buzzcut",
+      "overlay_mutation_hair_buzzcut_var_blond",
       "overlay_mutation_buzzcut_var_blond"
     ],
     "fg": "overlay_mutation_buzzcut_var_blond"
   },
   {
     "id": [
-      "overlay_mutation_hair_blond_crewcut",
+      "overlay_mutation_hair_crewcut_var_blond",
       "overlay_mutation_crewcut_var_blond"
     ],
     "fg": "overlay_mutation_hair_blond_crewcut"

--- a/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/blue/overlay_mutation_hair_blue.json
+++ b/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/blue/overlay_mutation_hair_blue.json
@@ -1,14 +1,14 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_blue_buzzcut",
+      "overlay_mutation_hair_buzzcut_var_blue",
       "overlay_mutation_buzzcut_var_blue"
     ],
     "fg": "overlay_mutation_buzzcut_var_blue"
   },
   {
     "id": [
-      "overlay_mutation_hair_blue_crewcut",
+      "overlay_mutation_hair_crewcut_var_blue",
       "overlay_mutation_crewcut_var_blue"
     ],
     "fg": "overlay_mutation_hair_blue_crewcut"

--- a/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/brown/overlay_mutation_hair_brown.json
+++ b/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/brown/overlay_mutation_hair_brown.json
@@ -1,14 +1,14 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_brown_buzzcut",
+      "overlay_mutation_hair_buzzcut_var_brown",
       "overlay_mutation_buzzcut_var_brown"
     ],
     "fg": "overlay_mutation_buzzcut_var_brown"
   },
   {
     "id": [
-      "overlay_mutation_hair_brown_crewcut",
+      "overlay_mutation_hair_crewcut_var_brown",
       "overlay_mutation_crewcut_var_brown"
     ],
     "fg": "overlay_mutation_hair_brown_crewcut"

--- a/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/gray/overlay_mutation_hair_gray.json
+++ b/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/gray/overlay_mutation_hair_gray.json
@@ -1,14 +1,14 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_gray_buzzcut",
+      "overlay_mutation_hair_buzzcut_var_gray",
       "overlay_mutation_buzzcut_var_gray"
     ],
     "fg": "overlay_mutation_buzzcut_var_gray"
   },
   {
     "id": [
-      "overlay_mutation_hair_gray_crewcut",
+      "overlay_mutation_hair_crewcut_var_gray",
       "overlay_mutation_crewcut_var_gray"
     ],
     "fg": "overlay_mutation_hair_gray_crewcut"

--- a/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/green/overlay_mutation_hair_green.json
+++ b/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/green/overlay_mutation_hair_green.json
@@ -1,14 +1,14 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_green_buzzcut",
+      "overlay_mutation_hair_buzzcut_var_green",
       "overlay_mutation_buzzcut_var_green"
     ],
     "fg": "overlay_mutation_buzzcut_var_green"
   },
   {
     "id": [
-      "overlay_mutation_hair_green_crewcut",
+      "overlay_mutation_hair_crewcut_var_green",
       "overlay_mutation_crewcut_var_green"
     ],
     "fg": "overlay_mutation_hair_green_crewcut"

--- a/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/pink/overlay_mutation_hair_pink.json
+++ b/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/pink/overlay_mutation_hair_pink.json
@@ -1,14 +1,14 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_pink_buzzcut",
+      "overlay_mutation_hair_buzzcut_var_pink",
       "overlay_mutation_buzzcut_var_pink"
     ],
     "fg": "overlay_mutation_buzzcut_var_pink"
   },
   {
     "id": [
-      "overlay_mutation_hair_pink_crewcut",
+      "overlay_mutation_hair_crewcut_var_pink",
       "overlay_mutation_crewcut_var_pink"
     ],
     "fg": "overlay_mutation_hair_pink_crewcut"

--- a/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/purple/overlay_mutation_hair_purple.json
+++ b/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/purple/overlay_mutation_hair_purple.json
@@ -1,14 +1,14 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_purple_buzzcut",
+      "overlay_mutation_hair_buzzcut_var_purple",
       "overlay_mutation_buzzcut_var_purple"
     ],
     "fg": "overlay_mutation_buzzcut_var_purple"
   },
   {
     "id": [
-      "overlay_mutation_hair_purple_crewcut",
+      "overlay_mutation_hair_crewcut_var_purple",
       "overlay_mutation_crewcut_var_purple"
     ],
     "fg": "overlay_mutation_hair_purple_crewcut"

--- a/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/red/overlay_mutation_hair_red.json
+++ b/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/red/overlay_mutation_hair_red.json
@@ -1,14 +1,14 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_red_buzzcut",
+      "overlay_mutation_hair_buzzcut_var_red",
       "overlay_mutation_buzzcut_var_red"
     ],
     "fg": "overlay_mutation_buzzcut_var_red"
   },
   {
     "id": [
-      "overlay_mutation_hair_red_crewcut",
+      "overlay_mutation_hair_crewcut_var_red",
       "overlay_mutation_crewcut_var_red"
     ],
     "fg": "overlay_mutation_hair_red_crewcut"

--- a/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/white/overlay_mutation_hair_white.json
+++ b/gfx/GiantDays/pngs_mobs_20x20/characters/overlay/mutation/hair/white/overlay_mutation_hair_white.json
@@ -1,14 +1,14 @@
 [
   {
     "id": [
-      "overlay_mutation_hair_white_buzzcut",
+      "overlay_mutation_hair_buzzcut_var_white",
       "overlay_mutation_buzzcut_var_white"
     ],
     "fg": "overlay_mutation_buzzcut_var_white"
   },
   {
     "id": [
-      "overlay_mutation_hair_white_crewcut",
+      "overlay_mutation_hair_crewcut_var_white",
       "overlay_mutation_crewcut_var_white"
     ],
     "fg": "overlay_mutation_hair_white_crewcut"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->
Fixed hair ids for GiantDays

#### Content of the change

<!-- Explain what does this pull request contain. -->
Modified the JSON files for both the 40x40 and 20x20 character hair mutation overlays to reflect newer hair IDs. 

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

Compiled on mac, and loaded up giantdays on experimental 3eb062c. Looks like all the hair is visible

#### Additional information

Did not rename any of the graphics files.  Helps with #2237

<img width="744" alt="Screenshot of Cataclysm at Apr 6, 2024 at 08_06_50" src="https://github.com/I-am-Erk/CDDA-Tilesets/assets/23535616/2e21014a-5b10-4d5d-b48d-a9c0be47f504">
