### PR TITLE
[Surveyor's Map] Fix E/W orientation of city buildings

### DIFF
--- a/gfx/SurveyorsMap/pngs_overmap_24x24/abandonedwarehouse/abandonedwarehouse.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/abandonedwarehouse/abandonedwarehouse.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "abandonedwarehouse" ],
-    "fg": [ "abandonedwarehouse_N", "abandonedwarehouse_E", "abandonedwarehouse_S", "abandonedwarehouse_W" ],
+    "fg": [ "abandonedwarehouse_N", "abandonedwarehouse_W", "abandonedwarehouse_S", "abandonedwarehouse_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "abandonedwarehouse_roof" ],
-    "fg": [ "abandonedwarehouse_roof_N", "abandonedwarehouse_roof_E", "abandonedwarehouse_roof_S", "abandonedwarehouse_roof_W" ],
+    "fg": [ "abandonedwarehouse_roof_N", "abandonedwarehouse_roof_W", "abandonedwarehouse_roof_S", "abandonedwarehouse_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/abandonedwarehouse_1/abandonedwarehouse_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/abandonedwarehouse_1/abandonedwarehouse_1.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "abandonedwarehouse_1" ],
-    "fg": [ "abandonedwarehouse_1_N", "abandonedwarehouse_1_E", "abandonedwarehouse_1_S", "abandonedwarehouse_1_W" ],
+    "fg": [ "abandonedwarehouse_1_N", "abandonedwarehouse_1_W", "abandonedwarehouse_1_S", "abandonedwarehouse_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -9,9 +9,9 @@
     "id": [ "abandonedwarehouse_1_roof" ],
     "fg": [
       "abandonedwarehouse_roof_1_N",
-      "abandonedwarehouse_roof_1_E",
+      "abandonedwarehouse_roof_1_W",
       "abandonedwarehouse_roof_1_S",
-      "abandonedwarehouse_roof_1_W"
+      "abandonedwarehouse_roof_1_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/abandonedwarehouse_2/abandonedwarehouse_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/abandonedwarehouse_2/abandonedwarehouse_2.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "abandonedwarehouse_2" ],
-    "fg": [ "abandonedwarehouse_2_N", "abandonedwarehouse_2_E", "abandonedwarehouse_2_S", "abandonedwarehouse_2_W" ],
+    "fg": [ "abandonedwarehouse_2_N", "abandonedwarehouse_2_W", "abandonedwarehouse_2_S", "abandonedwarehouse_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -9,9 +9,9 @@
     "id": [ "abandonedwarehouse_2_roof" ],
     "fg": [
       "abandonedwarehouse_roof_2_N",
-      "abandonedwarehouse_roof_2_E",
+      "abandonedwarehouse_roof_2_W",
       "abandonedwarehouse_roof_2_S",
-      "abandonedwarehouse_roof_2_W"
+      "abandonedwarehouse_roof_2_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/abandonedwarehouse_3/abandonedwarehouse_3.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/abandonedwarehouse_3/abandonedwarehouse_3.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "abandonedwarehouse_3" ],
-    "fg": [ "abandonedwarehouse_3_N", "abandonedwarehouse_3_E", "abandonedwarehouse_3_S", "abandonedwarehouse_3_W" ],
+    "fg": [ "abandonedwarehouse_3_N", "abandonedwarehouse_3_W", "abandonedwarehouse_3_S", "abandonedwarehouse_3_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -9,9 +9,9 @@
     "id": [ "abandonedwarehouse_3_roof" ],
     "fg": [
       "abandonedwarehouse_roof_3_N",
-      "abandonedwarehouse_roof_3_E",
+      "abandonedwarehouse_roof_3_W",
       "abandonedwarehouse_roof_3_S",
-      "abandonedwarehouse_roof_3_W"
+      "abandonedwarehouse_roof_3_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/abandonedwarehouse_4/abandonedwarehouse_4.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/abandonedwarehouse_4/abandonedwarehouse_4.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "abandonedwarehouse_4" ],
-    "fg": [ "abandonedwarehouse_4_N", "abandonedwarehouse_4_E", "abandonedwarehouse_4_S", "abandonedwarehouse_4_W" ],
+    "fg": [ "abandonedwarehouse_4_N", "abandonedwarehouse_4_W", "abandonedwarehouse_4_S", "abandonedwarehouse_4_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -9,9 +9,9 @@
     "id": [ "abandonedwarehouse_4_roof" ],
     "fg": [
       "abandonedwarehouse_roof_4_N",
-      "abandonedwarehouse_roof_4_E",
+      "abandonedwarehouse_roof_4_W",
       "abandonedwarehouse_roof_4_S",
-      "abandonedwarehouse_roof_4_W"
+      "abandonedwarehouse_roof_4_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/abstorefront/abstorefront.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/abstorefront/abstorefront.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "abstorefront" ],
-    "fg": [ "abstorefront_N", "abstorefront_E", "abstorefront_S", "abstorefront_W" ],
+    "fg": [ "abstorefront_N", "abstorefront_W", "abstorefront_S", "abstorefront_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "abstorefront_roof" ],
-    "fg": [ "abstorefront_roof_N", "abstorefront_roof_E", "abstorefront_roof_S", "abstorefront_roof_W" ],
+    "fg": [ "abstorefront_roof_N", "abstorefront_roof_W", "abstorefront_roof_S", "abstorefront_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/abstorefront_1/abstorefront_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/abstorefront_1/abstorefront_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "abstorefront_1" ],
-    "fg": [ "abstorefront_1_N", "abstorefront_1_E", "abstorefront_1_S", "abstorefront_1_W" ],
+    "fg": [ "abstorefront_1_N", "abstorefront_1_W", "abstorefront_1_S", "abstorefront_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "abstorefront_roof_1" ],
-    "fg": [ "abstorefront_roof_1_N", "abstorefront_roof_1_E", "abstorefront_roof_1_S", "abstorefront_roof_1_W" ],
+    "fg": [ "abstorefront_roof_1_N", "abstorefront_roof_1_W", "abstorefront_roof_1_S", "abstorefront_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/abstorefront_2/abstorefront_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/abstorefront_2/abstorefront_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "abstorefront_2" ],
-    "fg": [ "abstorefront_2_N", "abstorefront_2_E", "abstorefront_2_S", "abstorefront_2_W" ],
+    "fg": [ "abstorefront_2_N", "abstorefront_2_W", "abstorefront_2_S", "abstorefront_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "abstorefront_roof_2" ],
-    "fg": [ "abstorefront_roof_2_N", "abstorefront_roof_2_E", "abstorefront_roof_2_S", "abstorefront_roof_2_W" ],
+    "fg": [ "abstorefront_roof_2_N", "abstorefront_roof_2_W", "abstorefront_roof_2_S", "abstorefront_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/animalpound/animalpound.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/animalpound/animalpound.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "animalpound" ],
-    "fg": [ "animalpound_N", "animalpound_E", "animalpound_S", "animalpound_W" ],
+    "fg": [ "animalpound_N", "animalpound_W", "animalpound_S", "animalpound_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "animalpound_roof" ],
-    "fg": [ "animalpound_roof_N", "animalpound_roof_E", "animalpound_roof_S", "animalpound_roof_W" ],
+    "fg": [ "animalpound_roof_N", "animalpound_roof_W", "animalpound_roof_S", "animalpound_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/animalshelter/animalshelter.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/animalshelter/animalshelter.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "animalshelter" ],
-    "fg": [ "animalshelter_N", "animalshelter_E", "animalshelter_S", "animalshelter_W" ],
+    "fg": [ "animalshelter_N", "animalshelter_W", "animalshelter_S", "animalshelter_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "animalshelter_roof" ],
-    "fg": [ "animalshelter_roof_N", "animalshelter_roof_E", "animalshelter_roof_S", "animalshelter_roof_W" ],
+    "fg": [ "animalshelter_roof_N", "animalshelter_roof_W", "animalshelter_roof_S", "animalshelter_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/art_gallery/art_gallery.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/art_gallery/art_gallery.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "art_gallery" ],
-    "fg": [ "art_gallery_N", "art_gallery_E", "art_gallery_S", "art_gallery_W" ],
+    "fg": [ "art_gallery_N", "art_gallery_W", "art_gallery_S", "art_gallery_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "art_gallery_roof" ],
-    "fg": [ "art_gallery_roof_N", "art_gallery_roof_E", "art_gallery_roof_S", "art_gallery_roof_W" ],
+    "fg": [ "art_gallery_roof_N", "art_gallery_roof_W", "art_gallery_roof_S", "art_gallery_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/bakery/bakery.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/bakery/bakery.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "bakery" ],
-    "fg": [ "bakery_N", "bakery_E", "bakery_S", "bakery_W" ],
+    "fg": [ "bakery_N", "bakery_W", "bakery_S", "bakery_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "bakery_roof" ],
-    "fg": [ "bakery_roof_N", "bakery_roof_E", "bakery_roof_S", "bakery_roof_W" ],
+    "fg": [ "bakery_roof_N", "bakery_roof_W", "bakery_roof_S", "bakery_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "bakery_upper_roof" ],
-    "fg": [ "bakery_upper_roof_N", "bakery_upper_roof_E", "bakery_upper_roof_S", "bakery_upper_roof_W" ],
+    "fg": [ "bakery_upper_roof_N", "bakery_upper_roof_W", "bakery_upper_roof_S", "bakery_upper_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/bank/bank.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/bank/bank.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "bank" ],
-    "fg": [ "bank_N", "bank_E", "bank_S", "bank_W" ],
+    "fg": [ "bank_N", "bank_W", "bank_S", "bank_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "bank_roof" ],
-    "fg": [ "bank_roof_N", "bank_roof_E", "bank_roof_S", "bank_roof_W" ],
+    "fg": [ "bank_roof_N", "bank_roof_W", "bank_roof_S", "bank_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/bank_1/bank_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/bank_1/bank_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "bank_1" ],
-    "fg": [ "bank_1_N", "bank_1_E", "bank_1_S", "bank_1_W" ],
+    "fg": [ "bank_1_N", "bank_1_W", "bank_1_S", "bank_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "bank_roof_1" ],
-    "fg": [ "bank_roof_1_N", "bank_roof_1_E", "bank_roof_1_S", "bank_roof_1_W" ],
+    "fg": [ "bank_roof_1_N", "bank_roof_1_W", "bank_roof_1_S", "bank_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/bar/bar.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/bar/bar.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "bar" ],
-    "fg": [ "bar_N", "bar_E", "bar_S", "bar_W" ],
+    "fg": [ "bar_N", "bar_W", "bar_S", "bar_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "bar_roof" ],
-    "fg": [ "bar_roof_N", "bar_roof_E", "bar_roof_S", "bar_roof_W" ],
+    "fg": [ "bar_roof_N", "bar_roof_W", "bar_roof_S", "bar_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/bar_1/bar_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/bar_1/bar_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "bar_1" ],
-    "fg": [ "bar_1_N", "bar_1_E", "bar_1_S", "bar_1_W" ],
+    "fg": [ "bar_1_N", "bar_1_W", "bar_1_S", "bar_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "bar_roof_1" ],
-    "fg": [ "bar_roof_1_N", "bar_roof_1_E", "bar_roof_1_S", "bar_roof_1_W" ],
+    "fg": [ "bar_roof_1_N", "bar_roof_1_W", "bar_roof_1_S", "bar_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/baseball_field/s_baseballfield.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/baseball_field/s_baseballfield.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "s_baseballfield_a1" ],
-    "fg": [ "s_baseballfield_a1_N", "s_baseballfield_a1_E", "s_baseballfield_a1_S", "s_baseballfield_a1_W" ],
+    "fg": [ "s_baseballfield_a1_N", "s_baseballfield_a1_W", "s_baseballfield_a1_S", "s_baseballfield_a1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_baseballfield_a2" ],
-    "fg": [ "s_baseballfield_a2_N", "s_baseballfield_a2_E", "s_baseballfield_a2_S", "s_baseballfield_a2_W" ],
+    "fg": [ "s_baseballfield_a2_N", "s_baseballfield_a2_W", "s_baseballfield_a2_S", "s_baseballfield_a2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_baseballfield_b1" ],
-    "fg": [ "s_baseballfield_b1_N", "s_baseballfield_b1_E", "s_baseballfield_b1_S", "s_baseballfield_b1_W" ],
+    "fg": [ "s_baseballfield_b1_N", "s_baseballfield_b1_W", "s_baseballfield_b1_S", "s_baseballfield_b1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_baseballfield_b2" ],
-    "fg": [ "s_baseballfield_b2_N", "s_baseballfield_b2_E", "s_baseballfield_b2_S", "s_baseballfield_b2_W" ],
+    "fg": [ "s_baseballfield_b2_N", "s_baseballfield_b2_W", "s_baseballfield_b2_S", "s_baseballfield_b2_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/bookstores and libraries/s_bookstore/s_bookstore.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/bookstores and libraries/s_bookstore/s_bookstore.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "s_bookstore" ],
-    "fg": [ "s_bookstore_N", "s_bookstore_E", "s_bookstore_S", "s_bookstore_W" ],
+    "fg": [ "s_bookstore_N", "s_bookstore_W", "s_bookstore_S", "s_bookstore_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_bookstore_roof" ],
-    "fg": [ "s_bookstore_roof_N", "s_bookstore_roof_E", "s_bookstore_roof_S", "s_bookstore_roof_W" ],
+    "fg": [ "s_bookstore_roof_N", "s_bookstore_roof_W", "s_bookstore_roof_S", "s_bookstore_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_bookstore_upper_roof" ],
-    "fg": [ "s_bookstore_upper_roof_N", "s_bookstore_upper_roof_E", "s_bookstore_upper_roof_S", "s_bookstore_upper_roof_W" ],
+    "fg": [ "s_bookstore_upper_roof_N", "s_bookstore_upper_roof_W", "s_bookstore_upper_roof_S", "s_bookstore_upper_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/bookstores and libraries/s_bookstore_1/s_bookstore_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/bookstores and libraries/s_bookstore_1/s_bookstore_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_bookstore_1" ],
-    "fg": [ "s_bookstore_1_N", "s_bookstore_1_E", "s_bookstore_1_S", "s_bookstore_1_W" ],
+    "fg": [ "s_bookstore_1_N", "s_bookstore_1_W", "s_bookstore_1_S", "s_bookstore_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_bookstore_roof_1" ],
-    "fg": [ "s_bookstore_roof_1_N", "s_bookstore_roof_1_E", "s_bookstore_roof_1_S", "s_bookstore_roof_1_W" ],
+    "fg": [ "s_bookstore_roof_1_N", "s_bookstore_roof_1_W", "s_bookstore_roof_1_S", "s_bookstore_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "s_bookstore_upper_roof_1" ],
     "fg": [
       "s_bookstore_upper_roof_1_N",
-      "s_bookstore_upper_roof_1_E",
+      "s_bookstore_upper_roof_1_W",
       "s_bookstore_upper_roof_1_S",
-      "s_bookstore_upper_roof_1_W"
+      "s_bookstore_upper_roof_1_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/bookstores and libraries/s_bookstore_2/s_bookstore_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/bookstores and libraries/s_bookstore_2/s_bookstore_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_bookstore_2" ],
-    "fg": [ "s_bookstore_2_N", "s_bookstore_2_E", "s_bookstore_2_S", "s_bookstore_2_W" ],
+    "fg": [ "s_bookstore_2_N", "s_bookstore_2_W", "s_bookstore_2_S", "s_bookstore_2_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_bookstore_roof_2" ],
-    "fg": [ "s_bookstore_roof_2_N", "s_bookstore_roof_2_E", "s_bookstore_roof_2_S", "s_bookstore_roof_2_W" ],
+    "fg": [ "s_bookstore_roof_2_N", "s_bookstore_roof_2_W", "s_bookstore_roof_2_S", "s_bookstore_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/bookstores and libraries/s_library/s_library.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/bookstores and libraries/s_library/s_library.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_library" ],
-    "fg": [ "s_library_N", "s_library_E", "s_library_S", "s_library_W" ],
+    "fg": [ "s_library_N", "s_library_W", "s_library_S", "s_library_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_library_roof" ],
-    "fg": [ "s_library_roof_N", "s_library_roof_E", "s_library_roof_S", "s_library_roof_W" ],
+    "fg": [ "s_library_roof_N", "s_library_roof_W", "s_library_roof_S", "s_library_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/bookstores and libraries/s_library_1/s_library_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/bookstores and libraries/s_library_1/s_library_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_library_1" ],
-    "fg": [ "s_library_1_N", "s_library_1_E", "s_library_1_S", "s_library_1_W" ],
+    "fg": [ "s_library_1_N", "s_library_1_W", "s_library_1_S", "s_library_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_library_roof_1" ],
-    "fg": [ "s_library_roof_1_N", "s_library_roof_1_E", "s_library_roof_1_S", "s_library_roof_1_W" ],
+    "fg": [ "s_library_roof_1_N", "s_library_roof_1_W", "s_library_roof_1_S", "s_library_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/bookstores and libraries/s_library_2/s_library_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/bookstores and libraries/s_library_2/s_library_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_library_2" ],
-    "fg": [ "s_library_2_N", "s_library_2_E", "s_library_2_S", "s_library_2_W" ],
+    "fg": [ "s_library_2_N", "s_library_2_W", "s_library_2_S", "s_library_2_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_library_roof_2" ],
-    "fg": [ "s_library_roof_2_N", "s_library_roof_2_E", "s_library_roof_2_S", "s_library_roof_2_W" ],
+    "fg": [ "s_library_roof_2_N", "s_library_roof_2_W", "s_library_roof_2_S", "s_library_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/bowling_alley/bowling_alley.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/bowling_alley/bowling_alley.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "bowling_alley" ],
-    "fg": [ "bowling_alley_N", "bowling_alley_E", "bowling_alley_S", "bowling_alley_W" ],
+    "fg": [ "bowling_alley_N", "bowling_alley_W", "bowling_alley_S", "bowling_alley_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "bowling_alley_roof" ],
-    "fg": [ "bowling_alley_roof_N", "bowling_alley_roof_E", "bowling_alley_roof_S", "bowling_alley_roof_W" ],
+    "fg": [ "bowling_alley_roof_N", "bowling_alley_roof_W", "bowling_alley_roof_S", "bowling_alley_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/camping/s_camping.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/camping/s_camping.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_camping" ],
-    "fg": [ "s_camping_N", "s_camping_E", "s_camping_S", "s_camping_W" ],
+    "fg": [ "s_camping_N", "s_camping_W", "s_camping_S", "s_camping_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_camping_roof" ],
-    "fg": [ "s_camping_roof_N", "s_camping_roof_E", "s_camping_roof_S", "s_camping_roof_W" ],
+    "fg": [ "s_camping_roof_N", "s_camping_roof_W", "s_camping_roof_S", "s_camping_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/candy_shop/candy_shop.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/candy_shop/candy_shop.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "candy_shop" ],
-    "fg": [ "candy_shop_N", "candy_shop_E", "candy_shop_S", "candy_shop_W" ],
+    "fg": [ "candy_shop_N", "candy_shop_W", "candy_shop_S", "candy_shop_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "candy_shop_roof" ],
-    "fg": [ "candy_shop_roof_N", "candy_shop_roof_E", "candy_shop_roof_S", "candy_shop_roof_W" ],
+    "fg": [ "candy_shop_roof_N", "candy_shop_roof_W", "candy_shop_roof_S", "candy_shop_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/candy_shop_1/candy_shop_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/candy_shop_1/candy_shop_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "candy_shop_1" ],
-    "fg": [ "candy_shop_1_N", "candy_shop_1_E", "candy_shop_1_S", "candy_shop_1_W" ],
+    "fg": [ "candy_shop_1_N", "candy_shop_1_W", "candy_shop_1_S", "candy_shop_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "candy_shop_roof_1" ],
-    "fg": [ "candy_shop_roof_1_N", "candy_shop_roof_1_E", "candy_shop_roof_1_S", "candy_shop_roof_1_W" ],
+    "fg": [ "candy_shop_roof_1_N", "candy_shop_roof_1_W", "candy_shop_roof_1_S", "candy_shop_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/church/church.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/church/church.json
@@ -1,31 +1,31 @@
 [
   {
     "id": [ "church" ],
-    "fg": [ "church_N", "church_E", "church_S", "church_W" ],
+    "fg": [ "church_N", "church_W", "church_S", "church_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "church_roof" ],
-    "fg": [ "church_roof_N", "church_roof_E", "church_roof_S", "church_roof_W" ],
+    "fg": [ "church_roof_N", "church_roof_W", "church_roof_S", "church_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "church_steeple" ],
-    "fg": [ "church_steeple_N", "church_steeple_E", "church_steeple_S", "church_steeple_W" ],
+    "fg": [ "church_steeple_N", "church_steeple_W", "church_steeple_S", "church_steeple_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "church_steeple_end" ],
-    "fg": [ "church_steeple_end_N", "church_steeple_end_E", "church_steeple_end_S", "church_steeple_end_W" ],
+    "fg": [ "church_steeple_end_N", "church_steeple_end_W", "church_steeple_end_S", "church_steeple_end_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "church_steeple_roof" ],
-    "fg": [ "church_steeple_roof_N", "church_steeple_roof_E", "church_steeple_roof_S", "church_steeple_roof_W" ],
+    "fg": [ "church_steeple_roof_N", "church_steeple_roof_W", "church_steeple_roof_S", "church_steeple_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/church_1/church_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/church_1/church_1.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "church_1" ],
-    "fg": [ "church_1_N", "church_1_E", "church_1_S", "church_1_W" ],
+    "fg": [ "church_1_N", "church_1_W", "church_1_S", "church_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "church_2ndfloor_1" ],
-    "fg": [ "church_2ndfloor_1_N", "church_2ndfloor_1_E", "church_2ndfloor_1_S", "church_2ndfloor_1_W" ],
+    "fg": [ "church_2ndfloor_1_N", "church_2ndfloor_1_W", "church_2ndfloor_1_S", "church_2ndfloor_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "church_3rdfloor_1" ],
-    "fg": [ "church_3rdfloor_1_N", "church_3rdfloor_1_E", "church_3rdfloor_1_S", "church_3rdfloor_1_W" ],
+    "fg": [ "church_3rdfloor_1_N", "church_3rdfloor_1_W", "church_3rdfloor_1_S", "church_3rdfloor_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "church_roof_1" ],
-    "fg": [ "church_roof_1_N", "church_roof_1_E", "church_roof_1_S", "church_roof_1_W" ],
+    "fg": [ "church_roof_1_N", "church_roof_1_W", "church_roof_1_S", "church_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/cs_car_dealership/cs_car_dealership.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/cs_car_dealership/cs_car_dealership.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "cs_car_dealership" ],
-    "fg": [ "cs_car_dealership_N", "cs_car_dealership_E", "cs_car_dealership_S", "cs_car_dealership_W" ],
+    "fg": [ "cs_car_dealership_N", "cs_car_dealership_W", "cs_car_dealership_S", "cs_car_dealership_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "cs_car_dealership_roof" ],
-    "fg": [ "cs_car_dealership_roof_N", "cs_car_dealership_roof_E", "cs_car_dealership_roof_S", "cs_car_dealership_roof_W" ],
+    "fg": [ "cs_car_dealership_roof_N", "cs_car_dealership_roof_W", "cs_car_dealership_roof_S", "cs_car_dealership_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/cs_car_showroom/cs_car_showroom.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/cs_car_showroom/cs_car_showroom.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "cs_car_showroom" ],
-    "fg": [ "cs_car_showroom_N", "cs_car_showroom_E", "cs_car_showroom_S", "cs_car_showroom_W" ],
+    "fg": [ "cs_car_showroom_N", "cs_car_showroom_W", "cs_car_showroom_S", "cs_car_showroom_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -9,16 +9,16 @@
     "id": [ "cs_car_showroom_2ndfloor" ],
     "fg": [
       "cs_car_showroom_2ndfloor_N",
-      "cs_car_showroom_2ndfloor_E",
+      "cs_car_showroom_2ndfloor_W",
       "cs_car_showroom_2ndfloor_S",
-      "cs_car_showroom_2ndfloor_W"
+      "cs_car_showroom_2ndfloor_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "cs_car_showroom_roof" ],
-    "fg": [ "cs_car_showroom_roof_N", "cs_car_showroom_roof_E", "cs_car_showroom_roof_S", "cs_car_showroom_roof_W" ],
+    "fg": [ "cs_car_showroom_roof_N", "cs_car_showroom_roof_W", "cs_car_showroom_roof_S", "cs_car_showroom_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/cs_city_dump_small/cs_city_dump_small.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/cs_city_dump_small/cs_city_dump_small.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "cs_city_dump_small" ],
-    "fg": [ "cs_city_dump_small_N", "cs_city_dump_small_E", "cs_city_dump_small_S", "cs_city_dump_small_W" ],
+    "fg": [ "cs_city_dump_small_N", "cs_city_dump_small_W", "cs_city_dump_small_S", "cs_city_dump_small_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/cs_gardening_allotment/cs_gardening_allotment.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/cs_gardening_allotment/cs_gardening_allotment.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "cs_gardening_allotment" ],
-    "fg": [ "cs_gardening_allotment_N", "cs_gardening_allotment_E", "cs_gardening_allotment_S", "cs_gardening_allotment_W" ],
+    "fg": [ "cs_gardening_allotment_N", "cs_gardening_allotment_W", "cs_gardening_allotment_S", "cs_gardening_allotment_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -9,9 +9,9 @@
     "id": [ "cs_gardening_allotment_roof" ],
     "fg": [
       "cs_gardening_allotment_roof_N",
-      "cs_gardening_allotment_roof_E",
+      "cs_gardening_allotment_roof_W",
       "cs_gardening_allotment_roof_S",
-      "cs_gardening_allotment_roof_W"
+      "cs_gardening_allotment_roof_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/cs_internet_cafe/cs_internet_cafe.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/cs_internet_cafe/cs_internet_cafe.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "cs_internet_cafe" ],
-    "fg": [ "cs_internet_cafe_N", "cs_internet_cafe_E", "cs_internet_cafe_S", "cs_internet_cafe_W" ],
+    "fg": [ "cs_internet_cafe_N", "cs_internet_cafe_W", "cs_internet_cafe_S", "cs_internet_cafe_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "cs_internet_cafe_roof" ],
-    "fg": [ "cs_internet_cafe_roof_N", "cs_internet_cafe_roof_E", "cs_internet_cafe_roof_S", "cs_internet_cafe_roof_W" ],
+    "fg": [ "cs_internet_cafe_roof_N", "cs_internet_cafe_roof_W", "cs_internet_cafe_roof_S", "cs_internet_cafe_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "cs_internet_cafe_upper_roof" ],
     "fg": [
       "cs_internet_cafe_upper_roof_N",
-      "cs_internet_cafe_upper_roof_E",
+      "cs_internet_cafe_upper_roof_W",
       "cs_internet_cafe_upper_roof_S",
-      "cs_internet_cafe_upper_roof_W"
+      "cs_internet_cafe_upper_roof_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/cs_market_small/cs_market_small.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/cs_market_small/cs_market_small.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "cs_market_small" ],
-    "fg": [ "cs_market_small_N", "cs_market_small_E", "cs_market_small_S", "cs_market_small_W" ],
+    "fg": [ "cs_market_small_N", "cs_market_small_W", "cs_market_small_S", "cs_market_small_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/cs_open_sewer/cs_open_sewer.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/cs_open_sewer/cs_open_sewer.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "cs_open_sewer" ],
-    "fg": [ "cs_open_sewer_N", "cs_open_sewer_E", "cs_open_sewer_S", "cs_open_sewer_W" ],
+    "fg": [ "cs_open_sewer_N", "cs_open_sewer_W", "cs_open_sewer_S", "cs_open_sewer_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/cs_private_park/cs_private_park.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/cs_private_park/cs_private_park.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "cs_private_park" ],
-    "fg": [ "cs_private_park_N", "cs_private_park_E", "cs_private_park_S", "cs_private_park_W" ],
+    "fg": [ "cs_private_park_N", "cs_private_park_W", "cs_private_park_S", "cs_private_park_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "cs_private_park_roof" ],
-    "fg": [ "cs_private_park_roof_N", "cs_private_park_roof_E", "cs_private_park_roof_S", "cs_private_park_roof_W" ],
+    "fg": [ "cs_private_park_roof_N", "cs_private_park_roof_W", "cs_private_park_roof_S", "cs_private_park_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/cs_public_art_piece/cs_public_art_piece.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/cs_public_art_piece/cs_public_art_piece.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "cs_public_art_piece" ],
-    "fg": [ "cs_public_art_piece_N", "cs_public_art_piece_E", "cs_public_art_piece_S", "cs_public_art_piece_W" ],
+    "fg": [ "cs_public_art_piece_N", "cs_public_art_piece_W", "cs_public_art_piece_S", "cs_public_art_piece_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/cs_public_space/cs_public_space.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/cs_public_space/cs_public_space.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "cs_public_space" ],
-    "fg": [ "cs_public_space_N", "cs_public_space_E", "cs_public_space_S", "cs_public_space_W" ],
+    "fg": [ "cs_public_space_N", "cs_public_space_W", "cs_public_space_S", "cs_public_space_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/cs_sex_shop/cs_sex_shop.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/cs_sex_shop/cs_sex_shop.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "cs_sex_shop" ],
-    "fg": [ "cs_sex_shop_N", "cs_sex_shop_E", "cs_sex_shop_S", "cs_sex_shop_W" ],
+    "fg": [ "cs_sex_shop_N", "cs_sex_shop_W", "cs_sex_shop_S", "cs_sex_shop_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "cs_sex_shop_roof" ],
-    "fg": [ "cs_sex_shop_roof_N", "cs_sex_shop_roof_E", "cs_sex_shop_roof_S", "cs_sex_shop_roof_W" ],
+    "fg": [ "cs_sex_shop_roof_N", "cs_sex_shop_roof_W", "cs_sex_shop_roof_S", "cs_sex_shop_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/cs_tire_shop/cs_tire_shop.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/cs_tire_shop/cs_tire_shop.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "cs_tire_shop" ],
-    "fg": [ "cs_tire_shop_N", "cs_tire_shop_E", "cs_tire_shop_S", "cs_tire_shop_W" ],
+    "fg": [ "cs_tire_shop_N", "cs_tire_shop_W", "cs_tire_shop_S", "cs_tire_shop_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "cs_tire_shop_roof" ],
-    "fg": [ "cs_tire_shop_roof_N", "cs_tire_shop_roof_E", "cs_tire_shop_roof_S", "cs_tire_shop_roof_W" ],
+    "fg": [ "cs_tire_shop_roof_N", "cs_tire_shop_roof_W", "cs_tire_shop_roof_S", "cs_tire_shop_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/dispensary/dispensary.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/dispensary/dispensary.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "dispensary" ],
-    "fg": [ "dispensary_N", "dispensary_E", "dispensary_S", "dispensary_W" ],
+    "fg": [ "dispensary_N", "dispensary_W", "dispensary_S", "dispensary_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "dispensary_roof" ],
-    "fg": [ "dispensary_roof_N", "dispensary_roof_E", "dispensary_roof_S", "dispensary_roof_W" ],
+    "fg": [ "dispensary_roof_N", "dispensary_roof_W", "dispensary_roof_S", "dispensary_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/dispensary_1/dispensary_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/dispensary_1/dispensary_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "dispensary_1" ],
-    "fg": [ "dispensary_1_N", "dispensary_1_E", "dispensary_1_S", "dispensary_1_W" ],
+    "fg": [ "dispensary_1_N", "dispensary_1_W", "dispensary_1_S", "dispensary_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "dispensary_roof_1" ],
-    "fg": [ "dispensary_roof_1_N", "dispensary_roof_1_E", "dispensary_roof_1_S", "dispensary_roof_1_W" ],
+    "fg": [ "dispensary_roof_1_N", "dispensary_roof_1_W", "dispensary_roof_1_S", "dispensary_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/dispensary_2/dispensary_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/dispensary_2/dispensary_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "dispensary_2" ],
-    "fg": [ "dispensary_2_N", "dispensary_2_E", "dispensary_2_S", "dispensary_2_W" ],
+    "fg": [ "dispensary_2_N", "dispensary_2_W", "dispensary_2_S", "dispensary_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "dispensary_roof_2" ],
-    "fg": [ "dispensary_roof_2_N", "dispensary_roof_2_E", "dispensary_roof_2_S", "dispensary_roof_2_W" ],
+    "fg": [ "dispensary_roof_2_N", "dispensary_roof_2_W", "dispensary_roof_2_S", "dispensary_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/dojo/dojo.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/dojo/dojo.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "dojo" ],
-    "fg": [ "dojo_N", "dojo_E", "dojo_S", "dojo_W" ],
+    "fg": [ "dojo_N", "dojo_W", "dojo_S", "dojo_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "dojo_roof" ],
-    "fg": [ "dojo_roof_N", "dojo_roof_E", "dojo_roof_S", "dojo_roof_W" ],
+    "fg": [ "dojo_roof_N", "dojo_roof_W", "dojo_roof_S", "dojo_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "dojo_upper_roof" ],
-    "fg": [ "dojo_upper_roof_N", "dojo_upper_roof_E", "dojo_upper_roof_S", "dojo_upper_roof_W" ],
+    "fg": [ "dojo_upper_roof_N", "dojo_upper_roof_W", "dojo_upper_roof_S", "dojo_upper_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/dojo_1/dojo_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/dojo_1/dojo_1.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "dojo_1" ],
-    "fg": [ "dojo_1_N", "dojo_1_E", "dojo_1_S", "dojo_1_W" ],
+    "fg": [ "dojo_1_N", "dojo_1_W", "dojo_1_S", "dojo_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "dojo_roof_1" ],
-    "fg": [ "dojo_roof_1_N", "dojo_roof_1_E", "dojo_roof_1_S", "dojo_roof_1_W" ],
+    "fg": [ "dojo_roof_1_N", "dojo_roof_1_W", "dojo_roof_1_S", "dojo_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "dojo_upper_roof_1" ],
-    "fg": [ "dojo_upper_roof_1_N", "dojo_upper_roof_1_E", "dojo_upper_roof_1_S", "dojo_upper_roof_1_W" ],
+    "fg": [ "dojo_upper_roof_1_N", "dojo_upper_roof_1_W", "dojo_upper_roof_1_S", "dojo_upper_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/dollarstore/dollarstore.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/dollarstore/dollarstore.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "dollarstore" ],
-    "fg": [ "dollarstore_N", "dollarstore_E", "dollarstore_S", "dollarstore_W" ],
+    "fg": [ "dollarstore_N", "dollarstore_W", "dollarstore_S", "dollarstore_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "dollarstore_roof" ],
-    "fg": [ "dollarstore_roof_N", "dollarstore_roof_E", "dollarstore_roof_S", "dollarstore_roof_W" ],
+    "fg": [ "dollarstore_roof_N", "dollarstore_roof_W", "dollarstore_roof_S", "dollarstore_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/dollarstore_1/dollarstore_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/dollarstore_1/dollarstore_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "dollarstore_1" ],
-    "fg": [ "dollarstore_1_N", "dollarstore_1_E", "dollarstore_1_S", "dollarstore_1_W" ],
+    "fg": [ "dollarstore_1_N", "dollarstore_1_W", "dollarstore_1_S", "dollarstore_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "dollarstore_roof_1" ],
-    "fg": [ "dollarstore_roof_1_N", "dollarstore_roof_1_E", "dollarstore_roof_1_S", "dollarstore_roof_1_W" ],
+    "fg": [ "dollarstore_roof_1_N", "dollarstore_roof_1_W", "dollarstore_roof_1_S", "dollarstore_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/dump/dump.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/dump/dump.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "dump", "landfill" ],
-    "fg": [ "dump_N", "dump_E", "dump_S", "dump_W" ],
+    "fg": [ "dump_N", "dump_W", "dump_S", "dump_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/farm_lots/2silos/2silos.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/farm_lots/2silos/2silos.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "2silos" ],
-    "fg": [ "2silos_N", "2silos_E", "2silos_S", "2silos_W" ],
+    "fg": [ "2silos_N", "2silos_W", "2silos_S", "2silos_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "2silos_1" ],
-    "fg": [ "2silos_1_N", "2silos_1_E", "2silos_1_S", "2silos_1_W" ],
+    "fg": [ "2silos_1_N", "2silos_1_W", "2silos_1_S", "2silos_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "2silos_2" ],
-    "fg": [ "2silos_2_N", "2silos_2_E", "2silos_2_S", "2silos_2_W" ],
+    "fg": [ "2silos_2_N", "2silos_2_W", "2silos_2_S", "2silos_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "2silos_roof" ],
-    "fg": [ "2silos_roof_N", "2silos_roof_E", "2silos_roof_S", "2silos_roof_W" ],
+    "fg": [ "2silos_roof_N", "2silos_roof_W", "2silos_roof_S", "2silos_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/farm_lots/coop_chicken/coop_chicken.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/farm_lots/coop_chicken/coop_chicken.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "coop_chicken" ],
-    "fg": [ "coop_chicken_N", "coop_chicken_E", "coop_chicken_S", "coop_chicken_W" ],
+    "fg": [ "coop_chicken_N", "coop_chicken_W", "coop_chicken_S", "coop_chicken_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/farm_lots/house_farm/house_farm.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/farm_lots/house_farm/house_farm.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_farm" ],
-    "fg": [ "house_farm_N", "house_farm_E", "house_farm_S", "house_farm_W" ],
+    "fg": [ "house_farm_N", "house_farm_W", "house_farm_S", "house_farm_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_farm_roof" ],
-    "fg": [ "house_farm_roof_N", "house_farm_roof_E", "house_farm_roof_S", "house_farm_roof_W" ],
+    "fg": [ "house_farm_roof_N", "house_farm_roof_W", "house_farm_roof_S", "house_farm_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/fire_station/fire_station.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/fire_station/fire_station.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "fire_station" ],
-    "fg": [ "fire_station_N", "fire_station_E", "fire_station_S", "fire_station_W" ],
+    "fg": [ "fire_station_N", "fire_station_W", "fire_station_S", "fire_station_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "fire_station_roof" ],
-    "fg": [ "fire_station_roof_N", "fire_station_roof_E", "fire_station_roof_S", "fire_station_roof_W" ],
+    "fg": [ "fire_station_roof_N", "fire_station_roof_W", "fire_station_roof_S", "fire_station_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/fire_station_1/fire_station_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/fire_station_1/fire_station_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "fire_station_1" ],
-    "fg": [ "fire_station_1_N", "fire_station_1_E", "fire_station_1_S", "fire_station_1_W" ],
+    "fg": [ "fire_station_1_N", "fire_station_1_W", "fire_station_1_S", "fire_station_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "fire_station_roof_1" ],
-    "fg": [ "fire_station_roof_1_N", "fire_station_roof_1_E", "fire_station_roof_1_S", "fire_station_roof_1_W" ],
+    "fg": [ "fire_station_roof_1_N", "fire_station_roof_1_W", "fire_station_roof_1_S", "fire_station_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/fitness_gym/fitness_gym.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/fitness_gym/fitness_gym.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "gym_fitness" ],
-    "fg": [ "gym_fitness_N", "gym_fitness_E", "gym_fitness_S", "gym_fitness_W" ],
+    "fg": [ "gym_fitness_N", "gym_fitness_W", "gym_fitness_S", "gym_fitness_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "gym_fitness_roof" ],
-    "fg": [ "gym_fitness_roof_N", "gym_fitness_roof_E", "gym_fitness_roof_S", "gym_fitness_roof_W" ],
+    "fg": [ "gym_fitness_roof_N", "gym_fitness_roof_W", "gym_fitness_roof_S", "gym_fitness_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/fitness_gym_1/gym_fitness_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/fitness_gym_1/gym_fitness_1.json
@@ -9,9 +9,9 @@
     "id": [ "gym_fitness_2ndFloor_1" ],
     "fg": [
       "gym_fitness_2ndFloor_1_North",
-      "gym_fitness_2ndFloor_1_Wast",
+      "gym_fitness_2ndFloor_1_West",
       "gym_fitness_2ndFloor_1_South",
-      "gym_fitness_2ndFloor_1_Eest"
+      "gym_fitness_2ndFloor_1_East"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/fitness_gym_1/gym_fitness_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/fitness_gym_1/gym_fitness_1.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "gym_fitness_1" ],
-    "fg": [ "gym_fitness_1_N", "gym_fitness_1_E", "gym_fitness_1_S", "gym_fitness_1_W" ],
+    "fg": [ "gym_fitness_1_N", "gym_fitness_1_W", "gym_fitness_1_S", "gym_fitness_1_E" ],
     "bg": [  ],
     "rotates": true
   },
@@ -9,16 +9,16 @@
     "id": [ "gym_fitness_2ndFloor_1" ],
     "fg": [
       "gym_fitness_2ndFloor_1_North",
-      "gym_fitness_2ndFloor_1_East",
+      "gym_fitness_2ndFloor_1_Wast",
       "gym_fitness_2ndFloor_1_South",
-      "gym_fitness_2ndFloor_1_West"
+      "gym_fitness_2ndFloor_1_Eest"
     ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "gym_fitness_roof_1" ],
-    "fg": [ "gym_fitness_roof_1_N", "gym_fitness_roof_1_E", "gym_fitness_roof_1_S", "gym_fitness_roof_1_W" ],
+    "fg": [ "gym_fitness_roof_1_N", "gym_fitness_roof_1_W", "gym_fitness_roof_1_S", "gym_fitness_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/furniture store/furniture.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/furniture store/furniture.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "furniture" ],
-    "fg": [ "furniture_N", "furniture_E", "furniture_S", "furniture_W" ],
+    "fg": [ "furniture_N", "furniture_W", "furniture_S", "furniture_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "furniture_roof" ],
-    "fg": [ "furniture_roof_N", "furniture_roof_E", "furniture_roof_S", "furniture_roof_W" ],
+    "fg": [ "furniture_roof_N", "furniture_roof_W", "furniture_roof_S", "furniture_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "furniture_upper_roof" ],
-    "fg": [ "furniture_upper_roof_N", "furniture_upper_roof_E", "furniture_upper_roof_S", "furniture_upper_roof_W" ],
+    "fg": [ "furniture_upper_roof_N", "furniture_upper_roof_W", "furniture_upper_roof_S", "furniture_upper_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/gambling_hall/gambling_hall.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/gambling_hall/gambling_hall.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "gambling_hall" ],
-    "fg": [ "gambling_hall_N", "gambling_hall_E", "gambling_hall_S", "gambling_hall_W" ],
+    "fg": [ "gambling_hall_N", "gambling_hall_W", "gambling_hall_S", "gambling_hall_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "gambling_hall_roof" ],
-    "fg": [ "gambling_hall_roof_N", "gambling_hall_roof_E", "gambling_hall_roof_S", "gambling_hall_roof_W" ],
+    "fg": [ "gambling_hall_roof_N", "gambling_hall_roof_W", "gambling_hall_roof_S", "gambling_hall_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "gambling_hall_upper_roof" ],
     "fg": [
       "gambling_hall_upper_roof_N",
-      "gambling_hall_upper_roof_E",
+      "gambling_hall_upper_roof_W",
       "gambling_hall_upper_roof_S",
-      "gambling_hall_upper_roof_W"
+      "gambling_hall_upper_roof_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/gambling_hall_1/gambling_hall_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/gambling_hall_1/gambling_hall_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "gambling_hall_1" ],
-    "fg": [ "gambling_hall_1_N", "gambling_hall_1_E", "gambling_hall_1_S", "gambling_hall_1_W" ],
+    "fg": [ "gambling_hall_1_N", "gambling_hall_1_W", "gambling_hall_1_S", "gambling_hall_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "gambling_hall_roof_1" ],
-    "fg": [ "gambling_hall_roof_1_N", "gambling_hall_roof_1_E", "gambling_hall_roof_1_S", "gambling_hall_roof_1_W" ],
+    "fg": [ "gambling_hall_roof_1_N", "gambling_hall_roof_1_W", "gambling_hall_roof_1_S", "gambling_hall_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/garage_gas/garage_gas.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/garage_gas/garage_gas.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "garage_gas_2" ],
-    "fg": [ "garage_gas_2_N", "garage_gas_2_E", "garage_gas_2_S", "garage_gas_2_W" ],
+    "fg": [ "garage_gas_2_N", "garage_gas_2_W", "garage_gas_2_S", "garage_gas_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "garage_gas_3" ],
-    "fg": [ "garage_gas_3_N", "garage_gas_3_E", "garage_gas_3_S", "garage_gas_3_W" ],
+    "fg": [ "garage_gas_3_N", "garage_gas_3_W", "garage_gas_3_S", "garage_gas_3_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "garage_gas_roof_2" ],
-    "fg": [ "garage_gas_roof_2_N", "garage_gas_roof_2_E", "garage_gas_roof_2_S", "garage_gas_roof_2_W" ],
+    "fg": [ "garage_gas_roof_2_N", "garage_gas_roof_2_W", "garage_gas_roof_2_S", "garage_gas_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "garage_gas_roof_3" ],
-    "fg": [ "garage_gas_roof_3_N", "garage_gas_roof_3_E", "garage_gas_roof_3_S", "garage_gas_roof_3_W" ],
+    "fg": [ "garage_gas_roof_3_N", "garage_gas_roof_3_W", "garage_gas_roof_3_S", "garage_gas_roof_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/glassblower/glassblower.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/glassblower/glassblower.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "craft_shop" ],
-    "fg": [ "craft_shop_N", "craft_shop_E", "craft_shop_S", "craft_shop_W" ],
+    "fg": [ "craft_shop_N", "craft_shop_W", "craft_shop_S", "craft_shop_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "craft_shop_roof" ],
-    "fg": [ "craft_shop_roof_N", "craft_shop_roof_E", "craft_shop_roof_S", "craft_shop_roof_W" ],
+    "fg": [ "craft_shop_roof_N", "craft_shop_roof_W", "craft_shop_roof_S", "craft_shop_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "craft_shop_upper_roof" ],
-    "fg": [ "craft_shop_upper_roof_N", "craft_shop_upper_roof_E", "craft_shop_upper_roof_S", "craft_shop_upper_roof_W" ],
+    "fg": [ "craft_shop_upper_roof_N", "craft_shop_upper_roof_W", "craft_shop_upper_roof_S", "craft_shop_upper_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/gym/gym.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/gym/gym.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "gym" ],
-    "fg": [ "gym_N", "gym_E", "gym_S", "gym_W" ],
+    "fg": [ "gym_N", "gym_W", "gym_S", "gym_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "gym_roof" ],
-    "fg": [ "gym_roof_N", "gym_roof_E", "gym_roof_S", "gym_roof_W" ],
+    "fg": [ "gym_roof_N", "gym_roof_W", "gym_roof_S", "gym_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "gym_upper_roof" ],
-    "fg": [ "gym_upper_roof_N", "gym_upper_roof_E", "gym_upper_roof_S", "gym_upper_roof_W" ],
+    "fg": [ "gym_upper_roof_N", "gym_upper_roof_W", "gym_upper_roof_S", "gym_upper_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/headshop/headshop.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/headshop/headshop.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "headshop" ],
-    "fg": [ "headshop_N", "headshop_E", "headshop_S", "headshop_W" ],
+    "fg": [ "headshop_N", "headshop_W", "headshop_S", "headshop_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "headshop_roof" ],
-    "fg": [ "headshop_roof_N", "headshop_roof_E", "headshop_roof_S", "headshop_roof_W" ],
+    "fg": [ "headshop_roof_N", "headshop_roof_W", "headshop_roof_S", "headshop_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "headshop_upper_roof" ],
-    "fg": [ "headshop_upper_roof_N", "headshop_upper_roof_E", "headshop_upper_roof_S", "headshop_upper_roof_W" ],
+    "fg": [ "headshop_upper_roof_N", "headshop_upper_roof_W", "headshop_upper_roof_S", "headshop_upper_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/home_improvement/home_improvement.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/home_improvement/home_improvement.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "home_improvement" ],
-    "fg": [ "home_improvement_N", "home_improvement_E", "home_improvement_S", "home_improvement_W" ],
+    "fg": [ "home_improvement_N", "home_improvement_W", "home_improvement_S", "home_improvement_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "home_improvement_roof" ],
-    "fg": [ "home_improvement_roof_N", "home_improvement_roof_E", "home_improvement_roof_S", "home_improvement_roof_W" ],
+    "fg": [ "home_improvement_roof_N", "home_improvement_roof_W", "home_improvement_roof_S", "home_improvement_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/icecream_shop/icecream_shop.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/icecream_shop/icecream_shop.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "icecream_shop" ],
-    "fg": [ "icecream_shop_N", "icecream_shop_E", "icecream_shop_S", "icecream_shop_W" ],
+    "fg": [ "icecream_shop_N", "icecream_shop_W", "icecream_shop_S", "icecream_shop_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "icecream_shop_roof" ],
-    "fg": [ "icecream_shop_roof_N", "icecream_shop_roof_E", "icecream_shop_roof_S", "icecream_shop_roof_W" ],
+    "fg": [ "icecream_shop_roof_N", "icecream_shop_roof_W", "icecream_shop_roof_S", "icecream_shop_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/lancenter/lancenter.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/lancenter/lancenter.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "lancenter" ],
-    "fg": [ "lancenter_N", "lancenter_E", "lancenter_S", "lancenter_W" ],
+    "fg": [ "lancenter_N", "lancenter_W", "lancenter_S", "lancenter_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "lancenter_roof" ],
-    "fg": [ "lancenter_roof_N", "lancenter_roof_E", "lancenter_roof_S", "lancenter_roof_W" ],
+    "fg": [ "lancenter_roof_N", "lancenter_roof_W", "lancenter_roof_S", "lancenter_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/lancenter_1/lancenter_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/lancenter_1/lancenter_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "lancenter_1" ],
-    "fg": [ "lancenter_1_N", "lancenter_1_E", "lancenter_1_S", "lancenter_1_W" ],
+    "fg": [ "lancenter_1_N", "lancenter_1_W", "lancenter_1_S", "lancenter_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "lancenter_roof_1" ],
-    "fg": [ "lancenter_roof_1_N", "lancenter_roof_1_E", "lancenter_roof_1_S", "lancenter_roof_1_W" ],
+    "fg": [ "lancenter_roof_1_N", "lancenter_roof_1_W", "lancenter_roof_1_S", "lancenter_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/landscapingsupplyco/landscapingsupplyco.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/landscapingsupplyco/landscapingsupplyco.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "landscapingsupplyco_1a" ],
-    "fg": [ "landscapingsupplyco_1a_N", "landscapingsupplyco_1a_E", "landscapingsupplyco_1a_S", "landscapingsupplyco_1a_W" ],
+    "fg": [ "landscapingsupplyco_1a_N", "landscapingsupplyco_1a_W", "landscapingsupplyco_1a_S", "landscapingsupplyco_1a_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "landscapingsupplyco_1b" ],
-    "fg": [ "landscapingsupplyco_1b_N", "landscapingsupplyco_1b_E", "landscapingsupplyco_1b_S", "landscapingsupplyco_1b_W" ],
+    "fg": [ "landscapingsupplyco_1b_N", "landscapingsupplyco_1b_W", "landscapingsupplyco_1b_S", "landscapingsupplyco_1b_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "landscapingsupplyco_1b_roof" ],
     "fg": [
       "landscapingsupplyco_1b_roof_N",
-      "landscapingsupplyco_1b_roof_E",
+      "landscapingsupplyco_1b_roof_W",
       "landscapingsupplyco_1b_roof_S",
-      "landscapingsupplyco_1b_roof_W"
+      "landscapingsupplyco_1b_roof_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/medium_storage_units/medium_storage_units.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/medium_storage_units/medium_storage_units.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "medium_storage_units_1" ],
-    "fg": [ "medium_storage_units_1_N", "medium_storage_units_1_E", "medium_storage_units_1_S", "medium_storage_units_1_W" ],
+    "fg": [ "medium_storage_units_1_N", "medium_storage_units_1_W", "medium_storage_units_1_S", "medium_storage_units_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "medium_storage_units_2" ],
-    "fg": [ "medium_storage_units_2_N", "medium_storage_units_2_E", "medium_storage_units_2_S", "medium_storage_units_2_W" ],
+    "fg": [ "medium_storage_units_2_N", "medium_storage_units_2_W", "medium_storage_units_2_S", "medium_storage_units_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "medium_storage_units_roof_1" ],
     "fg": [
       "medium_storage_units_roof_1_N",
-      "medium_storage_units_roof_1_E",
+      "medium_storage_units_roof_1_W",
       "medium_storage_units_roof_1_S",
-      "medium_storage_units_roof_1_W"
+      "medium_storage_units_roof_1_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true
@@ -26,9 +26,9 @@
     "id": [ "medium_storage_units_roof_2" ],
     "fg": [
       "medium_storage_units_roof_2_N",
-      "medium_storage_units_roof_2_E",
+      "medium_storage_units_roof_2_W",
       "medium_storage_units_roof_2_S",
-      "medium_storage_units_roof_2_W"
+      "medium_storage_units_roof_2_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/metalworker/craft_shop_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/metalworker/craft_shop_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "craft_shop_1" ],
-    "fg": [ "craft_shop_1_N", "craft_shop_1_E", "craft_shop_1_S", "craft_shop_1_W" ],
+    "fg": [ "craft_shop_1_N", "craft_shop_1_W", "craft_shop_1_S", "craft_shop_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "craft_shop_roof_1" ],
-    "fg": [ "craft_shop_roof_1_N", "craft_shop_roof_1_E", "craft_shop_roof_1_S", "craft_shop_roof_1_W" ],
+    "fg": [ "craft_shop_roof_1_N", "craft_shop_roof_1_W", "craft_shop_roof_1_S", "craft_shop_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/mil_surplus/mil_surplus.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/mil_surplus/mil_surplus.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "mil_surplus" ],
-    "fg": [ "mil_surplus_N", "mil_surplus_E", "mil_surplus_S", "mil_surplus_W" ],
+    "fg": [ "mil_surplus_N", "mil_surplus_W", "mil_surplus_S", "mil_surplus_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "mil_surplus_roof" ],
-    "fg": [ "mil_surplus_roof_N", "mil_surplus_roof_E", "mil_surplus_roof_S", "mil_surplus_roof_W" ],
+    "fg": [ "mil_surplus_roof_N", "mil_surplus_roof_W", "mil_surplus_roof_S", "mil_surplus_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/mil_surplus_1/mil_surplus_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/mil_surplus_1/mil_surplus_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "mil_surplus_1" ],
-    "fg": [ "mil_surplus_1_N", "mil_surplus_1_E", "mil_surplus_1_S", "mil_surplus_1_W" ],
+    "fg": [ "mil_surplus_1_N", "mil_surplus_1_W", "mil_surplus_1_S", "mil_surplus_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "mil_surplus_roof_1" ],
-    "fg": [ "mil_surplus_roof_1_N", "mil_surplus_roof_1_E", "mil_surplus_roof_1_S", "mil_surplus_roof_1_W" ],
+    "fg": [ "mil_surplus_roof_1_N", "mil_surplus_roof_1_W", "mil_surplus_roof_1_S", "mil_surplus_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/mil_surplus_2/mil_surplus_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/mil_surplus_2/mil_surplus_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "mil_surplus_2" ],
-    "fg": [ "mil_surplus_2_N", "mil_surplus_2_E", "mil_surplus_2_S", "mil_surplus_2_W" ],
+    "fg": [ "mil_surplus_2_N", "mil_surplus_2_W", "mil_surplus_2_S", "mil_surplus_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "mil_surplus_roof_2" ],
-    "fg": [ "mil_surplus_roof_2_N", "mil_surplus_roof_2_E", "mil_surplus_roof_2_S", "mil_surplus_roof_2_W" ],
+    "fg": [ "mil_surplus_roof_2_N", "mil_surplus_roof_2_W", "mil_surplus_roof_2_S", "mil_surplus_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/mine_entrance/mine_entrance.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/mine_entrance/mine_entrance.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "mine_entrance" ],
-    "fg": [ "mine_entrance_N", "mine_entrance_E", "mine_entrance_S", "mine_entrance_W" ],
+    "fg": [ "mine_entrance_N", "mine_entrance_W", "mine_entrance_S", "mine_entrance_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -9,16 +9,16 @@
     "id": [ "mine_entrance_loading_zone" ],
     "fg": [
       "mine_entrance_loading_zone_N",
-      "mine_entrance_loading_zone_E",
+      "mine_entrance_loading_zone_W",
       "mine_entrance_loading_zone_S",
-      "mine_entrance_loading_zone_W"
+      "mine_entrance_loading_zone_E"
     ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "mine_entrance_roof" ],
-    "fg": [ "mine_entrance_roof_N", "mine_entrance_roof_E", "mine_entrance_roof_S", "mine_entrance_roof_W" ],
+    "fg": [ "mine_entrance_roof_N", "mine_entrance_roof_W", "mine_entrance_roof_S", "mine_entrance_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -26,9 +26,9 @@
     "id": [ "mine_entrance_loading_zone_roof" ],
     "fg": [
       "mine_entrance_loading_zone_roof_N",
-      "mine_entrance_loading_zone_roof_E",
+      "mine_entrance_loading_zone_roof_W",
       "mine_entrance_loading_zone_roof_S",
-      "mine_entrance_loading_zone_roof_W"
+      "mine_entrance_loading_zone_roof_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/moonshine_still/moonshine_still.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/moonshine_still/moonshine_still.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "moonshine_still" ],
-    "fg": [ "moonshine_still_N", "moonshine_still_E", "moonshine_still_S", "moonshine_still_W" ],
+    "fg": [ "moonshine_still_N", "moonshine_still_W", "moonshine_still_S", "moonshine_still_E" ],
     "bg": [ "forest_center" ],
     "rotates": true
   },
   {
     "id": [ "moonshine_still_roof" ],
-    "fg": [ "moonshine_still_roof_N", "moonshine_still_roof_E", "moonshine_still_roof_S", "moonshine_still_roof_W" ],
+    "fg": [ "moonshine_still_roof_N", "moonshine_still_roof_W", "moonshine_still_roof_S", "moonshine_still_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/moonshine_still_1/moonshine_still_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/moonshine_still_1/moonshine_still_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "moonshine_still_1" ],
-    "fg": [ "moonshine_still_1_N", "moonshine_still_1_E", "moonshine_still_1_S", "moonshine_still_1_W" ],
+    "fg": [ "moonshine_still_1_N", "moonshine_still_1_W", "moonshine_still_1_S", "moonshine_still_1_E" ],
     "bg": [ "forest_center" ],
     "rotates": true
   },
   {
     "id": [ "moonshine_still_roof_1" ],
-    "fg": [ "moonshine_still_roof_1_N", "moonshine_still_roof_1_E", "moonshine_still_roof_1_S", "moonshine_still_roof_1_W" ],
+    "fg": [ "moonshine_still_roof_1_N", "moonshine_still_roof_1_W", "moonshine_still_roof_1_S", "moonshine_still_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/moonshine_still_2/moonshine_still_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/moonshine_still_2/moonshine_still_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "moonshine_still_2" ],
-    "fg": [ "moonshine_still_2_N", "moonshine_still_2_E", "moonshine_still_2_S", "moonshine_still_2_W" ],
+    "fg": [ "moonshine_still_2_N", "moonshine_still_2_W", "moonshine_still_2_S", "moonshine_still_2_E" ],
     "bg": [ "forest_center" ],
     "rotates": true
   },
   {
     "id": [ "moonshine_still_roof_2" ],
-    "fg": [ "moonshine_still_roof_2_N", "moonshine_still_roof_2_E", "moonshine_still_roof_2_S", "moonshine_still_roof_2_W" ],
+    "fg": [ "moonshine_still_roof_2_N", "moonshine_still_roof_2_W", "moonshine_still_roof_2_S", "moonshine_still_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/mortuary/mortuary.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/mortuary/mortuary.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "mortuary" ],
-    "fg": [ "mortuary_N", "mortuary_E", "mortuary_S", "mortuary_W" ],
+    "fg": [ "mortuary_N", "mortuary_W", "mortuary_S", "mortuary_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "mortuary_roof" ],
-    "fg": [ "mortuary_roof_N", "mortuary_roof_E", "mortuary_roof_S", "mortuary_roof_W" ],
+    "fg": [ "mortuary_roof_N", "mortuary_roof_W", "mortuary_roof_S", "mortuary_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/museum/museum.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/museum/museum.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "museum" ],
-    "fg": [ "museum_N", "museum_E", "museum_S", "museum_W" ],
+    "fg": [ "museum_N", "museum_W", "museum_S", "museum_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "museum_roof" ],
-    "fg": [ "museum_roof_N", "museum_roof_E", "museum_roof_S", "museum_roof_W" ],
+    "fg": [ "museum_roof_N", "museum_roof_W", "museum_roof_S", "museum_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/music_venue/music_venue.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/music_venue/music_venue.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "music_venue" ],
-    "fg": [ "music_venue_N", "music_venue_E", "music_venue_S", "music_venue_W" ],
+    "fg": [ "music_venue_N", "music_venue_W", "music_venue_S", "music_venue_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "music_venue_roof" ],
-    "fg": [ "music_venue_roof_N", "music_venue_roof_E", "music_venue_roof_S", "music_venue_roof_W" ],
+    "fg": [ "music_venue_roof_N", "music_venue_roof_W", "music_venue_roof_S", "music_venue_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/music_venue_1/music_venue_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/music_venue_1/music_venue_1.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "music_venue_1" ],
-    "fg": [ "music_venue_1_N", "music_venue_1_E", "music_venue_1_S", "music_venue_1_W" ],
+    "fg": [ "music_venue_1_N", "music_venue_1_W", "music_venue_1_S", "music_venue_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "music_venue_1_roof" ],
-    "fg": [ "music_venue_1_roof_N", "music_venue_1_roof_E", "music_venue_1_roof_S", "music_venue_1_roof_W" ],
+    "fg": [ "music_venue_1_roof_N", "music_venue_1_roof_W", "music_venue_1_roof_S", "music_venue_1_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "music_venue_1_roof_top" ],
-    "fg": [ "music_venue_1_roof_top_N", "music_venue_1_roof_top_E", "music_venue_1_roof_top_S", "music_venue_1_roof_top_W" ],
+    "fg": [ "music_venue_1_roof_top_N", "music_venue_1_roof_top_W", "music_venue_1_roof_top_S", "music_venue_1_roof_top_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/nature_trail/naturetrail.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/nature_trail/naturetrail.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "NatureTrail_1a" ],
-    "fg": [ "naturetrail_1a_N", "naturetrail_1a_E", "naturetrail_1a_S", "naturetrail_1a_W" ],
+    "fg": [ "naturetrail_1a_N", "naturetrail_1a_W", "naturetrail_1a_S", "naturetrail_1a_E" ],
     "bg": [ "forest_center" ],
     "rotates": true
   },
   {
     "id": [ "NatureTrail_1b" ],
-    "fg": [ "naturetrail_1b_N", "naturetrail_1b_E", "naturetrail_1b_S", "naturetrail_1b_W" ],
+    "fg": [ "naturetrail_1b_N", "naturetrail_1b_W", "naturetrail_1b_S", "naturetrail_1b_E" ],
     "bg": [ "forest_center" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/office_cubical/office_cubical.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/office_cubical/office_cubical.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "office_cubical" ],
-    "fg": [ "office_cubical_N", "office_cubical_E", "office_cubical_S", "office_cubical_W" ],
+    "fg": [ "office_cubical_N", "office_cubical_W", "office_cubical_S", "office_cubical_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "office_cubical_roof" ],
-    "fg": [ "office_cubical_roof_N", "office_cubical_roof_E", "office_cubical_roof_S", "office_cubical_roof_W" ],
+    "fg": [ "office_cubical_roof_N", "office_cubical_roof_W", "office_cubical_roof_S", "office_cubical_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/office_cubical_1/office_cubical_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/office_cubical_1/office_cubical_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "office_cubical_1" ],
-    "fg": [ "office_cubical_1_N", "office_cubical_1_E", "office_cubical_1_S", "office_cubical_1_W" ],
+    "fg": [ "office_cubical_1_N", "office_cubical_1_W", "office_cubical_1_S", "office_cubical_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "office_cubical_roof_1" ],
-    "fg": [ "office_cubical_roof_1_N", "office_cubical_roof_1_E", "office_cubical_roof_1_S", "office_cubical_roof_1_W" ],
+    "fg": [ "office_cubical_roof_1_N", "office_cubical_roof_1_W", "office_cubical_roof_1_S", "office_cubical_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/office_doctor/office_doctor.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/office_doctor/office_doctor.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "office_doctor" ],
-    "fg": [ "office_doctor_N", "office_doctor_E", "office_doctor_S", "office_doctor_W" ],
+    "fg": [ "office_doctor_N", "office_doctor_W", "office_doctor_S", "office_doctor_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "office_doctor_roof" ],
-    "fg": [ "office_doctor_roof_N", "office_doctor_roof_E", "office_doctor_roof_S", "office_doctor_roof_W" ],
+    "fg": [ "office_doctor_roof_N", "office_doctor_roof_W", "office_doctor_roof_S", "office_doctor_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/office_doctor_1/office_doctor_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/office_doctor_1/office_doctor_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "office_doctor_1" ],
-    "fg": [ "office_doctor_1_N", "office_doctor_1_E", "office_doctor_1_S", "office_doctor_1_W" ],
+    "fg": [ "office_doctor_1_N", "office_doctor_1_W", "office_doctor_1_S", "office_doctor_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "office_doctor_roof_1" ],
-    "fg": [ "office_doctor_roof_1_N", "office_doctor_roof_1_E", "office_doctor_roof_1_S", "office_doctor_roof_1_W" ],
+    "fg": [ "office_doctor_roof_1_N", "office_doctor_roof_1_W", "office_doctor_roof_1_S", "office_doctor_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/office_doctor_2/office_doctor_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/office_doctor_2/office_doctor_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "office_doctor_2" ],
-    "fg": [ "office_doctor_2_N", "office_doctor_2_E", "office_doctor_2_S", "office_doctor_2_W" ],
+    "fg": [ "office_doctor_2_N", "office_doctor_2_W", "office_doctor_2_S", "office_doctor_2_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "office_doctor_roof_2" ],
-    "fg": [ "office_doctor_roof_2_N", "office_doctor_roof_2_E", "office_doctor_roof_2_S", "office_doctor_roof_2_W" ],
+    "fg": [ "office_doctor_roof_2_N", "office_doctor_roof_2_W", "office_doctor_roof_2_S", "office_doctor_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "office_doctor_upper_roof_2" ],
     "fg": [
       "office_doctor_upper_roof_2_N",
-      "office_doctor_upper_roof_2_E",
+      "office_doctor_upper_roof_2_W",
       "office_doctor_upper_roof_2_S",
-      "office_doctor_upper_roof_2_W"
+      "office_doctor_upper_roof_2_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/paintball_field/paintball_field.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/paintball_field/paintball_field.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "paintball_field" ],
-    "fg": [ "paintball_field_N", "paintball_field_E", "paintball_field_S", "paintball_field_W" ],
+    "fg": [ "paintball_field_N", "paintball_field_W", "paintball_field_S", "paintball_field_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "paintball_field_roof" ],
-    "fg": [ "paintball_field_roof_N", "paintball_field_roof_E", "paintball_field_roof_S", "paintball_field_roof_W" ],
+    "fg": [ "paintball_field_roof_N", "paintball_field_roof_W", "paintball_field_roof_S", "paintball_field_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/paintball_field_1/paintball_field_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/paintball_field_1/paintball_field_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "paintball_field_1" ],
-    "fg": [ "paintball_field_1_N", "paintball_field_1_E", "paintball_field_1_S", "paintball_field_1_W" ],
+    "fg": [ "paintball_field_1_N", "paintball_field_1_W", "paintball_field_1_S", "paintball_field_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "paintball_field_roof_1" ],
-    "fg": [ "paintball_field_roof_1_N", "paintball_field_roof_1_E", "paintball_field_roof_1_S", "paintball_field_roof_1_W" ],
+    "fg": [ "paintball_field_roof_1_N", "paintball_field_roof_1_W", "paintball_field_roof_1_S", "paintball_field_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/parking_garage/parking_garage.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/parking_garage/parking_garage.json
@@ -1,55 +1,55 @@
 [
   {
     "id": [ "parking_garage_down_0" ],
-    "fg": [ "parking_garage_down_0_N", "parking_garage_down_0_E", "parking_garage_down_0_S", "parking_garage_down_0_W" ],
+    "fg": [ "parking_garage_down_0_N", "parking_garage_down_0_W", "parking_garage_down_0_S", "parking_garage_down_0_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "parking_garage_down_1" ],
-    "fg": [ "parking_garage_down_1_N", "parking_garage_down_1_E", "parking_garage_down_1_S", "parking_garage_down_1_W" ],
+    "fg": [ "parking_garage_down_1_N", "parking_garage_down_1_W", "parking_garage_down_1_S", "parking_garage_down_1_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "parking_garage_0_0" ],
-    "fg": [ "parking_garage_0_0_N", "parking_garage_0_0_E", "parking_garage_0_0_S", "parking_garage_0_0_W" ],
+    "fg": [ "parking_garage_0_0_N", "parking_garage_0_0_W", "parking_garage_0_0_S", "parking_garage_0_0_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "parking_garage_0_1" ],
-    "fg": [ "parking_garage_0_1_N", "parking_garage_0_1_E", "parking_garage_0_1_S", "parking_garage_0_1_W" ],
+    "fg": [ "parking_garage_0_1_N", "parking_garage_0_1_W", "parking_garage_0_1_S", "parking_garage_0_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "parking_garage_1_0", "parking_garage_2_0", "parking_garage_roof_0" ],
-    "fg": [ "parking_garage_1_0_N", "parking_garage_1_0_E", "parking_garage_1_0_S", "parking_garage_1_0_W" ],
+    "fg": [ "parking_garage_1_0_N", "parking_garage_1_0_W", "parking_garage_1_0_S", "parking_garage_1_0_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "parking_garage_1_1" ],
-    "fg": [ "parking_garage_1_1_N", "parking_garage_1_1_E", "parking_garage_1_1_S", "parking_garage_1_1_W" ],
+    "fg": [ "parking_garage_1_1_N", "parking_garage_1_1_W", "parking_garage_1_1_S", "parking_garage_1_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "parking_garage_2_1" ],
-    "fg": [ "parking_garage_2_1_N", "parking_garage_2_1_E", "parking_garage_2_1_S", "parking_garage_2_1_W" ],
+    "fg": [ "parking_garage_2_1_N", "parking_garage_2_1_W", "parking_garage_2_1_S", "parking_garage_2_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "parking_garage_roof_1" ],
-    "fg": [ "parking_garage_roof_1_N", "parking_garage_roof_1_E", "parking_garage_roof_1_S", "parking_garage_roof_1_W" ],
+    "fg": [ "parking_garage_roof_1_N", "parking_garage_roof_1_W", "parking_garage_roof_1_S", "parking_garage_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "parking_garage_roof_top" ],
-    "fg": [ "parking_garage_roof_top_N", "parking_garage_roof_top_E", "parking_garage_roof_top_S", "parking_garage_roof_top_W" ],
+    "fg": [ "parking_garage_roof_top_N", "parking_garage_roof_top_W", "parking_garage_roof_top_S", "parking_garage_roof_top_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/parks/PublicPond/PublicPond.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/parks/PublicPond/PublicPond.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "PublicPond_1a" ],
-    "fg": [ "publicpond_1a_N", "publicpond_1a_E", "publicpond_1a_S", "publicpond_1a_W" ],
+    "fg": [ "publicpond_1a_N", "publicpond_1a_W", "publicpond_1a_S", "publicpond_1a_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "PublicPond_1b" ],
-    "fg": [ "publicpond_1b_N", "publicpond_1b_E", "publicpond_1b_S", "publicpond_1b_W" ],
+    "fg": [ "publicpond_1b_N", "publicpond_1b_W", "publicpond_1b_S", "publicpond_1b_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/parks/botanical_garden/botanicalgarden.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/parks/botanical_garden/botanicalgarden.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "BotanicalGarden_1a" ],
-    "fg": [ "botanicalgarden_1a_N", "botanicalgarden_1a_E", "botanicalgarden_1a_S", "botanicalgarden_1a_W" ],
+    "fg": [ "botanicalgarden_1a_N", "botanicalgarden_1a_W", "botanicalgarden_1a_S", "botanicalgarden_1a_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "BotanicalGarden_1a_roof" ],
-    "fg": [ "botanicalgarden_1a_roof_N", "botanicalgarden_1a_roof_E", "botanicalgarden_1a_roof_S", "botanicalgarden_1a_roof_W" ],
+    "fg": [ "botanicalgarden_1a_roof_N", "botanicalgarden_1a_roof_W", "botanicalgarden_1a_roof_S", "botanicalgarden_1a_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "BotanicalGarden_1b" ],
-    "fg": [ "botanicalgarden_1b_N", "botanicalgarden_1b_E", "botanicalgarden_1b_S", "botanicalgarden_1b_W" ],
+    "fg": [ "botanicalgarden_1b_N", "botanicalgarden_1b_W", "botanicalgarden_1b_S", "botanicalgarden_1b_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "BotanicalGarden_1b_roof" ],
-    "fg": [ "botanicalgarden_1b_roof_N", "botanicalgarden_1b_roof_E", "botanicalgarden_1b_roof_S", "botanicalgarden_1b_roof_W" ],
+    "fg": [ "botanicalgarden_1b_roof_N", "botanicalgarden_1b_roof_W", "botanicalgarden_1b_roof_S", "botanicalgarden_1b_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/parks/parks.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/parks/parks.json
@@ -7,7 +7,7 @@
   },
   {
     "id": [ "communitygarden" ],
-    "fg": [ "communitygarden_N", "communitygarden_E", "communitygarden_S", "communitygarden_W" ],
+    "fg": [ "communitygarden_N", "communitygarden_W", "communitygarden_S", "communitygarden_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -19,49 +19,49 @@
   },
   {
     "id": [ "communitygarden_3" ],
-    "fg": [ "communitygarden_3_N", "communitygarden_3_E", "communitygarden_3_S", "communitygarden_3_W" ],
+    "fg": [ "communitygarden_3_N", "communitygarden_3_W", "communitygarden_3_S", "communitygarden_3_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "baskeball_court" ],
-    "fg": [ "baskeball_court_N", "baskeball_court_E", "baskeball_court_S", "baskeball_court_W" ],
+    "fg": [ "baskeball_court_N", "baskeball_court_W", "baskeball_court_S", "baskeball_court_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "tennis_court" ],
-    "fg": [ "tennis_court_N", "tennis_court_E", "tennis_court_S", "tennis_court_W" ],
+    "fg": [ "tennis_court_N", "tennis_court_W", "tennis_court_S", "tennis_court_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "volleyball_court" ],
-    "fg": [ "volleyball_court_N", "volleyball_court_E", "volleyball_court_S", "volleyball_court_W" ],
+    "fg": [ "volleyball_court_N", "volleyball_court_W", "volleyball_court_S", "volleyball_court_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "dog_park" ],
-    "fg": [ "dog_park_N", "dog_park_E", "dog_park_S", "dog_park_W" ],
+    "fg": [ "dog_park_N", "dog_park_W", "dog_park_S", "dog_park_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "park_maze" ],
-    "fg": [ "park_maze_N", "park_maze_E", "park_maze_S", "park_maze_W" ],
+    "fg": [ "park_maze_N", "park_maze_W", "park_maze_S", "park_maze_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "park_maze_2" ],
-    "fg": [ "park_maze_2_N", "park_maze_2_E", "park_maze_2_S", "park_maze_2_W" ],
+    "fg": [ "park_maze_2_N", "park_maze_2_W", "park_maze_2_S", "park_maze_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "park" ],
-    "fg": [ "park_N", "park_E", "park_S", "park_W" ],
+    "fg": [ "park_N", "park_W", "park_S", "park_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -73,19 +73,19 @@
   },
   {
     "id": [ "park_3" ],
-    "fg": [ "park_3_N", "park_3_E", "park_3_S", "park_3_W" ],
+    "fg": [ "park_3_N", "park_3_W", "park_3_S", "park_3_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "park_4" ],
-    "fg": [ "park_4_N", "park_4_E", "park_4_S", "park_4_W" ],
+    "fg": [ "park_4_N", "park_4_W", "park_4_S", "park_4_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "park_5" ],
-    "fg": [ "park_5_N", "park_5_E", "park_5_S", "park_5_W" ],
+    "fg": [ "park_5_N", "park_5_W", "park_5_S", "park_5_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -97,19 +97,19 @@
   },
   {
     "id": [ "park_7" ],
-    "fg": [ "park_7_N", "park_7_E", "park_7_S", "park_7_W" ],
+    "fg": [ "park_7_N", "park_7_W", "park_7_S", "park_7_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "playground" ],
-    "fg": [ "playground_N", "playground_E", "playground_S", "playground_W" ],
+    "fg": [ "playground_N", "playground_W", "playground_S", "playground_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "playground_1" ],
-    "fg": [ "playground_1_N", "playground_1_E", "playground_1_S", "playground_1_W" ],
+    "fg": [ "playground_1_N", "playground_1_W", "playground_1_S", "playground_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pavilion/pavilion.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pavilion/pavilion.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "pavilion" ],
-    "fg": [ "pavilion_N", "pavilion_E", "pavilion_S", "pavilion_W" ],
+    "fg": [ "pavilion_N", "pavilion_W", "pavilion_S", "pavilion_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "pavilion_roof" ],
-    "fg": [ "pavilion_roof_N", "pavilion_roof_E", "pavilion_roof_S", "pavilion_roof_W" ],
+    "fg": [ "pavilion_roof_N", "pavilion_roof_W", "pavilion_roof_S", "pavilion_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pavilion_1/pavilion_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pavilion_1/pavilion_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "pavilion_1" ],
-    "fg": [ "pavilion_1_N", "pavilion_1_E", "pavilion_1_S", "pavilion_1_W" ],
+    "fg": [ "pavilion_1_N", "pavilion_1_W", "pavilion_1_S", "pavilion_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "pavilion_roof_1" ],
-    "fg": [ "pavilion_roof_1_N", "pavilion_roof_1_E", "pavilion_roof_1_S", "pavilion_roof_1_W" ],
+    "fg": [ "pavilion_roof_1_N", "pavilion_roof_1_W", "pavilion_roof_1_S", "pavilion_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pawn/pawn.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pawn/pawn.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "pawn" ],
-    "fg": [ "pawn_N", "pawn_E", "pawn_S", "pawn_W" ],
+    "fg": [ "pawn_N", "pawn_W", "pawn_S", "pawn_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "pawn_roof" ],
-    "fg": [ "pawn_roof_N", "pawn_roof_E", "pawn_roof_S", "pawn_roof_W" ],
+    "fg": [ "pawn_roof_N", "pawn_roof_W", "pawn_roof_S", "pawn_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pawn_1/pawn_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pawn_1/pawn_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "pawn_1" ],
-    "fg": [ "pawn_1_N", "pawn_1_E", "pawn_1_S", "pawn_1_W" ],
+    "fg": [ "pawn_1_N", "pawn_1_W", "pawn_1_S", "pawn_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "pawn_roof_1" ],
-    "fg": [ "pawn_roof_1_N", "pawn_roof_1_E", "pawn_roof_1_S", "pawn_roof_1_W" ],
+    "fg": [ "pawn_roof_1_N", "pawn_roof_1_W", "pawn_roof_1_S", "pawn_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pawn_pf/pawn_pf.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pawn_pf/pawn_pf.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "pawn_pf" ],
-    "fg": [ "pawn_pf_N", "pawn_pf_E", "pawn_pf_S", "pawn_pf_W" ],
+    "fg": [ "pawn_pf_N", "pawn_pf_W", "pawn_pf_S", "pawn_pf_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "pawn_pf_roof" ],
-    "fg": [ "pawn_pf_roof_N", "pawn_pf_roof_E", "pawn_pf_roof_S", "pawn_pf_roof_W" ],
+    "fg": [ "pawn_pf_roof_N", "pawn_pf_roof_W", "pawn_pf_roof_S", "pawn_pf_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "pawn_pf_under" ],
-    "fg": [ "pawn_pf_under_N", "pawn_pf_under_E", "pawn_pf_under_S", "pawn_pf_under_W" ],
+    "fg": [ "pawn_pf_under_N", "pawn_pf_under_W", "pawn_pf_under_S", "pawn_pf_under_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pharm/s_pharm.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pharm/s_pharm.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_pharm" ],
-    "fg": [ "s_pharm_N", "s_pharm_E", "s_pharm_S", "s_pharm_W" ],
+    "fg": [ "s_pharm_N", "s_pharm_W", "s_pharm_S", "s_pharm_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_pharm_roof" ],
-    "fg": [ "s_pharm_roof_N", "s_pharm_roof_E", "s_pharm_roof_S", "s_pharm_roof_W" ],
+    "fg": [ "s_pharm_roof_N", "s_pharm_roof_W", "s_pharm_roof_S", "s_pharm_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pharm_1/pharm_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pharm_1/pharm_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_pharm_1" ],
-    "fg": [ "s_pharm_1_N", "s_pharm_1_E", "s_pharm_1_S", "s_pharm_1_W" ],
+    "fg": [ "s_pharm_1_N", "s_pharm_1_W", "s_pharm_1_S", "s_pharm_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_pharm_roof_1" ],
-    "fg": [ "s_pharm_roof_1_N", "s_pharm_roof_1_E", "s_pharm_roof_1_S", "s_pharm_roof_1_W" ],
+    "fg": [ "s_pharm_roof_1_N", "s_pharm_roof_1_W", "s_pharm_roof_1_S", "s_pharm_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/police/police.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/police/police.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "police" ],
-    "fg": [ "police_N", "police_E", "police_S", "police_W" ],
+    "fg": [ "police_N", "police_W", "police_S", "police_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "police_roof" ],
-    "fg": [ "police_roof_N", "police_roof_E", "police_roof_S", "police_roof_W" ],
+    "fg": [ "police_roof_N", "police_roof_W", "police_roof_S", "police_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/police_1/police_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/police_1/police_1.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "police_1" ],
-    "fg": [ "police_1_N", "police_1_E", "police_1_S", "police_1_W" ],
+    "fg": [ "police_1_N", "police_1_W", "police_1_S", "police_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "police_2ndfloor_1" ],
-    "fg": [ "police_2ndfloor_1_N", "police_2ndfloor_1_E", "police_2ndfloor_1_S", "police_2ndfloor_1_W" ],
+    "fg": [ "police_2ndfloor_1_N", "police_2ndfloor_1_W", "police_2ndfloor_1_S", "police_2ndfloor_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "police_roof_1" ],
-    "fg": [ "police_roof_1_N", "police_roof_1_E", "police_roof_1_S", "police_roof_1_W" ],
+    "fg": [ "police_roof_1_N", "police_roof_1_W", "police_roof_1_S", "police_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/police_2/police_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/police_2/police_2.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "police_2" ],
-    "fg": [ "police_2_N", "police_2_E", "police_2_S", "police_2_W" ],
+    "fg": [ "police_2_N", "police_2_W", "police_2_S", "police_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "police_roof_2" ],
-    "fg": [ "police_roof_2_N", "police_roof_2_E", "police_roof_2_S", "police_roof_2_W" ],
+    "fg": [ "police_roof_2_N", "police_roof_2_W", "police_roof_2_S", "police_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "police_2ndfloor_2" ],
-    "fg": [ "police_upper_roof_2_N", "police_upper_roof_2_E", "police_upper_roof_2_S", "police_upper_roof_2_W" ],
+    "fg": [ "police_upper_roof_2_N", "police_upper_roof_2_W", "police_upper_roof_2_S", "police_upper_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pool/pool.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pool/pool.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "pool" ],
-    "fg": [ "pool_N", "pool_E", "pool_S", "pool_W" ],
+    "fg": [ "pool_N", "pool_W", "pool_S", "pool_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "pool_roof" ],
-    "fg": [ "pool_roof_N", "pool_roof_E", "pool_roof_S", "pool_roof_W" ],
+    "fg": [ "pool_roof_N", "pool_roof_W", "pool_roof_S", "pool_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pool_1/pool_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pool_1/pool_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "pool_1" ],
-    "fg": [ "pool_1_N", "pool_1_E", "pool_1_S", "pool_1_W" ],
+    "fg": [ "pool_1_N", "pool_1_W", "pool_1_S", "pool_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "pool_roof_1" ],
-    "fg": [ "pool_roof_1_N", "pool_roof_1_E", "pool_roof_1_S", "pool_roof_1_W" ],
+    "fg": [ "pool_roof_1_N", "pool_roof_1_W", "pool_roof_1_S", "pool_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pool_2/pool_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pool_2/pool_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "pool_2" ],
-    "fg": [ "pool_2_N", "pool_2_E", "pool_2_S", "pool_2_W" ],
+    "fg": [ "pool_2_N", "pool_2_W", "pool_2_S", "pool_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "pool_roof_2" ],
-    "fg": [ "pool_roof_2_N", "pool_roof_2_E", "pool_roof_2_S", "pool_roof_2_W" ],
+    "fg": [ "pool_roof_2_N", "pool_roof_2_W", "pool_roof_2_S", "pool_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pool_3/pool_3.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pool_3/pool_3.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "pool_3" ],
-    "fg": [ "pool_3_N", "pool_3_E", "pool_3_S", "pool_3_W" ],
+    "fg": [ "pool_3_N", "pool_3_W", "pool_3_S", "pool_3_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "pool_roof_3" ],
-    "fg": [ "pool_roof_3_N", "pool_roof_3_E", "pool_roof_3_S", "pool_roof_3_W" ],
+    "fg": [ "pool_roof_3_N", "pool_roof_3_W", "pool_roof_3_S", "pool_roof_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pool_4/pool_4.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pool_4/pool_4.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "pool_4" ],
-    "fg": [ "pool_4_N", "pool_4_E", "pool_4_S", "pool_4_W" ],
+    "fg": [ "pool_4_N", "pool_4_W", "pool_4_S", "pool_4_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "pool_roof_4" ],
-    "fg": [ "pool_roof_4_N", "pool_roof_4_E", "pool_roof_4_S", "pool_roof_4_W" ],
+    "fg": [ "pool_roof_4_N", "pool_roof_4_W", "pool_roof_4_S", "pool_roof_4_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pool_5/pool_5.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pool_5/pool_5.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "pool_5" ],
-    "fg": [ "pool_5_N", "pool_5_E", "pool_5_S", "pool_5_W" ],
+    "fg": [ "pool_5_N", "pool_5_W", "pool_5_S", "pool_5_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pool_6/pool_6.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pool_6/pool_6.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "pool_6" ],
-    "fg": [ "pool_6_N", "pool_6_E", "pool_6_S", "pool_6_W" ],
+    "fg": [ "pool_6_N", "pool_6_W", "pool_6_S", "pool_6_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/post_office/post_office.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/post_office/post_office.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "post_office" ],
-    "fg": [ "post_office_N", "post_office_E", "post_office_S", "post_office_W" ],
+    "fg": [ "post_office_N", "post_office_W", "post_office_S", "post_office_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "post_office_roof" ],
-    "fg": [ "post_office_roof_N", "post_office_roof_E", "post_office_roof_S", "post_office_roof_W" ],
+    "fg": [ "post_office_roof_N", "post_office_roof_W", "post_office_roof_S", "post_office_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/post_office_1/post_office_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/post_office_1/post_office_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "post_office_1" ],
-    "fg": [ "post_office_1_N", "post_office_1_E", "post_office_1_S", "post_office_1_W" ],
+    "fg": [ "post_office_1_N", "post_office_1_W", "post_office_1_S", "post_office_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "post_office_roof_1" ],
-    "fg": [ "post_office_roof_1_N", "post_office_roof_1_E", "post_office_roof_1_S", "post_office_roof_1_W" ],
+    "fg": [ "post_office_roof_1_N", "post_office_roof_1_W", "post_office_roof_1_S", "post_office_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/pottery_sewing/craft_shop_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/pottery_sewing/craft_shop_2.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "craft_shop_2" ],
-    "fg": [ "craft_shop_2_N", "craft_shop_2_E", "craft_shop_2_S", "craft_shop_2_W" ],
+    "fg": [ "craft_shop_2_N", "craft_shop_2_W", "craft_shop_2_S", "craft_shop_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "craft_shop_2ndfloor_2" ],
-    "fg": [ "craft_shop_2ndfloor_2_N", "craft_shop_2ndfloor_2_E", "craft_shop_2ndfloor_2_S", "craft_shop_2ndfloor_2_W" ],
+    "fg": [ "craft_shop_2ndfloor_2_N", "craft_shop_2ndfloor_2_W", "craft_shop_2ndfloor_2_S", "craft_shop_2ndfloor_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "craft_shop_roof_2" ],
-    "fg": [ "craft_shop_roof_2_N", "craft_shop_roof_2_E", "craft_shop_roof_2_S", "craft_shop_roof_2_W" ],
+    "fg": [ "craft_shop_roof_2_N", "craft_shop_roof_2_W", "craft_shop_roof_2_S", "craft_shop_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/recyclecenter/recyclecenter.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/recyclecenter/recyclecenter.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "recyclecenter" ],
-    "fg": [ "recyclecenter_N", "recyclecenter_E", "recyclecenter_S", "recyclecenter_W" ],
+    "fg": [ "recyclecenter_N", "recyclecenter_W", "recyclecenter_S", "recyclecenter_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "recyclecenter_roof" ],
-    "fg": [ "recyclecenter_roof_N", "recyclecenter_roof_E", "recyclecenter_roof_S", "recyclecenter_roof_W" ],
+    "fg": [ "recyclecenter_roof_N", "recyclecenter_roof_W", "recyclecenter_roof_S", "recyclecenter_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/recyclecenter_1/recyclecenter_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/recyclecenter_1/recyclecenter_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "recyclecenter_1" ],
-    "fg": [ "recyclecenter_1_N", "recyclecenter_1_E", "recyclecenter_1_S", "recyclecenter_1_W" ],
+    "fg": [ "recyclecenter_1_N", "recyclecenter_1_W", "recyclecenter_1_S", "recyclecenter_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "recyclecenter_roof_1" ],
-    "fg": [ "recyclecenter_roof_1_N", "recyclecenter_roof_1_E", "recyclecenter_roof_1_S", "recyclecenter_roof_1_W" ],
+    "fg": [ "recyclecenter_roof_1_N", "recyclecenter_roof_1_W", "recyclecenter_roof_1_S", "recyclecenter_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/recyclecenter_2/recyclecenter_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/recyclecenter_2/recyclecenter_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "recyclecenter_2" ],
-    "fg": [ "recyclecenter_2_N", "recyclecenter_2_E", "recyclecenter_2_S", "recyclecenter_2_W" ],
+    "fg": [ "recyclecenter_2_N", "recyclecenter_2_W", "recyclecenter_2_S", "recyclecenter_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "recyclecenter_roof_2" ],
-    "fg": [ "recyclecenter_roof_2_N", "recyclecenter_roof_2_E", "recyclecenter_roof_2_S", "recyclecenter_roof_2_W" ],
+    "fg": [ "recyclecenter_roof_2_N", "recyclecenter_roof_2_W", "recyclecenter_roof_2_S", "recyclecenter_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/roadstop/roadstop.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/roadstop/roadstop.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "roadstop" ],
-    "fg": [ "roadstop_N", "roadstop_E", "roadstop_S", "roadstop_W" ],
+    "fg": [ "roadstop_N", "roadstop_W", "roadstop_S", "roadstop_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "roadstop_roof" ],
-    "fg": [ "roadstop_roof_N", "roadstop_roof_E", "roadstop_roof_S", "roadstop_roof_W" ],
+    "fg": [ "roadstop_roof_N", "roadstop_roof_W", "roadstop_roof_S", "roadstop_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/roadstop_a/roadstop_a.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/roadstop_a/roadstop_a.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "roadstop_a" ],
-    "fg": [ "roadstop_a_N", "roadstop_a_E", "roadstop_a_S", "roadstop_a_W" ],
+    "fg": [ "roadstop_a_N", "roadstop_a_W", "roadstop_a_S", "roadstop_a_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "roadstop_a_roof" ],
-    "fg": [ "roadstop_a_roof_N", "roadstop_a_roof_E", "roadstop_a_roof_S", "roadstop_a_roof_W" ],
+    "fg": [ "roadstop_a_roof_N", "roadstop_a_roof_W", "roadstop_a_roof_S", "roadstop_a_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/roadstop_b/roadstop_b.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/roadstop_b/roadstop_b.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "roadstop_b" ],
-    "fg": [ "roadstop_b_N", "roadstop_b_E", "roadstop_b_S", "roadstop_b_W" ],
+    "fg": [ "roadstop_b_N", "roadstop_b_W", "roadstop_b_S", "roadstop_b_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "roadstop_b_roof" ],
-    "fg": [ "roadstop_b_roof_N", "roadstop_b_roof_E", "roadstop_b_roof_S", "roadstop_b_roof_W" ],
+    "fg": [ "roadstop_b_roof_N", "roadstop_b_roof_W", "roadstop_b_roof_S", "roadstop_b_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_antique/s_antique.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_antique/s_antique.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_antique" ],
-    "fg": [ "s_antique_N", "s_antique_E", "s_antique_S", "s_antique_W" ],
+    "fg": [ "s_antique_N", "s_antique_W", "s_antique_S", "s_antique_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_antique_roof" ],
-    "fg": [ "s_antique_roof_N", "s_antique_roof_E", "s_antique_roof_S", "s_antique_roof_W" ],
+    "fg": [ "s_antique_roof_N", "s_antique_roof_W", "s_antique_roof_S", "s_antique_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_apt/s_apt.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_apt/s_apt.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "s_apt" ],
-    "fg": [ "s_apt_N", "s_apt_E", "s_apt_S", "s_apt_W" ],
+    "fg": [ "s_apt_N", "s_apt_W", "s_apt_S", "s_apt_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_apt_2ndfloor" ],
-    "fg": [ "s_apt_2ndfloor_N", "s_apt_2ndfloor_E", "s_apt_2ndfloor_S", "s_apt_2ndfloor_W" ],
+    "fg": [ "s_apt_2ndfloor_N", "s_apt_2ndfloor_W", "s_apt_2ndfloor_S", "s_apt_2ndfloor_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_apt_roof" ],
-    "fg": [ "s_apt_roof_N", "s_apt_roof_E", "s_apt_roof_S", "s_apt_roof_W" ],
+    "fg": [ "s_apt_roof_N", "s_apt_roof_W", "s_apt_roof_S", "s_apt_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_apt_upper_roof" ],
-    "fg": [ "s_apt_upper_roof_N", "s_apt_upper_roof_E", "s_apt_upper_roof_S", "s_apt_upper_roof_W" ],
+    "fg": [ "s_apt_upper_roof_N", "s_apt_upper_roof_W", "s_apt_upper_roof_S", "s_apt_upper_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_apt_2/s_apt_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_apt_2/s_apt_2.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "s_apt_2" ],
-    "fg": [ "s_apt_2_N", "s_apt_2_E", "s_apt_2_S", "s_apt_2_W" ],
+    "fg": [ "s_apt_2_N", "s_apt_2_W", "s_apt_2_S", "s_apt_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_apt_2_2ndfloor" ],
-    "fg": [ "s_apt_2_2ndfloor_N", "s_apt_2_2ndfloor_E", "s_apt_2_2ndfloor_S", "s_apt_2_2ndfloor_W" ],
+    "fg": [ "s_apt_2_2ndfloor_N", "s_apt_2_2ndfloor_W", "s_apt_2_2ndfloor_S", "s_apt_2_2ndfloor_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_apt_2_roof" ],
-    "fg": [ "s_apt_2_roof_N", "s_apt_2_roof_E", "s_apt_2_roof_S", "s_apt_2_roof_W" ],
+    "fg": [ "s_apt_2_roof_N", "s_apt_2_roof_W", "s_apt_2_roof_S", "s_apt_2_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_apt_2_upper_roof" ],
-    "fg": [ "s_apt_2_upper_roof_N", "s_apt_2_upper_roof_E", "s_apt_2_upper_roof_S", "s_apt_2_upper_roof_W" ],
+    "fg": [ "s_apt_2_upper_roof_N", "s_apt_2_upper_roof_W", "s_apt_2_upper_roof_S", "s_apt_2_upper_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_arcade/s_arcade.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_arcade/s_arcade.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_arcade" ],
-    "fg": [ "s_arcade_N", "s_arcade_E", "s_arcade_S", "s_arcade_W" ],
+    "fg": [ "s_arcade_N", "s_arcade_W", "s_arcade_S", "s_arcade_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_arcade_roof" ],
-    "fg": [ "s_arcade_roof_N", "s_arcade_roof_E", "s_arcade_roof_S", "s_arcade_roof_W" ],
+    "fg": [ "s_arcade_roof_N", "s_arcade_roof_W", "s_arcade_roof_S", "s_arcade_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_bike_shop/s_bike_shop.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_bike_shop/s_bike_shop.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_bike_shop" ],
-    "fg": [ "s_bike_shop_N", "s_bike_shop_E", "s_bike_shop_S", "s_bike_shop_W" ],
+    "fg": [ "s_bike_shop_N", "s_bike_shop_W", "s_bike_shop_S", "s_bike_shop_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_bike_shop_roof" ],
-    "fg": [ "s_bike_shop_roof_N", "s_bike_shop_roof_E", "s_bike_shop_roof_S", "s_bike_shop_roof_W" ],
+    "fg": [ "s_bike_shop_roof_N", "s_bike_shop_roof_W", "s_bike_shop_roof_S", "s_bike_shop_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_bike_shop_1/s_bike_shop_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_bike_shop_1/s_bike_shop_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_bike_shop_1" ],
-    "fg": [ "s_bike_shop_1_N", "s_bike_shop_1_E", "s_bike_shop_1_S", "s_bike_shop_1_W" ],
+    "fg": [ "s_bike_shop_1_N", "s_bike_shop_1_W", "s_bike_shop_1_S", "s_bike_shop_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_bike_shop_roof_1" ],
-    "fg": [ "s_bike_shop_roof_1_N", "s_bike_shop_roof_1_E", "s_bike_shop_roof_1_S", "s_bike_shop_roof_1_W" ],
+    "fg": [ "s_bike_shop_roof_1_N", "s_bike_shop_roof_1_W", "s_bike_shop_roof_1_S", "s_bike_shop_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_butcher/s_butcher.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_butcher/s_butcher.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "s_butcher" ],
-    "fg": [ "s_butcher_N", "s_butcher_E", "s_butcher_S", "s_butcher_W" ],
+    "fg": [ "s_butcher_N", "s_butcher_W", "s_butcher_S", "s_butcher_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_butcher_roof" ],
-    "fg": [ "s_butcher_roof_N", "s_butcher_roof_E", "s_butcher_roof_S", "s_butcher_roof_W" ],
+    "fg": [ "s_butcher_roof_N", "s_butcher_roof_W", "s_butcher_roof_S", "s_butcher_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_butcher_upper_roof" ],
-    "fg": [ "s_butcher_upper_roof_N", "s_butcher_upper_roof_E", "s_butcher_upper_roof_S", "s_butcher_upper_roof_W" ],
+    "fg": [ "s_butcher_upper_roof_N", "s_butcher_upper_roof_W", "s_butcher_upper_roof_S", "s_butcher_upper_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_butcher_1/s_butcher_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_butcher_1/s_butcher_1.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "s_butcher_1" ],
-    "fg": [ "s_butcher_1_N", "s_butcher_1_E", "s_butcher_1_S", "s_butcher_1_W" ],
+    "fg": [ "s_butcher_1_N", "s_butcher_1_W", "s_butcher_1_S", "s_butcher_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_butcher_roof_1" ],
-    "fg": [ "s_butcher_roof_1_N", "s_butcher_roof_1_E", "s_butcher_roof_1_S", "s_butcher_roof_1_W" ],
+    "fg": [ "s_butcher_roof_1_N", "s_butcher_roof_1_W", "s_butcher_roof_1_S", "s_butcher_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_butcher_upper_roof_1" ],
-    "fg": [ "s_butcher_upper_roof_1_N", "s_butcher_upper_roof_1_E", "s_butcher_upper_roof_1_S", "s_butcher_upper_roof_1_W" ],
+    "fg": [ "s_butcher_upper_roof_1_N", "s_butcher_upper_roof_1_W", "s_butcher_upper_roof_1_S", "s_butcher_upper_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_butcher_2/s_butcher_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_butcher_2/s_butcher_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_butcher_2" ],
-    "fg": [ "s_butcher_2_N", "s_butcher_2_E", "s_butcher_2_S", "s_butcher_2_W" ],
+    "fg": [ "s_butcher_2_N", "s_butcher_2_W", "s_butcher_2_S", "s_butcher_2_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_butcher_roof_2" ],
-    "fg": [ "s_butcher_roof_2_N", "s_butcher_roof_2_E", "s_butcher_roof_2_S", "s_butcher_roof_2_W" ],
+    "fg": [ "s_butcher_roof_2_N", "s_butcher_roof_2_W", "s_butcher_roof_2_S", "s_butcher_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_cardealer/s_cardealer.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_cardealer/s_cardealer.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_cardealer" ],
-    "fg": [ "s_cardealer_N", "s_cardealer_E", "s_cardealer_S", "s_cardealer_W" ],
+    "fg": [ "s_cardealer_N", "s_cardealer_W", "s_cardealer_S", "s_cardealer_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_cardealer_roof" ],
-    "fg": [ "s_cardealer_roof_N", "s_cardealer_roof_E", "s_cardealer_roof_S", "s_cardealer_roof_W" ],
+    "fg": [ "s_cardealer_roof_N", "s_cardealer_roof_W", "s_cardealer_roof_S", "s_cardealer_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes/s_clothes.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes/s_clothes.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_clothes" ],
-    "fg": [ "s_clothes_N", "s_clothes_E", "s_clothes_S", "s_clothes_W" ],
+    "fg": [ "s_clothes_N", "s_clothes_W", "s_clothes_S", "s_clothes_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_clothes_roof" ],
-    "fg": [ "s_clothes_roof_N", "s_clothes_roof_E", "s_clothes_roof_S", "s_clothes_roof_W" ],
+    "fg": [ "s_clothes_roof_N", "s_clothes_roof_W", "s_clothes_roof_S", "s_clothes_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes_1/s_clothes_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes_1/s_clothes_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_clothes_1" ],
-    "fg": [ "s_clothes_1_N", "s_clothes_1_E", "s_clothes_1_S", "s_clothes_1_W" ],
+    "fg": [ "s_clothes_1_N", "s_clothes_1_W", "s_clothes_1_S", "s_clothes_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_clothes_roof_1" ],
-    "fg": [ "s_clothes_roof_1_N", "s_clothes_roof_1_E", "s_clothes_roof_1_S", "s_clothes_roof_1_W" ],
+    "fg": [ "s_clothes_roof_1_N", "s_clothes_roof_1_W", "s_clothes_roof_1_S", "s_clothes_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes_2/s_clothes_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes_2/s_clothes_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_clothes_2" ],
-    "fg": [ "s_clothes_2_N", "s_clothes_2_E", "s_clothes_2_S", "s_clothes_2_W" ],
+    "fg": [ "s_clothes_2_N", "s_clothes_2_W", "s_clothes_2_S", "s_clothes_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_clothes_roof_2" ],
-    "fg": [ "s_clothes_roof_2_N", "s_clothes_roof_2_E", "s_clothes_roof_2_S", "s_clothes_roof_2_W" ],
+    "fg": [ "s_clothes_roof_2_N", "s_clothes_roof_2_W", "s_clothes_roof_2_S", "s_clothes_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes_3/s_clothes_3.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes_3/s_clothes_3.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_clothes_3" ],
-    "fg": [ "s_clothes_3_N", "s_clothes_3_E", "s_clothes_3_S", "s_clothes_3_W" ],
+    "fg": [ "s_clothes_3_N", "s_clothes_3_W", "s_clothes_3_S", "s_clothes_3_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_clothes_roof_3" ],
-    "fg": [ "s_clothes_roof_3_N", "s_clothes_roof_3_E", "s_clothes_roof_3_S", "s_clothes_roof_3_W" ],
+    "fg": [ "s_clothes_roof_3_N", "s_clothes_roof_3_W", "s_clothes_roof_3_S", "s_clothes_roof_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes_4/s_clothes_4.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes_4/s_clothes_4.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "s_clothes_4" ],
-    "fg": [ "s_clothes_4_N", "s_clothes_4_E", "s_clothes_4_S", "s_clothes_4_W" ],
+    "fg": [ "s_clothes_4_N", "s_clothes_4_W", "s_clothes_4_S", "s_clothes_4_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_clothes_roof_4" ],
-    "fg": [ "s_clothes_roof_4_N", "s_clothes_roof_4_E", "s_clothes_roof_4_S", "s_clothes_roof_4_W" ],
+    "fg": [ "s_clothes_roof_4_N", "s_clothes_roof_4_W", "s_clothes_roof_4_S", "s_clothes_roof_4_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_clothes_upper_roof_4" ],
-    "fg": [ "s_clothes_upper_roof_4_N", "s_clothes_upper_roof_4_E", "s_clothes_upper_roof_4_S", "s_clothes_upper_roof_4_W" ],
+    "fg": [ "s_clothes_upper_roof_4_N", "s_clothes_upper_roof_4_W", "s_clothes_upper_roof_4_S", "s_clothes_upper_roof_4_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes_5/s_clothes_5.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes_5/s_clothes_5.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_clothes_5" ],
-    "fg": [ "s_clothes_5_N", "s_clothes_5_E", "s_clothes_5_S", "s_clothes_5_W" ],
+    "fg": [ "s_clothes_5_N", "s_clothes_5_W", "s_clothes_5_S", "s_clothes_5_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_clothes_roof_5" ],
-    "fg": [ "s_clothes_roof_5_N", "s_clothes_roof_5_E", "s_clothes_roof_5_S", "s_clothes_roof_5_W" ],
+    "fg": [ "s_clothes_roof_5_N", "s_clothes_roof_5_W", "s_clothes_roof_5_S", "s_clothes_roof_5_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes_6/s_clothes_6.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_clothes_6/s_clothes_6.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_clothes_6" ],
-    "fg": [ "s_clothes_6_N", "s_clothes_6_E", "s_clothes_6_S", "s_clothes_6_W" ],
+    "fg": [ "s_clothes_6_N", "s_clothes_6_W", "s_clothes_6_S", "s_clothes_6_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_clothes_roof_6" ],
-    "fg": [ "s_clothes_roof_6_N", "s_clothes_roof_6_E", "s_clothes_roof_6_S", "s_clothes_roof_6_W" ],
+    "fg": [ "s_clothes_roof_6_N", "s_clothes_roof_6_W", "s_clothes_roof_6_S", "s_clothes_roof_6_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_daycare/s_daycare.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_daycare/s_daycare.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_daycare" ],
-    "fg": [ "s_daycare_N", "s_daycare_E", "s_daycare_S", "s_daycare_W" ],
+    "fg": [ "s_daycare_N", "s_daycare_W", "s_daycare_S", "s_daycare_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_daycare_roof" ],
-    "fg": [ "s_daycare_roof_N", "s_daycare_roof_E", "s_daycare_roof_S", "s_daycare_roof_W" ],
+    "fg": [ "s_daycare_roof_N", "s_daycare_roof_W", "s_daycare_roof_S", "s_daycare_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_diner/s_diner.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_diner/s_diner.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "s_diner" ],
-    "fg": [ "s_diner_N", "s_diner_E", "s_diner_S", "s_diner_W" ],
+    "fg": [ "s_diner_N", "s_diner_W", "s_diner_S", "s_diner_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_diner_2ndfloor" ],
-    "fg": [ "s_diner_2ndfloor_N", "s_diner_2ndfloor_E", "s_diner_2ndfloor_S", "s_diner_2ndfloor_W" ],
+    "fg": [ "s_diner_2ndfloor_N", "s_diner_2ndfloor_W", "s_diner_2ndfloor_S", "s_diner_2ndfloor_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_diner_roof" ],
-    "fg": [ "s_diner_roof_N", "s_diner_roof_E", "s_diner_roof_S", "s_diner_roof_W" ],
+    "fg": [ "s_diner_roof_N", "s_diner_roof_W", "s_diner_roof_S", "s_diner_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_electronics/s_electronics.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_electronics/s_electronics.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_electronics" ],
-    "fg": [ "s_electronics_N", "s_electronics_E", "s_electronics_S", "s_electronics_W" ],
+    "fg": [ "s_electronics_N", "s_electronics_W", "s_electronics_S", "s_electronics_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_electronics_roof" ],
-    "fg": [ "s_electronics_roof_N", "s_electronics_roof_E", "s_electronics_roof_S", "s_electronics_roof_W" ],
+    "fg": [ "s_electronics_roof_N", "s_electronics_roof_W", "s_electronics_roof_S", "s_electronics_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_electronics_1/s_electronics_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_electronics_1/s_electronics_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_electronics_1" ],
-    "fg": [ "s_electronics_1_N", "s_electronics_1_E", "s_electronics_1_S", "s_electronics_1_W" ],
+    "fg": [ "s_electronics_1_N", "s_electronics_1_W", "s_electronics_1_S", "s_electronics_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_electronics_roof_1" ],
-    "fg": [ "s_electronics_roof_1_N", "s_electronics_roof_1_E", "s_electronics_roof_1_S", "s_electronics_roof_1_W" ],
+    "fg": [ "s_electronics_roof_1_N", "s_electronics_roof_1_W", "s_electronics_roof_1_S", "s_electronics_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_electronicstore/s_electronicstore.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_electronicstore/s_electronicstore.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "s_electronicstore" ],
-    "fg": [ "s_electronicstore_N", "s_electronicstore_E", "s_electronicstore_S", "s_electronicstore_W" ],
+    "fg": [ "s_electronicstore_N", "s_electronicstore_W", "s_electronicstore_S", "s_electronicstore_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -9,16 +9,16 @@
     "id": [ "s_electronicstore_2ndfloor" ],
     "fg": [
       "s_electronicstore_2ndfloor_N",
-      "s_electronicstore_2ndfloor_E",
+      "s_electronicstore_2ndfloor_W",
       "s_electronicstore_2ndfloor_S",
-      "s_electronicstore_2ndfloor_W"
+      "s_electronicstore_2ndfloor_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_electronicstore_roof" ],
-    "fg": [ "s_electronicstore_roof_N", "s_electronicstore_roof_E", "s_electronicstore_roof_S", "s_electronicstore_roof_W" ],
+    "fg": [ "s_electronicstore_roof_N", "s_electronicstore_roof_W", "s_electronicstore_roof_S", "s_electronicstore_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_games/s_games.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_games/s_games.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_games" ],
-    "fg": [ "s_games_N", "s_games_E", "s_games_S", "s_games_W" ],
+    "fg": [ "s_games_N", "s_games_W", "s_games_S", "s_games_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_games_roof" ],
-    "fg": [ "s_games_roof_N", "s_games_roof_E", "s_games_roof_S", "s_games_roof_W" ],
+    "fg": [ "s_games_roof_N", "s_games_roof_W", "s_games_roof_S", "s_games_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_garage/s_garage.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_garage/s_garage.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_garage" ],
-    "fg": [ "s_garage_N", "s_garage_E", "s_garage_S", "s_garage_W" ],
+    "fg": [ "s_garage_N", "s_garage_W", "s_garage_S", "s_garage_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_garage_roof" ],
-    "fg": [ "s_garage_roof_N", "s_garage_roof_E", "s_garage_roof_S", "s_garage_roof_W" ],
+    "fg": [ "s_garage_roof_N", "s_garage_roof_W", "s_garage_roof_S", "s_garage_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_garage_1/s_garage_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_garage_1/s_garage_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_garage_1" ],
-    "fg": [ "s_garage_1_N", "s_garage_1_E", "s_garage_1_S", "s_garage_1_W" ],
+    "fg": [ "s_garage_1_N", "s_garage_1_W", "s_garage_1_S", "s_garage_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_garage_roof_1" ],
-    "fg": [ "s_garage_roof_1_N", "s_garage_roof_1_E", "s_garage_roof_1_S", "s_garage_roof_1_W" ],
+    "fg": [ "s_garage_roof_1_N", "s_garage_roof_1_W", "s_garage_roof_1_S", "s_garage_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_garage_2/s_garage_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_garage_2/s_garage_2.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "s_garage_2" ],
-    "fg": [ "s_garage_2_N", "s_garage_2_E", "s_garage_2_S", "s_garage_2_W" ],
+    "fg": [ "s_garage_2_N", "s_garage_2_W", "s_garage_2_S", "s_garage_2_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_garage_roof_2" ],
-    "fg": [ "s_garage_roof_2_N", "s_garage_roof_2_E", "s_garage_roof_2_S", "s_garage_roof_2_W" ],
+    "fg": [ "s_garage_roof_2_N", "s_garage_roof_2_W", "s_garage_roof_2_S", "s_garage_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_garage_upper_roof_2" ],
-    "fg": [ "s_garage_upper_roof_2_N", "s_garage_upper_roof_2_E", "s_garage_upper_roof_2_S", "s_garage_upper_roof_2_W" ],
+    "fg": [ "s_garage_upper_roof_2_N", "s_garage_upper_roof_2_W", "s_garage_upper_roof_2_S", "s_garage_upper_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_gardening/s_gardening.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_gardening/s_gardening.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_gardening" ],
-    "fg": [ "s_gardening_N", "s_gardening_E", "s_gardening_S", "s_gardening_W" ],
+    "fg": [ "s_gardening_N", "s_gardening_W", "s_gardening_S", "s_gardening_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_gardening_roof" ],
-    "fg": [ "s_gardening_roof_N", "s_gardening_roof_E", "s_gardening_roof_S", "s_gardening_roof_W" ],
+    "fg": [ "s_gardening_roof_N", "s_gardening_roof_W", "s_gardening_roof_S", "s_gardening_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_grocery/s_grocery.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_grocery/s_grocery.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_grocery" ],
-    "fg": [ "s_grocery_N", "s_grocery_E", "s_grocery_S", "s_grocery_W" ],
+    "fg": [ "s_grocery_N", "s_grocery_W", "s_grocery_S", "s_grocery_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_grocery_roof" ],
-    "fg": [ "s_grocery_roof_N", "s_grocery_roof_E", "s_grocery_roof_S", "s_grocery_roof_W" ],
+    "fg": [ "s_grocery_roof_N", "s_grocery_roof_W", "s_grocery_roof_S", "s_grocery_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_grocery_1/s_grocery_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_grocery_1/s_grocery_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_grocery_1" ],
-    "fg": [ "s_grocery_1_N", "s_grocery_1_E", "s_grocery_1_S", "s_grocery_1_W" ],
+    "fg": [ "s_grocery_1_N", "s_grocery_1_W", "s_grocery_1_S", "s_grocery_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_grocery_roof_1" ],
-    "fg": [ "s_grocery_roof_1_N", "s_grocery_roof_1_E", "s_grocery_roof_1_S", "s_grocery_roof_1_W" ],
+    "fg": [ "s_grocery_roof_1_N", "s_grocery_roof_1_W", "s_grocery_roof_1_S", "s_grocery_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_gun/s_gun.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_gun/s_gun.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_gun" ],
-    "fg": [ "s_gun_N", "s_gun_E", "s_gun_S", "s_gun_W" ],
+    "fg": [ "s_gun_N", "s_gun_W", "s_gun_S", "s_gun_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_gun_roof" ],
-    "fg": [ "s_gun_roof_N", "s_gun_roof_E", "s_gun_roof_S", "s_gun_roof_W" ],
+    "fg": [ "s_gun_roof_N", "s_gun_roof_W", "s_gun_roof_S", "s_gun_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_gun_1 and 2/s_gun_1&2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_gun_1 and 2/s_gun_1&2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_gun_1", "s_gun_2" ],
-    "fg": [ "s_gun_1_N", "s_gun_1_E", "s_gun_1_S", "s_gun_1_W" ],
+    "fg": [ "s_gun_1_N", "s_gun_1_W", "s_gun_1_S", "s_gun_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_gun_roof_1", "s_gun_roof_2" ],
-    "fg": [ "s_gun_roof_1_N", "s_gun_roof_1_E", "s_gun_roof_1_S", "s_gun_roof_1_W" ],
+    "fg": [ "s_gun_roof_1_N", "s_gun_roof_1_W", "s_gun_roof_1_S", "s_gun_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_gun_3/s_gun_3.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_gun_3/s_gun_3.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_gun_3" ],
-    "fg": [ "s_gun_3_N", "s_gun_3_E", "s_gun_3_S", "s_gun_3_W" ],
+    "fg": [ "s_gun_3_N", "s_gun_3_W", "s_gun_3_S", "s_gun_3_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_gun_roof_3" ],
-    "fg": [ "s_gun_roof_3_N", "s_gun_roof_3_E", "s_gun_roof_3_S", "s_gun_roof_3_W" ],
+    "fg": [ "s_gun_roof_3_N", "s_gun_roof_3_W", "s_gun_roof_3_S", "s_gun_roof_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_gun_4/s_gun_4.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_gun_4/s_gun_4.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "s_gun_4" ],
-    "fg": [ "s_gun_4_N", "s_gun_4_E", "s_gun_4_S", "s_gun_4_W" ],
+    "fg": [ "s_gun_4_N", "s_gun_4_W", "s_gun_4_S", "s_gun_4_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_gun_2ndfloor_4" ],
-    "fg": [ "s_gun_2ndfloor_4_N", "s_gun_2ndfloor_4_E", "s_gun_2ndfloor_4_S", "s_gun_2ndfloor_4_W" ],
+    "fg": [ "s_gun_2ndfloor_4_N", "s_gun_2ndfloor_4_W", "s_gun_2ndfloor_4_S", "s_gun_2ndfloor_4_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_gun_roof_4" ],
-    "fg": [ "s_gun_roof_4_N", "s_gun_roof_4_E", "s_gun_roof_4_S", "s_gun_roof_4_W" ],
+    "fg": [ "s_gun_roof_4_N", "s_gun_roof_4_W", "s_gun_roof_4_S", "s_gun_roof_4_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_gunstore/s_gunstore.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_gunstore/s_gunstore.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "s_gunstore" ],
-    "fg": [ "s_gunstore_N", "s_gunstore_E", "s_gunstore_S", "s_gunstore_W" ],
+    "fg": [ "s_gunstore_N", "s_gunstore_W", "s_gunstore_S", "s_gunstore_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_gunstore_2ndfloor" ],
-    "fg": [ "s_gunstore_2ndfloor_N", "s_gunstore_2ndfloor_E", "s_gunstore_2ndfloor_S", "s_gunstore_2ndfloor_W" ],
+    "fg": [ "s_gunstore_2ndfloor_N", "s_gunstore_2ndfloor_W", "s_gunstore_2ndfloor_S", "s_gunstore_2ndfloor_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_gunstore_roof" ],
-    "fg": [ "s_gunstore_roof_N", "s_gunstore_roof_E", "s_gunstore_roof_S", "s_gunstore_roof_W" ],
+    "fg": [ "s_gunstore_roof_N", "s_gunstore_roof_W", "s_gunstore_roof_S", "s_gunstore_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_hardware/s_hardware.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_hardware/s_hardware.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_hardware" ],
-    "fg": [ "s_hardware_N", "s_hardware_E", "s_hardware_S", "s_hardware_W" ],
+    "fg": [ "s_hardware_N", "s_hardware_W", "s_hardware_S", "s_hardware_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_hardware_roof" ],
-    "fg": [ "s_hardware_roof_N", "s_hardware_roof_E", "s_hardware_roof_S", "s_hardware_roof_W" ],
+    "fg": [ "s_hardware_roof_N", "s_hardware_roof_W", "s_hardware_roof_S", "s_hardware_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_hardware_1/s_hardware_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_hardware_1/s_hardware_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_hardware_1" ],
-    "fg": [ "s_hardware_1_N", "s_hardware_1_E", "s_hardware_1_S", "s_hardware_1_W" ],
+    "fg": [ "s_hardware_1_N", "s_hardware_1_W", "s_hardware_1_S", "s_hardware_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_hardware_roof_1" ],
-    "fg": [ "s_hardware_roof_1_N", "s_hardware_roof_1_E", "s_hardware_roof_1_S", "s_hardware_roof_1_W" ],
+    "fg": [ "s_hardware_roof_1_N", "s_hardware_roof_1_W", "s_hardware_roof_1_S", "s_hardware_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_hardware_2/s_hardware_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_hardware_2/s_hardware_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_hardware_2" ],
-    "fg": [ "s_hardware_2_N", "s_hardware_2_E", "s_hardware_2_S", "s_hardware_2_W" ],
+    "fg": [ "s_hardware_2_N", "s_hardware_2_W", "s_hardware_2_S", "s_hardware_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_hardware_roof_2" ],
-    "fg": [ "s_hardware_roof_2_N", "s_hardware_roof_2_E", "s_hardware_roof_2_S", "s_hardware_roof_2_W" ],
+    "fg": [ "s_hardware_roof_2_N", "s_hardware_roof_2_W", "s_hardware_roof_2_S", "s_hardware_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_hardware_3/s_hardware_3.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_hardware_3/s_hardware_3.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_hardware_3" ],
-    "fg": [ "s_hardware_3_N", "s_hardware_3_E", "s_hardware_3_S", "s_hardware_3_W" ],
+    "fg": [ "s_hardware_3_N", "s_hardware_3_W", "s_hardware_3_S", "s_hardware_3_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_hardware_roof_3" ],
-    "fg": [ "s_hardware_roof_3_N", "s_hardware_roof_3_E", "s_hardware_roof_3_S", "s_hardware_roof_3_W" ],
+    "fg": [ "s_hardware_roof_3_N", "s_hardware_roof_3_W", "s_hardware_roof_3_S", "s_hardware_roof_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_hunting/s_hunting.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_hunting/s_hunting.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_hunting" ],
-    "fg": [ "s_hunting_N", "s_hunting_E", "s_hunting_S", "s_hunting_W" ],
+    "fg": [ "s_hunting_N", "s_hunting_W", "s_hunting_S", "s_hunting_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_hunting_roof" ],
-    "fg": [ "s_hunting_roof_N", "s_hunting_roof_E", "s_hunting_roof_S", "s_hunting_roof_W" ],
+    "fg": [ "s_hunting_roof_N", "s_hunting_roof_W", "s_hunting_roof_S", "s_hunting_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_jewelry/s_jewelry.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_jewelry/s_jewelry.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_jewelry" ],
-    "fg": [ "s_jewelry_N", "s_jewelry_E", "s_jewelry_S", "s_jewelry_W" ],
+    "fg": [ "s_jewelry_N", "s_jewelry_W", "s_jewelry_S", "s_jewelry_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_jewelry_roof" ],
-    "fg": [ "s_jewelry_roof_N", "s_jewelry_roof_E", "s_jewelry_roof_S", "s_jewelry_roof_W" ],
+    "fg": [ "s_jewelry_roof_N", "s_jewelry_roof_W", "s_jewelry_roof_S", "s_jewelry_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_laundromat/s_laundromat.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_laundromat/s_laundromat.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_laundromat" ],
-    "fg": [ "s_laundromat_N", "s_laundromat_E", "s_laundromat_S", "s_laundromat_W" ],
+    "fg": [ "s_laundromat_N", "s_laundromat_W", "s_laundromat_S", "s_laundromat_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_laundromat_roof" ],
-    "fg": [ "s_laundromat_roof_N", "s_laundromat_roof_E", "s_laundromat_roof_S", "s_laundromat_roof_W" ],
+    "fg": [ "s_laundromat_roof_N", "s_laundromat_roof_W", "s_laundromat_roof_S", "s_laundromat_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_laundromat_1/s_laundromat_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_laundromat_1/s_laundromat_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_laundromat_1" ],
-    "fg": [ "s_laundromat_1_N", "s_laundromat_1_E", "s_laundromat_1_S", "s_laundromat_1_W" ],
+    "fg": [ "s_laundromat_1_N", "s_laundromat_1_W", "s_laundromat_1_S", "s_laundromat_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_laundromat_roof_1" ],
-    "fg": [ "s_laundromat_roof_1_N", "s_laundromat_roof_1_E", "s_laundromat_roof_1_S", "s_laundromat_roof_1_W" ],
+    "fg": [ "s_laundromat_roof_1_N", "s_laundromat_roof_1_W", "s_laundromat_roof_1_S", "s_laundromat_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_liquor/s_liquor.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_liquor/s_liquor.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_liquor" ],
-    "fg": [ "s_liquor_N", "s_liquor_E", "s_liquor_S", "s_liquor_W" ],
+    "fg": [ "s_liquor_N", "s_liquor_W", "s_liquor_S", "s_liquor_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_liquor_roof" ],
-    "fg": [ "s_liquor_roof_N", "s_liquor_roof_E", "s_liquor_roof_S", "s_liquor_roof_W" ],
+    "fg": [ "s_liquor_roof_N", "s_liquor_roof_W", "s_liquor_roof_S", "s_liquor_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_music/s_music.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_music/s_music.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_music" ],
-    "fg": [ "s_music_shop_N", "s_music_shop_E", "s_music_shop_S", "s_music_shop_W" ],
+    "fg": [ "s_music_shop_N", "s_music_shop_W", "s_music_shop_S", "s_music_shop_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_music_roof" ],
-    "fg": [ "s_music_shop_roof_N", "s_music_shop_roof_E", "s_music_shop_roof_S", "s_music_shop_roof_W" ],
+    "fg": [ "s_music_shop_roof_N", "s_music_shop_roof_W", "s_music_shop_roof_S", "s_music_shop_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_petstore/s_petstore.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_petstore/s_petstore.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_petstore" ],
-    "fg": [ "s_petstore_N", "s_petstore_E", "s_petstore_S", "s_petstore_W" ],
+    "fg": [ "s_petstore_N", "s_petstore_W", "s_petstore_S", "s_petstore_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_petstore_roof" ],
-    "fg": [ "s_petstore_roof_N", "s_petstore_roof_E", "s_petstore_roof_S", "s_petstore_roof_W" ],
+    "fg": [ "s_petstore_roof_N", "s_petstore_roof_W", "s_petstore_roof_S", "s_petstore_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_petstore_1/s_petstore_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_petstore_1/s_petstore_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_petstore_1" ],
-    "fg": [ "s_petstore_1_N", "s_petstore_1_E", "s_petstore_1_S", "s_petstore_1_W" ],
+    "fg": [ "s_petstore_1_N", "s_petstore_1_W", "s_petstore_1_S", "s_petstore_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_petstore_roof_1" ],
-    "fg": [ "s_petstore_roof_1_N", "s_petstore_roof_1_E", "s_petstore_roof_1_S", "s_petstore_roof_1_W" ],
+    "fg": [ "s_petstore_roof_1_N", "s_petstore_roof_1_W", "s_petstore_roof_1_S", "s_petstore_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_petstore_2/s_petstore_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_petstore_2/s_petstore_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_petstore_2" ],
-    "fg": [ "s_petstore_2_N", "s_petstore_2_E", "s_petstore_2_S", "s_petstore_2_W" ],
+    "fg": [ "s_petstore_2_N", "s_petstore_2_W", "s_petstore_2_S", "s_petstore_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_petstore_roof_2" ],
-    "fg": [ "s_petstore_roof_2_N", "s_petstore_roof_2_E", "s_petstore_roof_2_S", "s_petstore_roof_2_W" ],
+    "fg": [ "s_petstore_roof_2_N", "s_petstore_roof_2_W", "s_petstore_roof_2_S", "s_petstore_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_pizza_parlor/s_pizza_parlor.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_pizza_parlor/s_pizza_parlor.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_pizza_parlor" ],
-    "fg": [ "s_pizza_parlor_N", "s_pizza_parlor_E", "s_pizza_parlor_S", "s_pizza_parlor_W" ],
+    "fg": [ "s_pizza_parlor_N", "s_pizza_parlor_W", "s_pizza_parlor_S", "s_pizza_parlor_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_pizza_parlor_roof" ],
-    "fg": [ "s_pizza_parlor_roof_N", "s_pizza_parlor_roof_E", "s_pizza_parlor_roof_S", "s_pizza_parlor_roof_W" ],
+    "fg": [ "s_pizza_parlor_roof_N", "s_pizza_parlor_roof_W", "s_pizza_parlor_roof_S", "s_pizza_parlor_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_pizza_parlor_1/s_pizza_parlor_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_pizza_parlor_1/s_pizza_parlor_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_pizza_parlor_1" ],
-    "fg": [ "s_pizza_parlor_1_N", "s_pizza_parlor_1_E", "s_pizza_parlor_1_S", "s_pizza_parlor_1_W" ],
+    "fg": [ "s_pizza_parlor_1_N", "s_pizza_parlor_1_W", "s_pizza_parlor_1_S", "s_pizza_parlor_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_pizza_parlor_roof_1" ],
-    "fg": [ "s_pizza_parlor_roof_1_N", "s_pizza_parlor_roof_1_E", "s_pizza_parlor_roof_1_S", "s_pizza_parlor_roof_1_W" ],
+    "fg": [ "s_pizza_parlor_roof_1_N", "s_pizza_parlor_roof_1_W", "s_pizza_parlor_roof_1_S", "s_pizza_parlor_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant/s_restaurant.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant/s_restaurant.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_restaurant", "s_restaurant_foodplace" ],
-    "fg": [ "s_restaurant_N", "s_restaurant_E", "s_restaurant_S", "s_restaurant_W" ],
+    "fg": [ "s_restaurant_N", "s_restaurant_W", "s_restaurant_S", "s_restaurant_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_restaurant_roof" ],
-    "fg": [ "s_restaurant_roof_N", "s_restaurant_roof_E", "s_restaurant_roof_S", "s_restaurant_roof_W" ],
+    "fg": [ "s_restaurant_roof_N", "s_restaurant_roof_W", "s_restaurant_roof_S", "s_restaurant_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_1/s_restaurant_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_1/s_restaurant_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_restaurant_1" ],
-    "fg": [ "s_restaurant_1_N", "s_restaurant_1_E", "s_restaurant_1_S", "s_restaurant_1_W" ],
+    "fg": [ "s_restaurant_1_N", "s_restaurant_1_W", "s_restaurant_1_S", "s_restaurant_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_restaurant_roof_1" ],
-    "fg": [ "s_restaurant_roof_1_N", "s_restaurant_roof_1_E", "s_restaurant_roof_1_S", "s_restaurant_roof_1_W" ],
+    "fg": [ "s_restaurant_roof_1_N", "s_restaurant_roof_1_W", "s_restaurant_roof_1_S", "s_restaurant_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_2/s_restaurant_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_2/s_restaurant_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_restaurant_2" ],
-    "fg": [ "s_restaurant_2_N", "s_restaurant_2_E", "s_restaurant_2_S", "s_restaurant_2_W" ],
+    "fg": [ "s_restaurant_2_N", "s_restaurant_2_W", "s_restaurant_2_S", "s_restaurant_2_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_restaurant_roof_2" ],
-    "fg": [ "s_restaurant_roof_2_N", "s_restaurant_roof_2_E", "s_restaurant_roof_2_S", "s_restaurant_roof_2_W" ],
+    "fg": [ "s_restaurant_roof_2_N", "s_restaurant_roof_2_W", "s_restaurant_roof_2_S", "s_restaurant_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_3/s_restaurant_3.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_3/s_restaurant_3.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_restaurant_3" ],
-    "fg": [ "s_restaurant_3_N", "s_restaurant_3_E", "s_restaurant_3_S", "s_restaurant_3_W" ],
+    "fg": [ "s_restaurant_3_N", "s_restaurant_3_W", "s_restaurant_3_S", "s_restaurant_3_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_restaurant_roof_3" ],
-    "fg": [ "s_restaurant_roof_3_N", "s_restaurant_roof_3_E", "s_restaurant_roof_3_S", "s_restaurant_roof_3_W" ],
+    "fg": [ "s_restaurant_roof_3_N", "s_restaurant_roof_3_W", "s_restaurant_roof_3_S", "s_restaurant_roof_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_coffee/s_restaurant_coffee.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_coffee/s_restaurant_coffee.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "s_restaurant_coffee" ],
-    "fg": [ "s_restaurant_coffee_N", "s_restaurant_coffee_E", "s_restaurant_coffee_S", "s_restaurant_coffee_W" ],
+    "fg": [ "s_restaurant_coffee_N", "s_restaurant_coffee_W", "s_restaurant_coffee_S", "s_restaurant_coffee_E" ],
     "bg": [  ],
     "rotates": true
   },
@@ -9,9 +9,9 @@
     "id": [ "s_restaurant_coffee_roof" ],
     "fg": [
       "s_restaurant_coffee_roof_N",
-      "s_restaurant_coffee_roof_E",
+      "s_restaurant_coffee_roof_W",
       "s_restaurant_coffee_roof_S",
-      "s_restaurant_coffee_roof_W"
+      "s_restaurant_coffee_roof_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_coffee_1/s_restaurant_coffee_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_coffee_1/s_restaurant_coffee_1.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "s_restaurant_coffee_1" ],
-    "fg": [ "s_restaurant_coffee_1_N", "s_restaurant_coffee_1_E", "s_restaurant_coffee_1_S", "s_restaurant_coffee_1_W" ],
+    "fg": [ "s_restaurant_coffee_1_N", "s_restaurant_coffee_1_W", "s_restaurant_coffee_1_S", "s_restaurant_coffee_1_E" ],
     "bg": [  ],
     "rotates": true
   },
@@ -9,9 +9,9 @@
     "id": [ "s_restaurant_coffee_roof_1" ],
     "fg": [
       "s_restaurant_coffee_roof_1_N",
-      "s_restaurant_coffee_roof_1_E",
+      "s_restaurant_coffee_roof_1_W",
       "s_restaurant_coffee_roof_1_S",
-      "s_restaurant_coffee_roof_1_W"
+      "s_restaurant_coffee_roof_1_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_coffee_2/s_restaurant_coffee_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_coffee_2/s_restaurant_coffee_2.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "s_restaurant_coffee_2" ],
-    "fg": [ "s_restaurant_coffee_2_N", "s_restaurant_coffee_2_E", "s_restaurant_coffee_2_S", "s_restaurant_coffee_2_W" ],
+    "fg": [ "s_restaurant_coffee_2_N", "s_restaurant_coffee_2_W", "s_restaurant_coffee_2_S", "s_restaurant_coffee_2_E" ],
     "bg": [  ],
     "rotates": true
   },
@@ -9,9 +9,9 @@
     "id": [ "s_restaurant_coffee_roof_2" ],
     "fg": [
       "s_restaurant_coffee_roof_2_N",
-      "s_restaurant_coffee_roof_2_E",
+      "s_restaurant_coffee_roof_2_W",
       "s_restaurant_coffee_roof_2_S",
-      "s_restaurant_coffee_roof_2_W"
+      "s_restaurant_coffee_roof_2_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_fast/s_restaurant_fast.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_fast/s_restaurant_fast.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_restaurant_fast" ],
-    "fg": [ "s_restaurant_fast_N", "s_restaurant_fast_E", "s_restaurant_fast_S", "s_restaurant_fast_W" ],
+    "fg": [ "s_restaurant_fast_N", "s_restaurant_fast_W", "s_restaurant_fast_S", "s_restaurant_fast_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_restaurant_fast_roof" ],
-    "fg": [ "s_restaurant_fast_roof_N", "s_restaurant_fast_roof_E", "s_restaurant_fast_roof_S", "s_restaurant_fast_roof_W" ],
+    "fg": [ "s_restaurant_fast_roof_N", "s_restaurant_fast_roof_W", "s_restaurant_fast_roof_S", "s_restaurant_fast_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_fast_1/s_restaurant_fast_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_fast_1/s_restaurant_fast_1.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "s_restaurant_fast_1" ],
-    "fg": [ "s_restaurant_fast_1_N", "s_restaurant_fast_1_E", "s_restaurant_fast_1_S", "s_restaurant_fast_1_W" ],
+    "fg": [ "s_restaurant_fast_1_N", "s_restaurant_fast_1_W", "s_restaurant_fast_1_S", "s_restaurant_fast_1_E" ],
     "bg": [  ],
     "rotates": true
   },
@@ -9,9 +9,9 @@
     "id": [ "s_restaurant_fast_roof_1" ],
     "fg": [
       "s_restaurant_fast_roof_1_N",
-      "s_restaurant_fast_roof_1_E",
+      "s_restaurant_fast_roof_1_W",
       "s_restaurant_fast_roof_1_S",
-      "s_restaurant_fast_roof_1_W"
+      "s_restaurant_fast_roof_1_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_foodplace/s_restaurant_foodplace.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_restaurant_foodplace/s_restaurant_foodplace.json
@@ -3,9 +3,9 @@
     "id": [ "s_restaurant_foodplace_roof" ],
     "fg": [
       "s_restaurant_foodplace_roof_N",
-      "s_restaurant_foodplace_roof_E",
+      "s_restaurant_foodplace_roof_W",
       "s_restaurant_foodplace_roof_S",
-      "s_restaurant_foodplace_roof_W"
+      "s_restaurant_foodplace_roof_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true
@@ -14,9 +14,9 @@
     "id": [ "s_restaurant_foodplace_upper_roof" ],
     "fg": [
       "s_restaurant_foodplace_upper_roof_N",
-      "s_restaurant_foodplace_upper_roof_E",
+      "s_restaurant_foodplace_upper_roof_W",
       "s_restaurant_foodplace_upper_roof_S",
-      "s_restaurant_foodplace_upper_roof_W"
+      "s_restaurant_foodplace_upper_roof_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_sports/s_sports.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_sports/s_sports.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_sports" ],
-    "fg": [ "s_sports_N", "s_sports_E", "s_sports_S", "s_sports_W" ],
+    "fg": [ "s_sports_N", "s_sports_W", "s_sports_S", "s_sports_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_sports_roof" ],
-    "fg": [ "s_sports_roof_N", "s_sports_roof_E", "s_sports_roof_S", "s_sports_roof_W" ],
+    "fg": [ "s_sports_roof_N", "s_sports_roof_W", "s_sports_roof_S", "s_sports_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_teashop/s_teashop.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_teashop/s_teashop.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_teashop" ],
-    "fg": [ "s_teashop_N", "s_teashop_E", "s_teashop_S", "s_teashop_W" ],
+    "fg": [ "s_teashop_N", "s_teashop_W", "s_teashop_S", "s_teashop_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_teashop_roof" ],
-    "fg": [ "s_teashop_roof_N", "s_teashop_roof_E", "s_teashop_roof_S", "s_teashop_roof_W" ],
+    "fg": [ "s_teashop_roof_N", "s_teashop_roof_W", "s_teashop_roof_S", "s_teashop_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_teashop_1/s_teashop_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_teashop_1/s_teashop_1.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "s_teashop_1" ],
-    "fg": [ "s_teashop_1_N", "s_teashop_1_E", "s_teashop_1_S", "s_teashop_1_W" ],
+    "fg": [ "s_teashop_1_N", "s_teashop_1_W", "s_teashop_1_S", "s_teashop_1_E" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "s_teashop_roof_1" ],
-    "fg": [ "s_teashop_roof_1_N", "s_teashop_roof_1_E", "s_teashop_roof_1_S", "s_teashop_roof_1_W" ],
+    "fg": [ "s_teashop_roof_1_N", "s_teashop_roof_1_W", "s_teashop_roof_1_S", "s_teashop_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "s_teashop_upper_roof_1" ],
-    "fg": [ "s_teashop_upper_roof_1_N", "s_teashop_upper_roof_1_E", "s_teashop_upper_roof_1_S", "s_teashop_upper_roof_1_W" ],
+    "fg": [ "s_teashop_upper_roof_1_N", "s_teashop_upper_roof_1_W", "s_teashop_upper_roof_1_S", "s_teashop_upper_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/s_thrift/s_thrift.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/s_thrift/s_thrift.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_thrift" ],
-    "fg": [ "s_thrift_N", "s_thrift_E", "s_thrift_S", "s_thrift_W" ],
+    "fg": [ "s_thrift_N", "s_thrift_W", "s_thrift_S", "s_thrift_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_thrift_roof" ],
-    "fg": [ "s_thrift_roof_N", "s_thrift_roof_E", "s_thrift_roof_S", "s_thrift_roof_W" ],
+    "fg": [ "s_thrift_roof_N", "s_thrift_roof_W", "s_thrift_roof_S", "s_thrift_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/sai/sai.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/sai/sai.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "sai" ],
-    "fg": [ "sai_N", "sai_E", "sai_S", "sai_W" ],
+    "fg": [ "sai_N", "sai_W", "sai_S", "sai_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/salon/salon.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/salon/salon.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "salon" ],
-    "fg": [ "salon_N", "salon_E", "salon_S", "salon_W" ],
+    "fg": [ "salon_N", "salon_W", "salon_S", "salon_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "salon_roof" ],
-    "fg": [ "salon_roof_N", "salon_roof_E", "salon_roof_S", "salon_roof_W" ],
+    "fg": [ "salon_roof_N", "salon_roof_W", "salon_roof_S", "salon_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/shelter/shelter.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/shelter/shelter.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "shelter", "shelter_vandal" ],
-    "fg": [ "shelter_N", "shelter_E", "shelter_S", "shelter_W" ],
+    "fg": [ "shelter_N", "shelter_W", "shelter_S", "shelter_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "shelter_roof" ],
-    "fg": [ "shelter_roof_N", "shelter_roof_E", "shelter_roof_S", "shelter_roof_W" ],
+    "fg": [ "shelter_roof_N", "shelter_roof_W", "shelter_roof_S", "shelter_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "shelter_under" ],
-    "fg": [ "shelter_under_N", "shelter_under_E", "shelter_under_S", "shelter_under_W" ],
+    "fg": [ "shelter_under_N", "shelter_under_W", "shelter_under_S", "shelter_under_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/shelter_1/shelter_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/shelter_1/shelter_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "shelter_1", "shelter_1_vandal" ],
-    "fg": [ "shelter_1_N", "shelter_1_E", "shelter_1_S", "shelter_1_W" ],
+    "fg": [ "shelter_1_N", "shelter_1_W", "shelter_1_S", "shelter_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "shelter_roof_1" ],
-    "fg": [ "shelter_roof_1_N", "shelter_roof_1_E", "shelter_roof_1_S", "shelter_roof_1_W" ],
+    "fg": [ "shelter_roof_1_N", "shelter_roof_1_W", "shelter_roof_1_S", "shelter_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/shelter_2/shelter_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/shelter_2/shelter_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "shelter_2", "shelter_2_vandal" ],
-    "fg": [ "shelter_2_N", "shelter_2_E", "shelter_2_S", "shelter_2_W" ],
+    "fg": [ "shelter_2_N", "shelter_2_W", "shelter_2_S", "shelter_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "shelter_roof_2" ],
-    "fg": [ "shelter_roof_2_N", "shelter_roof_2_E", "shelter_roof_2_S", "shelter_roof_2_W" ],
+    "fg": [ "shelter_roof_2_N", "shelter_roof_2_W", "shelter_roof_2_S", "shelter_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/skate_park/skate_park.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/skate_park/skate_park.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "skate_park" ],
-    "fg": [ "skate_park_N", "skate_park_E", "skate_park_S", "skate_park_W" ],
+    "fg": [ "skate_park_N", "skate_park_W", "skate_park_S", "skate_park_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/small_office/small_office.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/small_office/small_office.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "small_office" ],
-    "fg": [ "small_office_N", "small_office_E", "small_office_S", "small_office_W" ],
+    "fg": [ "small_office_N", "small_office_W", "small_office_S", "small_office_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "small_office_roof" ],
-    "fg": [ "small_office_roof_N", "small_office_roof_E", "small_office_roof_S", "small_office_roof_W" ],
+    "fg": [ "small_office_roof_N", "small_office_roof_W", "small_office_roof_S", "small_office_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "small_office_upper_roof" ],
-    "fg": [ "small_office_upper_roof_N", "small_office_upper_roof_E", "small_office_upper_roof_S", "small_office_upper_roof_W" ],
+    "fg": [ "small_office_upper_roof_N", "small_office_upper_roof_W", "small_office_upper_roof_S", "small_office_upper_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/small_storage_units/small_storage_units.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/small_storage_units/small_storage_units.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "small_storage_units" ],
-    "fg": [ "small_storage_units_N", "small_storage_units_E", "small_storage_units_S", "small_storage_units_W" ],
+    "fg": [ "small_storage_units_N", "small_storage_units_W", "small_storage_units_S", "small_storage_units_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -9,9 +9,9 @@
     "id": [ "small_storage_units_roof" ],
     "fg": [
       "small_storage_units_roof_N",
-      "small_storage_units_roof_E",
+      "small_storage_units_roof_W",
       "small_storage_units_roof_S",
-      "small_storage_units_roof_W"
+      "small_storage_units_roof_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/small_storage_units_1/small_storage_units_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/small_storage_units_1/small_storage_units_1.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "small_storage_units_1" ],
-    "fg": [ "small_storage_units_1_N", "small_storage_units_1_E", "small_storage_units_1_S", "small_storage_units_1_W" ],
+    "fg": [ "small_storage_units_1_N", "small_storage_units_1_W", "small_storage_units_1_S", "small_storage_units_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
@@ -9,9 +9,9 @@
     "id": [ "small_storage_units_roof_1" ],
     "fg": [
       "small_storage_units_roof_1_N",
-      "small_storage_units_roof_1_E",
+      "small_storage_units_roof_1_W",
       "small_storage_units_roof_1_S",
-      "small_storage_units_roof_1_W"
+      "small_storage_units_roof_1_E"
     ],
     "bg": [ "open_air" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/small_wooded_trail/small_wooded_trail.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/small_wooded_trail/small_wooded_trail.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "small_wooded_trail" ],
-    "fg": [ "small_wooded_trail_N", "small_wooded_trail_E", "small_wooded_trail_S", "small_wooded_trail_W" ],
+    "fg": [ "small_wooded_trail_N", "small_wooded_trail_W", "small_wooded_trail_S", "small_wooded_trail_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "small_wooded_trail_2" ],
-    "fg": [ "small_wooded_trail_2_N", "small_wooded_trail_2_E", "small_wooded_trail_2_S", "small_wooded_trail_2_W" ],
+    "fg": [ "small_wooded_trail_2_N", "small_wooded_trail_2_W", "small_wooded_trail_2_S", "small_wooded_trail_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/smallscrapyard/smallscrapyard.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/smallscrapyard/smallscrapyard.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "smallscrapyard" ],
-    "fg": [ "smallscrapyard_N", "smallscrapyard_E", "smallscrapyard_S", "smallscrapyard_W" ],
+    "fg": [ "smallscrapyard_N", "smallscrapyard_W", "smallscrapyard_S", "smallscrapyard_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/smoke_lounge/smoke_lounge.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/smoke_lounge/smoke_lounge.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "smoke_lounge" ],
-    "fg": [ "smoke_lounge_N", "smoke_lounge_E", "smoke_lounge_S", "smoke_lounge_W" ],
+    "fg": [ "smoke_lounge_N", "smoke_lounge_W", "smoke_lounge_S", "smoke_lounge_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "smoke_lounge_roof" ],
-    "fg": [ "smoke_lounge_roof_N", "smoke_lounge_roof_E", "smoke_lounge_roof_S", "smoke_lounge_roof_W" ],
+    "fg": [ "smoke_lounge_roof_N", "smoke_lounge_roof_W", "smoke_lounge_roof_S", "smoke_lounge_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/smoke_lounge_1/smoke_lounge_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/smoke_lounge_1/smoke_lounge_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "smoke_lounge_1" ],
-    "fg": [ "smoke_lounge_1_N", "smoke_lounge_1_E", "smoke_lounge_1_S", "smoke_lounge_1_W" ],
+    "fg": [ "smoke_lounge_1_N", "smoke_lounge_1_W", "smoke_lounge_1_S", "smoke_lounge_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "smoke_lounge_roof_1" ],
-    "fg": [ "smoke_lounge_roof_1_N", "smoke_lounge_roof_1_E", "smoke_lounge_roof_1_S", "smoke_lounge_roof_1_W" ],
+    "fg": [ "smoke_lounge_roof_1_N", "smoke_lounge_roof_1_W", "smoke_lounge_roof_1_S", "smoke_lounge_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/station_radio/station_radio.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/station_radio/station_radio.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "station_radio" ],
-    "fg": [ "station_radio_N", "station_radio_E", "station_radio_S", "station_radio_W" ],
+    "fg": [ "station_radio_N", "station_radio_W", "station_radio_S", "station_radio_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "station_radio_roof" ],
-    "fg": [ "station_radio_roof_N", "station_radio_roof_E", "station_radio_roof_S", "station_radio_roof_W" ],
+    "fg": [ "station_radio_roof_N", "station_radio_roof_W", "station_radio_roof_S", "station_radio_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/station_radio_1/station_radio_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/station_radio_1/station_radio_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "station_radio_1" ],
-    "fg": [ "station_radio_1_N", "station_radio_1_E", "station_radio_1_S", "station_radio_1_W" ],
+    "fg": [ "station_radio_1_N", "station_radio_1_W", "station_radio_1_S", "station_radio_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "station_radio_roof_1" ],
-    "fg": [ "station_radio_roof_1_N", "station_radio_roof_1_E", "station_radio_roof_1_S", "station_radio_roof_1_W" ],
+    "fg": [ "station_radio_roof_1_N", "station_radio_roof_1_W", "station_radio_roof_1_S", "station_radio_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/stripclub/stripclub.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/stripclub/stripclub.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "stripclub" ],
-    "fg": [ "stripclub_N", "stripclub_E", "stripclub_S", "stripclub_W" ],
+    "fg": [ "stripclub_N", "stripclub_W", "stripclub_S", "stripclub_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "stripclub_roof" ],
-    "fg": [ "stripclub_roof_N", "stripclub_roof_E", "stripclub_roof_S", "stripclub_roof_W" ],
+    "fg": [ "stripclub_roof_N", "stripclub_roof_W", "stripclub_roof_S", "stripclub_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/stripclub_1/stripclub_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/stripclub_1/stripclub_1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "stripclub_1" ],
-    "fg": [ "stripclub_1_N", "stripclub_1_E", "stripclub_1_S", "stripclub_1_W" ],
+    "fg": [ "stripclub_1_N", "stripclub_1_W", "stripclub_1_S", "stripclub_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "stripclub_roof_1" ],
-    "fg": [ "stripclub_roof_1_N", "stripclub_roof_1_E", "stripclub_roof_1_S", "stripclub_roof_1_W" ],
+    "fg": [ "stripclub_roof_1_N", "stripclub_roof_1_W", "stripclub_roof_1_S", "stripclub_roof_1_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/stripclub_2/stripclub_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/stripclub_2/stripclub_2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "stripclub_2" ],
-    "fg": [ "stripclub_2_N", "stripclub_2_E", "stripclub_2_S", "stripclub_2_W" ],
+    "fg": [ "stripclub_2_N", "stripclub_2_W", "stripclub_2_S", "stripclub_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "stripclub_roof_2" ],
-    "fg": [ "stripclub_roof_2_N", "stripclub_roof_2_E", "stripclub_roof_2_S", "stripclub_roof_2_W" ],
+    "fg": [ "stripclub_roof_2_N", "stripclub_roof_2_W", "stripclub_roof_2_S", "stripclub_roof_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/sub_station/sub_station.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/sub_station/sub_station.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "sub_station" ],
-    "fg": [ "sub_station_N", "sub_station_E", "sub_station_S", "sub_station_W" ],
+    "fg": [ "sub_station_N", "sub_station_W", "sub_station_S", "sub_station_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "sub_station_roof" ],
-    "fg": [ "sub_station_roof_N", "sub_station_roof_E", "sub_station_roof_S", "sub_station_roof_W" ],
+    "fg": [ "sub_station_roof_N", "sub_station_roof_W", "sub_station_roof_S", "sub_station_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "sewer_sub_station" ],
-    "fg": [ "sewer_sub_station_N", "sewer_sub_station_E", "sewer_sub_station_S", "sewer_sub_station_W" ],
+    "fg": [ "sewer_sub_station_N", "sewer_sub_station_W", "sewer_sub_station_S", "sewer_sub_station_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "underground_sub_station" ],
-    "fg": [ "underground_sub_station_N", "underground_sub_station_E", "underground_sub_station_S", "underground_sub_station_W" ],
+    "fg": [ "underground_sub_station_N", "underground_sub_station_W", "underground_sub_station_S", "underground_sub_station_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/trailer_park/trailer_park.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/trailer_park/trailer_park.json
@@ -1,37 +1,37 @@
 [
   {
     "id": [ "trailerparksmall0" ],
-    "fg": [ "trailerparksmall0_N", "trailerparksmall0_E", "trailerparksmall0_S", "trailerparksmall0_W" ],
+    "fg": [ "trailerparksmall0_N", "trailerparksmall0_W", "trailerparksmall0_S", "trailerparksmall0_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "trailerparksmall1" ],
-    "fg": [ "trailerparksmall1_N", "trailerparksmall1_E", "trailerparksmall1_S", "trailerparksmall1_W" ],
+    "fg": [ "trailerparksmall1_N", "trailerparksmall1_W", "trailerparksmall1_S", "trailerparksmall1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "trailerparksmall2" ],
-    "fg": [ "trailerparksmall2_N", "trailerparksmall2_E", "trailerparksmall2_S", "trailerparksmall2_W" ],
+    "fg": [ "trailerparksmall2_N", "trailerparksmall2_W", "trailerparksmall2_S", "trailerparksmall2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "trailerparksmall0_roof" ],
-    "fg": [ "trailerparksmall0_roof_N", "trailerparksmall0_roof_E", "trailerparksmall0_roof_S", "trailerparksmall0_roof_W" ],
+    "fg": [ "trailerparksmall0_roof_N", "trailerparksmall0_roof_W", "trailerparksmall0_roof_S", "trailerparksmall0_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "trailerparksmall1_roof" ],
-    "fg": [ "trailerparksmall1_roof_N", "trailerparksmall1_roof_E", "trailerparksmall1_roof_S", "trailerparksmall1_roof_W" ],
+    "fg": [ "trailerparksmall1_roof_N", "trailerparksmall1_roof_W", "trailerparksmall1_roof_S", "trailerparksmall1_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "trailerparksmall2_roof" ],
-    "fg": [ "trailerparksmall2_roof_N", "trailerparksmall2_roof_E", "trailerparksmall2_roof_S", "trailerparksmall2_roof_W" ],
+    "fg": [ "trailerparksmall2_roof_N", "trailerparksmall2_roof_W", "trailerparksmall2_roof_S", "trailerparksmall2_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/veterinarian/veterinarian.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/veterinarian/veterinarian.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "veterinarian" ],
-    "fg": [ "veterinarian_N", "veterinarian_E", "veterinarian_S", "veterinarian_W" ],
+    "fg": [ "veterinarian_N", "veterinarian_W", "veterinarian_S", "veterinarian_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "veterinarian_roof" ],
-    "fg": [ "veterinarian_roof_N", "veterinarian_roof_E", "veterinarian_roof_S", "veterinarian_roof_W" ],
+    "fg": [ "veterinarian_roof_N", "veterinarian_roof_W", "veterinarian_roof_S", "veterinarian_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/vfw/s_vfw.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/vfw/s_vfw.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "s_vfw" ],
-    "fg": [ "s_vfw_N", "s_vfw_E", "s_vfw_S", "s_vfw_W" ],
+    "fg": [ "s_vfw_N", "s_vfw_W", "s_vfw_S", "s_vfw_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "s_vfw_roof" ],
-    "fg": [ "s_vfw_roof_N", "s_vfw_roof_E", "s_vfw_roof_S", "s_vfw_roof_W" ],
+    "fg": [ "s_vfw_roof_N", "s_vfw_roof_W", "s_vfw_roof_S", "s_vfw_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/warehouse/warehouse.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/warehouse/warehouse.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "warehouse" ],
-    "fg": [ "warehouse_N", "warehouse_E", "warehouse_S", "warehouse_W" ],
+    "fg": [ "warehouse_N", "warehouse_W", "warehouse_S", "warehouse_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "warehouse_roof" ],
-    "fg": [ "warehouse_roof_N", "warehouse_roof_E", "warehouse_roof_S", "warehouse_roof_W" ],
+    "fg": [ "warehouse_roof_N", "warehouse_roof_W", "warehouse_roof_S", "warehouse_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/woodworker/craft_shop_3.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/woodworker/craft_shop_3.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "craft_shop_3" ],
-    "fg": [ "craft_shop_3_N", "craft_shop_3_E", "craft_shop_3_S", "craft_shop_3_W" ],
+    "fg": [ "craft_shop_3_N", "craft_shop_3_W", "craft_shop_3_S", "craft_shop_3_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "craft_shop_2ndfloor_3" ],
-    "fg": [ "craft_shop_2ndfloor_3_N", "craft_shop_2ndfloor_3_E", "craft_shop_2ndfloor_3_S", "craft_shop_2ndfloor_3_W" ],
+    "fg": [ "craft_shop_2ndfloor_3_N", "craft_shop_2ndfloor_3_W", "craft_shop_2ndfloor_3_S", "craft_shop_2ndfloor_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "craft_shop_roof_3" ],
-    "fg": [ "craft_shop_roof_3_N", "craft_shop_roof_3_E", "craft_shop_roof_3_S", "craft_shop_roof_3_W" ],
+    "fg": [ "craft_shop_roof_3_N", "craft_shop_roof_3_W", "craft_shop_roof_3_S", "craft_shop_roof_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Update json to fix East/West building orientation.  

#### Content of the change

Swap _W & _E in json files for commercial buildings, parks.

#### Testing

I composed the tileset and checked the overmap using a mega city to confirm changes worked & don't cause errors.


#### Additional information

Simple swap in the json's IDs order so it is NWSE instead of NESW.  