### PR TITLE
[SurveyorsMap] Fix E-W orientation of house sprites

### DIFF
--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/2storyModern01/2storyModern01.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/2storyModern01/2storyModern01.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "2storyModern01_first" ],
-    "fg": [ "2storyModern01_first_N", "2storyModern01_first_E", "2storyModern01_first_S", "2storyModern01_first_W" ],
+    "fg": [ "2storyModern01_first_N", "2storyModern01_first_W", "2storyModern01_first_S", "2storyModern01_first_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "2storyModern01_second" ],
-    "fg": [ "2storyModern01_second_N", "2storymodern01_second_E", "2storymodern01_second_S", "2storymodern01_second_W" ],
+    "fg": [ "2storyModern01_second_N", "2storymodern01_second_W", "2storymodern01_second_S", "2storymodern01_second_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "2storyModern01_roof" ],
-    "fg": [ "2storyModern01_roof_N", "2storyModern01_roof_E", "2storyModern01_roof_S", "2storyModern01_roof_W" ],
+    "fg": [ "2storyModern01_roof_N", "2storyModern01_roof_W", "2storyModern01_roof_S", "2storyModern01_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "2storyModern01_basement" ],
-    "fg": [ "2storymodern01_basement_N", "2storymodern01_basement_E", "2storymodern01_basement_S", "2storymodern01_basement_W" ],
+    "fg": [ "2storymodern01_basement_N", "2storymodern01_basement_W", "2storymodern01_basement_S", "2storymodern01_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/duplex/duplex.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/duplex/duplex.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "duplex" ],
-    "fg": [ "duplex_N", "duplex_E", "duplex_S", "duplex_W" ],
+    "fg": [ "duplex_N", "duplex_W", "duplex_S", "duplex_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "duplex_roof" ],
-    "fg": [ "duplex_roof_N", "duplex_roof_E", "duplex_roof_S", "duplex_roof_W" ],
+    "fg": [ "duplex_roof_N", "duplex_roof_W", "duplex_roof_S", "duplex_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/garden_house_1/garden_house_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/garden_house_1/garden_house_1.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "garden_house_1_floor_1" ],
-    "fg": [ "garden_house_1_floor_1_N", "garden_house_1_floor_1_E", "garden_house_1_floor_1_S", "garden_house_1_floor_1_W" ],
+    "fg": [ "garden_house_1_floor_1_N", "garden_house_1_floor_1_W", "garden_house_1_floor_1_S", "garden_house_1_floor_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "garden_house_1_floor_2" ],
-    "fg": [ "garden_house_1_floor_2_N", "garden_house_1_floor_2_E", "garden_house_1_floor_2_S", "garden_house_1_floor_2_W" ],
+    "fg": [ "garden_house_1_floor_2_N", "garden_house_1_floor_2_W", "garden_house_1_floor_2_S", "garden_house_1_floor_2_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "garden_house_1_basement" ],
-    "fg": [ "garden_house_1_basement_N", "garden_house_1_basement_E", "garden_house_1_basement_S", "garden_house_1_basement_W" ],
+    "fg": [ "garden_house_1_basement_N", "garden_house_1_basement_W", "garden_house_1_basement_S", "garden_house_1_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "garden_house_1_roof" ],
-    "fg": [ "garden_house_1_roof_N", "garden_house_1_roof_E", "garden_house_1_roof_S", "garden_house_1_roof_W" ],
+    "fg": [ "garden_house_1_roof_N", "garden_house_1_roof_W", "garden_house_1_roof_S", "garden_house_1_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house.json
@@ -1,193 +1,193 @@
 [
   {
     "id": [ "house_01" ],
-    "fg": [ "house_01_N", "house_01_E", "house_01_S", "house_01_W" ],
+    "fg": [ "house_01_N", "house_01_W", "house_01_S", "house_01_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_01_roof" ],
-    "fg": [ "house_01_roof_N", "house_01_roof_E", "house_01_roof_S", "house_01_roof_W" ],
+    "fg": [ "house_01_roof_N", "house_01_roof_W", "house_01_roof_S", "house_01_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_02" ],
-    "fg": [ "house_02_N", "house_02_E", "house_02_S", "house_02_W" ],
+    "fg": [ "house_02_N", "house_02_W", "house_02_S", "house_02_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_02_roof" ],
-    "fg": [ "house_02_roof_N", "house_02_roof_E", "house_02_roof_S", "house_02_roof_W" ],
+    "fg": [ "house_02_roof_N", "house_02_roof_W", "house_02_roof_S", "house_02_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_03" ],
-    "fg": [ "house_03_N", "house_03_E", "house_03_S", "house_03_W" ],
+    "fg": [ "house_03_N", "house_03_W", "house_03_S", "house_03_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_03_roof" ],
-    "fg": [ "house_03_roof_N", "house_03_roof_E", "house_03_roof_S", "house_03_roof_W" ],
+    "fg": [ "house_03_roof_N", "house_03_roof_W", "house_03_roof_S", "house_03_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_04" ],
-    "fg": [ "house_04_N", "house_04_E", "house_04_S", "house_04_W" ],
+    "fg": [ "house_04_N", "house_04_W", "house_04_S", "house_04_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_04_roof" ],
-    "fg": [ "house_04_roof_N", "house_04_roof_E", "house_04_roof_S", "house_04_roof_W" ],
+    "fg": [ "house_04_roof_N", "house_04_roof_W", "house_04_roof_S", "house_04_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_04_basement" ],
-    "fg": [ "house_04_basement_N", "house_04_basement_E", "house_04_basement_S", "house_04_basement_W" ],
+    "fg": [ "house_04_basement_N", "house_04_basement_W", "house_04_basement_S", "house_04_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "house_05ab" ],
-    "fg": [ "house_05ab_N", "house_05ab_E", "house_05ab_S", "house_05ab_W" ],
+    "fg": [ "house_05ab_N", "house_05ab_W", "house_05ab_S", "house_05ab_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_05ab_basement" ],
-    "fg": [ "house_05ab_basement_N", "house_05ab_basement_E", "house_05ab_basement_S", "house_05ab_basement_W" ],
+    "fg": [ "house_05ab_basement_N", "house_05ab_basement_W", "house_05ab_basement_S", "house_05ab_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "house_05" ],
-    "fg": [ "house_05_N", "house_05_E", "house_05_S", "house_05_W" ],
+    "fg": [ "house_05_N", "house_05_W", "house_05_S", "house_05_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_05_basement" ],
-    "fg": [ "house_05_basement_N", "house_05_basement_E", "house_05_basement_S", "house_05_basement_W" ],
+    "fg": [ "house_05_basement_N", "house_05_basement_W", "house_05_basement_S", "house_05_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "house_06" ],
-    "fg": [ "house_06_N", "house_06_E", "house_06_S", "house_06_W" ],
+    "fg": [ "house_06_N", "house_06_W", "house_06_S", "house_06_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_07" ],
-    "fg": [ "house_07_N", "house_07_E", "house_07_S", "house_07_W" ],
+    "fg": [ "house_07_N", "house_07_W", "house_07_S", "house_07_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_08" ],
-    "fg": [ "house_08_N", "house_08_E", "house_08_S", "house_08_W" ],
+    "fg": [ "house_08_N", "house_08_W", "house_08_S", "house_08_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_08_roof" ],
-    "fg": [ "house_08_roof_N", "house_08_roof_E", "house_08_roof_S", "house_08_roof_W" ],
+    "fg": [ "house_08_roof_N", "house_08_roof_W", "house_08_roof_S", "house_08_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_08_basement" ],
-    "fg": [ "house_08_basement_N", "house_08_basement_E", "house_08_basement_S", "house_08_basement_W" ],
+    "fg": [ "house_08_basement_N", "house_08_basement_W", "house_08_basement_S", "house_08_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "house_09" ],
-    "fg": [ "house_09_N", "house_09_E", "house_09_S", "house_09_W" ],
+    "fg": [ "house_09_N", "house_09_W", "house_09_S", "house_09_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_09_roof" ],
-    "fg": [ "house_09_roof_N", "house_09_roof_E", "house_09_roof_S", "house_09_roof_W" ],
+    "fg": [ "house_09_roof_N", "house_09_roof_W", "house_09_roof_S", "house_09_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "basement_bionic", "basement_bionic_decoy" ],
-    "fg": [ "house_09_basement_N", "house_09_basement_E", "house_09_basement_S", "house_09_basement_W" ],
+    "fg": [ "house_09_basement_N", "house_09_basement_W", "house_09_basement_S", "house_09_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "house_10" ],
-    "fg": [ "house_10_N", "house_10_E", "house_10_S", "house_10_W" ],
+    "fg": [ "house_10_N", "house_10_W", "house_10_S", "house_10_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_10_roof" ],
-    "fg": [ "house_10_roof_N", "house_10_roof_E", "house_10_roof_S", "house_10_roof_W" ],
+    "fg": [ "house_10_roof_N", "house_10_roof_W", "house_10_roof_S", "house_10_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_10_basement" ],
-    "fg": [ "house_10_basement_N", "house_10_basement_E", "house_10_basement_S", "house_10_basement_W" ],
+    "fg": [ "house_10_basement_N", "house_10_basement_W", "house_10_basement_S", "house_10_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "house_11" ],
-    "fg": [ "house_11_N", "house_11_E", "house_11_S", "house_11_W" ],
+    "fg": [ "house_11_N", "house_11_W", "house_11_S", "house_11_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_11_roof" ],
-    "fg": [ "house_11_roof_N", "house_11_roof_E", "house_11_roof_S", "house_11_roof_W" ],
+    "fg": [ "house_11_roof_N", "house_11_roof_W", "house_11_roof_S", "house_11_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_11_basement" ],
-    "fg": [ "house_11_basement_N", "house_11_basement_E", "house_11_basement_S", "house_11_basement_W" ],
+    "fg": [ "house_11_basement_N", "house_11_basement_W", "house_11_basement_S", "house_11_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "house_12" ],
-    "fg": [ "house_12_N", "house_12_E", "house_12_S", "house_12_W" ],
+    "fg": [ "house_12_N", "house_12_W", "house_12_S", "house_12_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_12_roof" ],
-    "fg": [ "house_12_roof_N", "house_12_roof_E", "house_12_roof_S", "house_12_roof_W" ],
+    "fg": [ "house_12_roof_N", "house_12_roof_W", "house_12_roof_S", "house_12_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_12_basement" ],
-    "fg": [ "house_12_basement_N", "house_12_basement_E", "house_12_basement_S", "house_12_basement_W" ],
+    "fg": [ "house_12_basement_N", "house_12_basement_W", "house_12_basement_S", "house_12_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "house_dogs" ],
-    "fg": [ "house_dogs_N", "house_dogs_E", "house_dogs_S", "house_dogs_W" ],
+    "fg": [ "house_dogs_N", "house_dogs_W", "house_dogs_S", "house_dogs_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_dogs_roof" ],
-    "fg": [ "house_dogs_roof_N", "house_dogs_roof_E", "house_dogs_roof_S", "house_dogs_roof_W" ],
+    "fg": [ "house_dogs_roof_N", "house_dogs_roof_W", "house_dogs_roof_S", "house_dogs_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_13/house_13.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_13/house_13.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_13" ],
-    "fg": [ "house_13_N", "house_13_E", "house_13_S", "house_13_W" ],
+    "fg": [ "house_13_N", "house_13_W", "house_13_S", "house_13_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_13_roof" ],
-    "fg": [ "house_13_roof_N", "house_13_roof_E", "house_13_roof_S", "house_13_roof_W" ],
+    "fg": [ "house_13_roof_N", "house_13_roof_W", "house_13_roof_S", "house_13_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_13_basement" ],
-    "fg": [ "house_13_basement_N", "house_13_basement_E", "house_13_basement_S", "house_13_basement_W" ],
+    "fg": [ "house_13_basement_N", "house_13_basement_W", "house_13_basement_S", "house_13_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_14/house_14.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_14/house_14.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_14" ],
-    "fg": [ "house_14_N", "house_14_E", "house_14_S", "house_14_W" ],
+    "fg": [ "house_14_N", "house_14_W", "house_14_S", "house_14_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_14_roof" ],
-    "fg": [ "house_14_roof_N", "house_14_roof_E", "house_14_roof_S", "house_14_roof_W" ],
+    "fg": [ "house_14_roof_N", "house_14_roof_W", "house_14_roof_S", "house_14_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_14_basement" ],
-    "fg": [ "house_14_basement_N", "house_14_basement_E", "house_14_basement_S", "house_14_basement_W" ],
+    "fg": [ "house_14_basement_N", "house_14_basement_W", "house_14_basement_S", "house_14_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_15/house_15.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_15/house_15.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_15" ],
-    "fg": [ "house_15_N", "house_15_E", "house_15_S", "house_15_W" ],
+    "fg": [ "house_15_N", "house_15_W", "house_15_S", "house_15_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_15_roof" ],
-    "fg": [ "house_15_roof_N", "house_15_roof_E", "house_15_roof_S", "house_15_roof_W" ],
+    "fg": [ "house_15_roof_N", "house_15_roof_W", "house_15_roof_S", "house_15_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_15_basement" ],
-    "fg": [ "house_15_basement_N", "house_15_basement_E", "house_15_basement_S", "house_15_basement_W" ],
+    "fg": [ "house_15_basement_N", "house_15_basement_W", "house_15_basement_S", "house_15_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_16/house_16.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_16/house_16.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_16" ],
-    "fg": [ "house_16_N", "house_16_E", "house_16_S", "house_16_W" ],
+    "fg": [ "house_16_N", "house_16_W", "house_16_S", "house_16_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_16_roof" ],
-    "fg": [ "house_16_roof_N", "house_16_roof_E", "house_16_roof_S", "house_16_roof_W" ],
+    "fg": [ "house_16_roof_N", "house_16_roof_W", "house_16_roof_S", "house_16_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_16_basement" ],
-    "fg": [ "house_16_basement_N", "house_16_basement_E", "house_16_basement_S", "house_16_basement_W" ],
+    "fg": [ "house_16_basement_N", "house_16_basement_W", "house_16_basement_S", "house_16_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_17/house_17.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_17/house_17.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_17" ],
-    "fg": [ "house_17_N", "house_17_E", "house_17_S", "house_17_W" ],
+    "fg": [ "house_17_N", "house_17_W", "house_17_S", "house_17_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_17_roof" ],
-    "fg": [ "house_17_roof_N", "house_17_roof_E", "house_17_roof_S", "house_17_roof_W" ],
+    "fg": [ "house_17_roof_N", "house_17_roof_W", "house_17_roof_S", "house_17_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_17_basement" ],
-    "fg": [ "house_17_basement_N", "house_17_basement_E", "house_17_basement_S", "house_17_basement_W" ],
+    "fg": [ "house_17_basement_N", "house_17_basement_W", "house_17_basement_S", "house_17_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_18/house_18.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_18/house_18.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_18" ],
-    "fg": [ "house_18_N", "house_18_E", "house_18_S", "house_18_W" ],
+    "fg": [ "house_18_N", "house_18_W", "house_18_S", "house_18_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_18_roof" ],
-    "fg": [ "house_18_roof_N", "house_18_roof_E", "house_18_roof_S", "house_18_roof_W" ],
+    "fg": [ "house_18_roof_N", "house_18_roof_W", "house_18_roof_S", "house_18_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_19/house_19.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_19/house_19.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_19" ],
-    "fg": [ "house_19_N", "house_19_E", "house_19_S", "house_19_W" ],
+    "fg": [ "house_19_N", "house_19_W", "house_19_S", "house_19_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_19_roof" ],
-    "fg": [ "house_19_roof_N", "house_19_roof_E", "house_19_roof_S", "house_19_roof_W" ],
+    "fg": [ "house_19_roof_N", "house_19_roof_W", "house_19_roof_S", "house_19_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_19_basement" ],
-    "fg": [ "house_19_basement_N", "house_19_basement_E", "house_19_basement_S", "house_19_basement_W" ],
+    "fg": [ "house_19_basement_N", "house_19_basement_W", "house_19_basement_S", "house_19_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_20/house_20.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_20/house_20.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_20" ],
-    "fg": [ "house_20_N", "house_20_E", "house_20_S", "house_20_W" ],
+    "fg": [ "house_20_N", "house_20_W", "house_20_S", "house_20_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_20_roof" ],
-    "fg": [ "house_20_roof_N", "house_20_roof_E", "house_20_roof_S", "house_20_roof_W" ],
+    "fg": [ "house_20_roof_N", "house_20_roof_W", "house_20_roof_S", "house_20_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_21/house_21.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_21/house_21.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_21" ],
-    "fg": [ "house_21_N", "house_21_E", "house_21_S", "house_21_W" ],
+    "fg": [ "house_21_N", "house_21_W", "house_21_S", "house_21_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_21_roof" ],
-    "fg": [ "house_21_roof_N", "house_21_roof_E", "house_21_roof_S", "house_21_roof_W" ],
+    "fg": [ "house_21_roof_N", "house_21_roof_W", "house_21_roof_S", "house_21_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_22/house_22.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_22/house_22.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_22" ],
-    "fg": [ "house_22_N", "house_22_E", "house_22_S", "house_22_W" ],
+    "fg": [ "house_22_N", "house_22_W", "house_22_S", "house_22_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_22_roof" ],
-    "fg": [ "house_22_roof_N", "house_22_roof_E", "house_22_roof_S", "house_22_roof_W" ],
+    "fg": [ "house_22_roof_N", "house_22_roof_W", "house_22_roof_S", "house_22_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_22_basement" ],
-    "fg": [ "house_22_basement_N", "house_22_basement_E", "house_22_basement_S", "house_22_basement_W" ],
+    "fg": [ "house_22_basement_N", "house_22_basement_W", "house_22_basement_S", "house_22_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_23/house_23.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_23/house_23.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_23" ],
-    "fg": [ "house_23_N", "house_23_E", "house_23_S", "house_23_W" ],
+    "fg": [ "house_23_N", "house_23_W", "house_23_S", "house_23_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_23_roof" ],
-    "fg": [ "house_23_roof_N", "house_23_roof_E", "house_23_roof_S", "house_23_roof_W" ],
+    "fg": [ "house_23_roof_N", "house_23_roof_W", "house_23_roof_S", "house_23_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_24/house_24.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_24/house_24.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_24" ],
-    "fg": [ "house_24_N", "house_24_E", "house_24_S", "house_24_W" ],
+    "fg": [ "house_24_N", "house_24_W", "house_24_S", "house_24_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_24_roof" ],
-    "fg": [ "house_24_roof_N", "house_24_roof_E", "house_24_roof_S", "house_24_roof_W" ],
+    "fg": [ "house_24_roof_N", "house_24_roof_W", "house_24_roof_S", "house_24_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_25/house_25.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_25/house_25.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_25" ],
-    "fg": [ "house_25_N", "house_25_E", "house_25_S", "house_25_W" ],
+    "fg": [ "house_25_N", "house_25_W", "house_25_S", "house_25_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_25_roof" ],
-    "fg": [ "house_25_roof_N", "house_25_roof_E", "house_25_roof_S", "house_25_roof_W" ],
+    "fg": [ "house_25_roof_N", "house_25_roof_W", "house_25_roof_S", "house_25_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_26/house_26.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_26/house_26.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_26" ],
-    "fg": [ "house_26_N", "house_26_E", "house_26_S", "house_26_W" ],
+    "fg": [ "house_26_N", "house_26_W", "house_26_S", "house_26_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_26_roof" ],
-    "fg": [ "house_26_roof_N", "house_26_roof_E", "house_26_roof_S", "house_26_roof_W" ],
+    "fg": [ "house_26_roof_N", "house_26_roof_W", "house_26_roof_S", "house_26_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "basement_survival" ],
-    "fg": [ "house_26_basement_N", "house_26_basement_E", "house_26_basement_S", "house_26_basement_W" ],
+    "fg": [ "house_26_basement_N", "house_26_basement_W", "house_26_basement_S", "house_26_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_27/house_27.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_27/house_27.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_27" ],
-    "fg": [ "house_27_N", "house_27_E", "house_27_S", "house_27_W" ],
+    "fg": [ "house_27_N", "house_27_W", "house_27_S", "house_27_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_27_roof" ],
-    "fg": [ "house_27_roof_N", "house_27_roof_E", "house_27_roof_S", "house_27_roof_W" ],
+    "fg": [ "house_27_roof_N", "house_27_roof_W", "house_27_roof_S", "house_27_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "basement_meth" ],
-    "fg": [ "house_27_basement_N", "house_27_basement_E", "house_27_basement_S", "house_27_basement_W" ],
+    "fg": [ "house_27_basement_N", "house_27_basement_W", "house_27_basement_S", "house_27_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_28/house_28.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_28/house_28.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_28" ],
-    "fg": [ "house_28_N", "house_28_E", "house_28_S", "house_28_W" ],
+    "fg": [ "house_28_N", "house_28_W", "house_28_S", "house_28_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_28_roof" ],
-    "fg": [ "house_28_roof_N", "house_28_roof_E", "house_28_roof_S", "house_28_roof_W" ],
+    "fg": [ "house_28_roof_N", "house_28_roof_W", "house_28_roof_S", "house_28_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
-    "id": [ "basement_weed" ],
-    "fg": [ "house_28_basement_N", "house_28_basement_E", "house_28_basement_S", "house_28_basement_W" ],
+    "id": [ "basement_Eeed" ],
+    "fg": [ "house_28_basement_N", "house_28_basement_W", "house_28_basement_S", "house_28_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_29/house_29.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_29/house_29.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_29" ],
-    "fg": [ "house_29_N", "house_29_E", "house_29_S", "house_29_W" ],
+    "fg": [ "house_29_N", "house_29_W", "house_29_S", "house_29_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_29_roof" ],
-    "fg": [ "house_29_roof_N", "house_29_roof_E", "house_29_roof_S", "house_29_roof_W" ],
+    "fg": [ "house_29_roof_N", "house_29_roof_W", "house_29_roof_S", "house_29_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "basement_chem" ],
-    "fg": [ "house_29_basement_N", "house_29_basement_E", "house_29_basement_S", "house_29_basement_W" ],
+    "fg": [ "house_29_basement_N", "house_29_basement_W", "house_29_basement_S", "house_29_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_2story/house_2story.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_2story/house_2story.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "house_2story_base" ],
-    "fg": [ "house_2story_base_N", "house_2story_base_E", "house_2story_base_S", "house_2story_base_W" ],
+    "fg": [ "house_2story_base_N", "house_2story_base_W", "house_2story_base_S", "house_2story_base_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_2story_second" ],
-    "fg": [ "house_2story_second_N", "house_2story_second_E", "house_2story_second_S", "house_2story_second_W" ],
+    "fg": [ "house_2story_second_N", "house_2story_second_W", "house_2story_second_S", "house_2story_second_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_2story_basement" ],
-    "fg": [ "house_2story_basement_N", "house_2story_basement_E", "house_2story_basement_S", "house_2story_basement_W" ],
+    "fg": [ "house_2story_basement_N", "house_2story_basement_W", "house_2story_basement_S", "house_2story_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "house_2story_roof" ],
-    "fg": [ "house_2story_roof_N", "house_2story_roof_E", "house_2story_roof_S", "house_2story_roof_W" ],
+    "fg": [ "house_2story_roof_N", "house_2story_roof_W", "house_2story_roof_S", "house_2story_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_30/house_30.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_30/house_30.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_30" ],
-    "fg": [ "house_30_N", "house_30_E", "house_30_S", "house_30_W" ],
+    "fg": [ "house_30_N", "house_30_W", "house_30_S", "house_30_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_30_roof" ],
-    "fg": [ "house_30_roof_N", "house_30_roof_E", "house_30_roof_S", "house_30_roof_W" ],
+    "fg": [ "house_30_roof_N", "house_30_roof_W", "house_30_roof_S", "house_30_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "basement_chem2" ],
-    "fg": [ "house_30_basement_N", "house_30_basement_E", "house_30_basement_S", "house_30_basement_W" ],
+    "fg": [ "house_30_basement_N", "house_30_basement_W", "house_30_basement_S", "house_30_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_31/house_31.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_31/house_31.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_31" ],
-    "fg": [ "house_31_N", "house_31_E", "house_31_S", "house_31_W" ],
+    "fg": [ "house_31_N", "house_31_W", "house_31_S", "house_31_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_31_roof" ],
-    "fg": [ "house_31_roof_N", "house_31_roof_E", "house_31_roof_S", "house_31_roof_W" ],
+    "fg": [ "house_31_roof_N", "house_31_roof_W", "house_31_roof_S", "house_31_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_32/house_32.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_32/house_32.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_32" ],
-    "fg": [ "house_32_N", "house_32_E", "house_32_S", "house_32_W" ],
+    "fg": [ "house_32_N", "house_32_W", "house_32_S", "house_32_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_32_roof" ],
-    "fg": [ "house_32_roof_N", "house_32_roof_E", "house_32_roof_S", "house_32_roof_W" ],
+    "fg": [ "house_32_roof_N", "house_32_roof_W", "house_32_roof_S", "house_32_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_33/house_33.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_33/house_33.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_33" ],
-    "fg": [ "house_33_N", "house_33_E", "house_33_S", "house_33_W" ],
+    "fg": [ "house_33_N", "house_33_W", "house_33_S", "house_33_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_33_roof" ],
-    "fg": [ "house_33_roof_N", "house_33_roof_E", "house_33_roof_S", "house_33_roof_W" ],
+    "fg": [ "house_33_roof_N", "house_33_roof_W", "house_33_roof_S", "house_33_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_33_basement" ],
-    "fg": [ "house_33_basement_N", "house_33_basement_E", "house_33_basement_S", "house_33_basement_W" ],
+    "fg": [ "house_33_basement_N", "house_33_basement_W", "house_33_basement_S", "house_33_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_34/house_34.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_34/house_34.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_34" ],
-    "fg": [ "house_34_N", "house_34_E", "house_34_S", "house_34_W" ],
+    "fg": [ "house_34_N", "house_34_W", "house_34_S", "house_34_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_34_roof" ],
-    "fg": [ "house_34_roof_N", "house_34_roof_E", "house_34_roof_S", "house_34_roof_W" ],
+    "fg": [ "house_34_roof_N", "house_34_roof_W", "house_34_roof_S", "house_34_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_34_basement" ],
-    "fg": [ "house_34_basement_N", "house_34_basement_E", "house_34_basement_S", "house_34_basement_W" ],
+    "fg": [ "house_34_basement_N", "house_34_basement_W", "house_34_basement_S", "house_34_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_35/house_35.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_35/house_35.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_35" ],
-    "fg": [ "house_35_N", "house_35_E", "house_35_S", "house_35_W" ],
+    "fg": [ "house_35_N", "house_35_W", "house_35_S", "house_35_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_35_roof" ],
-    "fg": [ "house_35_roof_N", "house_35_roof_E", "house_35_roof_S", "house_35_roof_W" ],
+    "fg": [ "house_35_roof_N", "house_35_roof_W", "house_35_roof_S", "house_35_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_36/house_36.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_36/house_36.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_36" ],
-    "fg": [ "house_36_N", "house_36_E", "house_36_S", "house_36_W" ],
+    "fg": [ "house_36_N", "house_36_W", "house_36_S", "house_36_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_36_roof" ],
-    "fg": [ "house_36_roof_N", "house_36_roof_E", "house_36_roof_S", "house_36_roof_W" ],
+    "fg": [ "house_36_roof_N", "house_36_roof_W", "house_36_roof_S", "house_36_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_36_basement" ],
-    "fg": [ "house_36_basement_N", "house_36_basement_E", "house_36_basement_S", "house_36_basement_W" ],
+    "fg": [ "house_36_basement_N", "house_36_basement_W", "house_36_basement_S", "house_36_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_37/house_37.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_37/house_37.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_37" ],
-    "fg": [ "house_37_N", "house_37_E", "house_37_S", "house_37_W" ],
+    "fg": [ "house_37_N", "house_37_W", "house_37_S", "house_37_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_37_roof" ],
-    "fg": [ "house_37_roof_N", "house_37_roof_E", "house_37_roof_S", "house_37_roof_W" ],
+    "fg": [ "house_37_roof_N", "house_37_roof_W", "house_37_roof_S", "house_37_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_37_basement" ],
-    "fg": [ "house_37_basement_N", "house_37_basement_E", "house_37_basement_S", "house_37_basement_W" ],
+    "fg": [ "house_37_basement_N", "house_37_basement_W", "house_37_basement_S", "house_37_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_38/house_38.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_38/house_38.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_38" ],
-    "fg": [ "house_38_N", "house_38_E", "house_38_S", "house_38_W" ],
+    "fg": [ "house_38_N", "house_38_W", "house_38_S", "house_38_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_38_roof" ],
-    "fg": [ "house_38_roof_N", "house_38_roof_E", "house_38_roof_S", "house_38_roof_W" ],
+    "fg": [ "house_38_roof_N", "house_38_roof_W", "house_38_roof_S", "house_38_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_39/house_39.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_39/house_39.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_39" ],
-    "fg": [ "house_39_N", "house_39_E", "house_39_S", "house_39_W" ],
+    "fg": [ "house_39_N", "house_39_W", "house_39_S", "house_39_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_39_roof" ],
-    "fg": [ "house_39_roof_N", "house_39_roof_E", "house_39_roof_S", "house_39_roof_W" ],
+    "fg": [ "house_39_roof_N", "house_39_roof_W", "house_39_roof_S", "house_39_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_39_basement" ],
-    "fg": [ "house_39_basement_N", "house_39_basement_E", "house_39_basement_S", "house_39_basement_W" ],
+    "fg": [ "house_39_basement_N", "house_39_basement_W", "house_39_basement_S", "house_39_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_40/house_40.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_40/house_40.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_40" ],
-    "fg": [ "house_40_N", "house_40_E", "house_40_S", "house_40_W" ],
+    "fg": [ "house_40_N", "house_40_W", "house_40_S", "house_40_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_40_roof" ],
-    "fg": [ "house_40_roof_N", "house_40_roof_E", "house_40_roof_S", "house_40_roof_W" ],
+    "fg": [ "house_40_roof_N", "house_40_roof_W", "house_40_roof_S", "house_40_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_41/house_41.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_41/house_41.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_41" ],
-    "fg": [ "house_41_N", "house_41_E", "house_41_S", "house_41_W" ],
+    "fg": [ "house_41_N", "house_41_W", "house_41_S", "house_41_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_41_roof" ],
-    "fg": [ "house_41_roof_N", "house_41_roof_E", "house_41_roof_S", "house_41_roof_W" ],
+    "fg": [ "house_41_roof_N", "house_41_roof_W", "house_41_roof_S", "house_41_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_42/house_42.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_42/house_42.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_42" ],
-    "fg": [ "house_42_N", "house_42_E", "house_42_S", "house_42_W" ],
+    "fg": [ "house_42_N", "house_42_W", "house_42_S", "house_42_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_42_roof" ],
-    "fg": [ "house_42_roof_N", "house_42_roof_E", "house_42_roof_S", "house_42_roof_W" ],
+    "fg": [ "house_42_roof_N", "house_42_roof_W", "house_42_roof_S", "house_42_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_crack1 and 2/house_crack1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_crack1 and 2/house_crack1.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_crack1", "house_crack2" ],
-    "fg": [ "house_crack1_N", "house_crack1_E", "house_crack1_S", "house_crack1_W" ],
+    "fg": [ "house_crack1_N", "house_crack1_W", "house_crack1_S", "house_crack1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_crack1_roof" ],
-    "fg": [ "house_crack1_roof_N", "house_crack1_roof_E", "house_crack1_roof_S", "house_crack1_roof_W" ],
+    "fg": [ "house_crack1_roof_N", "house_crack1_roof_W", "house_crack1_roof_S", "house_crack1_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "basement_messed" ],
-    "fg": [ "basement_messed_N", "basement_messed_E", "basement_messed_S", "basement_messed_W" ],
+    "fg": [ "basement_messed_N", "basement_messed_W", "basement_messed_S", "basement_messed_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_crack3/house_crack3.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_crack3/house_crack3.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_crack3" ],
-    "fg": [ "house_crack3_N", "house_crack3_E", "house_crack3_S", "house_crack3_W" ],
+    "fg": [ "house_crack3_N", "house_crack3_W", "house_crack3_S", "house_crack3_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_crack3_roof" ],
-    "fg": [ "house_crack3_roof_N", "house_crack3_roof_E", "house_crack3_roof_S", "house_crack3_roof_W" ],
+    "fg": [ "house_crack3_roof_N", "house_crack3_roof_W", "house_crack3_roof_S", "house_crack3_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_crack3_basement" ],
-    "fg": [ "house_crack3_basement_N", "house_crack3_basement_E", "house_crack3_basement_S", "house_crack3_basement_W" ],
+    "fg": [ "house_crack3_basement_N", "house_crack3_basement_W", "house_crack3_basement_S", "house_crack3_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched1/house_detatched1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched1/house_detatched1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_detatched1" ],
-    "fg": [ "house_detatched1_N", "house_detatched1_E", "house_detatched1_S", "house_detatched1_W" ],
+    "fg": [ "house_detatched1_N", "house_detatched1_W", "house_detatched1_S", "house_detatched1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_detatched1_roof" ],
-    "fg": [ "house_detatched1_roof_N", "house_detatched1_roof_E", "house_detatched1_roof_S", "house_detatched1_roof_W" ],
+    "fg": [ "house_detatched1_roof_N", "house_detatched1_roof_W", "house_detatched1_roof_S", "house_detatched1_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "house_detatched1_basement" ],
     "fg": [
       "house_detatched1_basement_N",
-      "house_detatched1_basement_E",
+      "house_detatched1_basement_W",
       "house_detatched1_basement_S",
-      "house_detatched1_basement_W"
+      "house_detatched1_basement_E"
     ],
     "bg": [ "solid_earth" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched10/house_detatched10.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched10/house_detatched10.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_detatched10" ],
-    "fg": [ "house_detatched10_N", "house_detatched10_E", "house_detatched10_S", "house_detatched10_W" ],
+    "fg": [ "house_detatched10_N", "house_detatched10_W", "house_detatched10_S", "house_detatched10_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_detatched10_roof" ],
-    "fg": [ "house_detatched10_roof_N", "house_detatched10_roof_E", "house_detatched10_roof_S", "house_detatched10_roof_W" ],
+    "fg": [ "house_detatched10_roof_N", "house_detatched10_roof_W", "house_detatched10_roof_S", "house_detatched10_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched2/house_detatched2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched2/house_detatched2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_detatched2" ],
-    "fg": [ "house_detatched2_N", "house_detatched2_E", "house_detatched2_S", "house_detatched2_W" ],
+    "fg": [ "house_detatched2_N", "house_detatched2_W", "house_detatched2_S", "house_detatched2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_detatched2_roof" ],
-    "fg": [ "house_detatched2_roof_N", "house_detatched2_roof_E", "house_detatched2_roof_S", "house_detatched2_roof_W" ],
+    "fg": [ "house_detatched2_roof_N", "house_detatched2_roof_W", "house_detatched2_roof_S", "house_detatched2_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "house_detatched2_basement" ],
     "fg": [
       "house_detatched2_basement_N",
-      "house_detatched2_basement_E",
+      "house_detatched2_basement_W",
       "house_detatched2_basement_S",
-      "house_detatched2_basement_W"
+      "house_detatched2_basement_E"
     ],
     "bg": [ "solid_earth" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched3/house_detatched3.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched3/house_detatched3.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_detatched3" ],
-    "fg": [ "house_detatched3_N", "house_detatched3_E", "house_detatched3_S", "house_detatched3_W" ],
+    "fg": [ "house_detatched3_N", "house_detatched3_W", "house_detatched3_S", "house_detatched3_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_detatched3_roof" ],
-    "fg": [ "house_detatched3_roof_N", "house_detatched3_roof_E", "house_detatched3_roof_S", "house_detatched3_roof_W" ],
+    "fg": [ "house_detatched3_roof_N", "house_detatched3_roof_W", "house_detatched3_roof_S", "house_detatched3_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "house_detatched3_basement" ],
     "fg": [
       "house_detatched3_basement_N",
-      "house_detatched3_basement_E",
+      "house_detatched3_basement_W",
       "house_detatched3_basement_S",
-      "house_detatched3_basement_W"
+      "house_detatched3_basement_E"
     ],
     "bg": [ "solid_earth" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched4/house_detatched4.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched4/house_detatched4.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_detatched4" ],
-    "fg": [ "house_detatched4_N", "house_detatched4_E", "house_detatched4_S", "house_detatched4_W" ],
+    "fg": [ "house_detatched4_N", "house_detatched4_W", "house_detatched4_S", "house_detatched4_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_detatched4_roof" ],
-    "fg": [ "house_detatched4_roof_N", "house_detatched4_roof_E", "house_detatched4_roof_S", "house_detatched4_roof_W" ],
+    "fg": [ "house_detatched4_roof_N", "house_detatched4_roof_W", "house_detatched4_roof_S", "house_detatched4_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "house_detatched4_basement" ],
     "fg": [
       "house_detatched4_basement_N",
-      "house_detatched4_basement_E",
+      "house_detatched4_basement_W",
       "house_detatched4_basement_S",
-      "house_detatched4_basement_W"
+      "house_detatched4_basement_E"
     ],
     "bg": [ "solid_earth" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched5/house_detatched5.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched5/house_detatched5.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_detatched5" ],
-    "fg": [ "house_detatched5_N", "house_detatched5_E", "house_detatched5_S", "house_detatched5_W" ],
+    "fg": [ "house_detatched5_N", "house_detatched5_W", "house_detatched5_S", "house_detatched5_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_detatched5_roof" ],
-    "fg": [ "house_detatched5_roof_N", "house_detatched5_roof_E", "house_detatched5_roof_S", "house_detatched5_roof_W" ],
+    "fg": [ "house_detatched5_roof_N", "house_detatched5_roof_W", "house_detatched5_roof_S", "house_detatched5_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "house_detatched5_basement" ],
     "fg": [
       "house_detatched5_basement_N",
-      "house_detatched5_basement_E",
+      "house_detatched5_basement_W",
       "house_detatched5_basement_S",
-      "house_detatched5_basement_W"
+      "house_detatched5_basement_E"
     ],
     "bg": [ "solid_earth" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched6/house_detatched6.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched6/house_detatched6.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_detatched6" ],
-    "fg": [ "house_detatched6_N", "house_detatched6_E", "house_detatched6_S", "house_detatched6_W" ],
+    "fg": [ "house_detatched6_N", "house_detatched6_W", "house_detatched6_S", "house_detatched6_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_detatched6_roof" ],
-    "fg": [ "house_detatched6_roof_N", "house_detatched6_roof_E", "house_detatched6_roof_S", "house_detatched6_roof_W" ],
+    "fg": [ "house_detatched6_roof_N", "house_detatched6_roof_W", "house_detatched6_roof_S", "house_detatched6_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "house_detatched6_basement" ],
     "fg": [
       "house_detatched6_basement_N",
-      "house_detatched6_basement_E",
+      "house_detatched6_basement_W",
       "house_detatched6_basement_S",
-      "house_detatched6_basement_W"
+      "house_detatched6_basement_E"
     ],
     "bg": [ "solid_earth" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched7/house_detatched7.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched7/house_detatched7.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_detatched7" ],
-    "fg": [ "house_detatched7_N", "house_detatched7_E", "house_detatched7_S", "house_detatched7_W" ],
+    "fg": [ "house_detatched7_N", "house_detatched7_W", "house_detatched7_S", "house_detatched7_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_detatched7_roof" ],
-    "fg": [ "house_detatched7_roof_N", "house_detatched7_roof_E", "house_detatched7_roof_S", "house_detatched7_roof_W" ],
+    "fg": [ "house_detatched7_roof_N", "house_detatched7_roof_W", "house_detatched7_roof_S", "house_detatched7_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "house_detatched7_basement" ],
     "fg": [
       "house_detatched7_basement_N",
-      "house_detatched7_basement_E",
+      "house_detatched7_basement_W",
       "house_detatched7_basement_S",
-      "house_detatched7_basement_W"
+      "house_detatched7_basement_E"
     ],
     "bg": [ "solid_earth" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched8/house_detatched8.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched8/house_detatched8.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_detatched8" ],
-    "fg": [ "house_detatched8_N", "house_detatched8_E", "house_detatched8_S", "house_detatched8_W" ],
+    "fg": [ "house_detatched8_N", "house_detatched8_W", "house_detatched8_S", "house_detatched8_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_detatched8_roof" ],
-    "fg": [ "house_detatched8_roof_N", "house_detatched8_roof_E", "house_detatched8_roof_S", "house_detatched8_roof_W" ],
+    "fg": [ "house_detatched8_roof_N", "house_detatched8_roof_W", "house_detatched8_roof_S", "house_detatched8_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "house_detatched8_basement" ],
     "fg": [
       "house_detatched8_basement_N",
-      "house_detatched8_basement_E",
+      "house_detatched8_basement_W",
       "house_detatched8_basement_S",
-      "house_detatched8_basement_W"
+      "house_detatched8_basement_E"
     ],
     "bg": [ "solid_earth" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched9/house_detatched9.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_detatched9/house_detatched9.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_detatched9" ],
-    "fg": [ "house_detatched9_N", "house_detatched9_E", "house_detatched9_S", "house_detatched9_W" ],
+    "fg": [ "house_detatched9_N", "house_detatched9_W", "house_detatched9_S", "house_detatched9_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_detatched9_roof" ],
-    "fg": [ "house_detatched9_roof_N", "house_detatched9_roof_E", "house_detatched9_roof_S", "house_detatched9_roof_W" ],
+    "fg": [ "house_detatched9_roof_N", "house_detatched9_roof_W", "house_detatched9_roof_S", "house_detatched9_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "house_detatched9_basement" ],
     "fg": [
       "house_detatched9_basement_N",
-      "house_detatched9_basement_E",
+      "house_detatched9_basement_W",
       "house_detatched9_basement_S",
-      "house_detatched9_basement_W"
+      "house_detatched9_basement_E"
     ],
     "bg": [ "solid_earth" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex10/house_duplex10.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex10/house_duplex10.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_duplex10" ],
-    "fg": [ "house_duplex10_N", "house_duplex10_E", "house_duplex10_S", "house_duplex10_W" ],
+    "fg": [ "house_duplex10_N", "house_duplex10_W", "house_duplex10_S", "house_duplex10_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_duplex10_roof" ],
-    "fg": [ "house_duplex10_roof_N", "house_duplex10_roof_E", "house_duplex10_roof_S", "house_duplex10_roof_W" ],
+    "fg": [ "house_duplex10_roof_N", "house_duplex10_roof_W", "house_duplex10_roof_S", "house_duplex10_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex11/house_duplex11.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex11/house_duplex11.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_duplex11" ],
-    "fg": [ "house_duplex11_N", "house_duplex11_E", "house_duplex11_S", "house_duplex11_W" ],
+    "fg": [ "house_duplex11_N", "house_duplex11_W", "house_duplex11_S", "house_duplex11_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_duplex11_roof" ],
-    "fg": [ "house_duplex11_roof_N", "house_duplex11_roof_E", "house_duplex11_roof_S", "house_duplex11_roof_W" ],
+    "fg": [ "house_duplex11_roof_N", "house_duplex11_roof_W", "house_duplex11_roof_S", "house_duplex11_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex2/house_duplex2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex2/house_duplex2.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_duplex2" ],
-    "fg": [ "house_duplex2_N", "house_duplex2_E", "house_duplex2_S", "house_duplex2_W" ],
+    "fg": [ "house_duplex2_N", "house_duplex2_W", "house_duplex2_S", "house_duplex2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_duplex2_roof" ],
-    "fg": [ "house_duplex2_roof_N", "house_duplex2_roof_E", "house_duplex2_roof_S", "house_duplex2_roof_W" ],
+    "fg": [ "house_duplex2_roof_N", "house_duplex2_roof_W", "house_duplex2_roof_S", "house_duplex2_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex3/house_duplex3.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex3/house_duplex3.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_duplex3" ],
-    "fg": [ "house_duplex3_N", "house_duplex3_E", "house_duplex3_S", "house_duplex3_W" ],
+    "fg": [ "house_duplex3_N", "house_duplex3_W", "house_duplex3_S", "house_duplex3_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_duplex3_roof" ],
-    "fg": [ "house_duplex3_roof_N", "house_duplex3_roof_E", "house_duplex3_roof_S", "house_duplex3_roof_W" ],
+    "fg": [ "house_duplex3_roof_N", "house_duplex3_roof_W", "house_duplex3_roof_S", "house_duplex3_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex4/house_duplex4.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex4/house_duplex4.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_duplex4" ],
-    "fg": [ "house_duplex4_N", "house_duplex4_E", "house_duplex4_S", "house_duplex4_W" ],
+    "fg": [ "house_duplex4_N", "house_duplex4_W", "house_duplex4_S", "house_duplex4_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_duplex4_roof" ],
-    "fg": [ "house_duplex4_roof_N", "house_duplex4_roof_E", "house_duplex4_roof_S", "house_duplex4_roof_W" ],
+    "fg": [ "house_duplex4_roof_N", "house_duplex4_roof_W", "house_duplex4_roof_S", "house_duplex4_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex5/house_duplex5.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex5/house_duplex5.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_duplex5" ],
-    "fg": [ "house_duplex5_N", "house_duplex5_E", "house_duplex5_S", "house_duplex5_W" ],
+    "fg": [ "house_duplex5_N", "house_duplex5_W", "house_duplex5_S", "house_duplex5_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_duplex5_roof" ],
-    "fg": [ "house_duplex5_roof_N", "house_duplex5_roof_E", "house_duplex5_roof_S", "house_duplex5_roof_W" ],
+    "fg": [ "house_duplex5_roof_N", "house_duplex5_roof_W", "house_duplex5_roof_S", "house_duplex5_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex6/house_duplex6.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex6/house_duplex6.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_duplex6" ],
-    "fg": [ "house_duplex6_N", "house_duplex6_E", "house_duplex6_S", "house_duplex6_W" ],
+    "fg": [ "house_duplex6_N", "house_duplex6_W", "house_duplex6_S", "house_duplex6_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_duplex6_roof" ],
-    "fg": [ "house_duplex6_roof_N", "house_duplex6_roof_E", "house_duplex6_roof_S", "house_duplex6_roof_W" ],
+    "fg": [ "house_duplex6_roof_N", "house_duplex6_roof_W", "house_duplex6_roof_S", "house_duplex6_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex7/house_duplex7.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex7/house_duplex7.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_duplex7" ],
-    "fg": [ "house_duplex7_N", "house_duplex7_E", "house_duplex7_S", "house_duplex7_W" ],
+    "fg": [ "house_duplex7_N", "house_duplex7_W", "house_duplex7_S", "house_duplex7_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_duplex7_roof" ],
-    "fg": [ "house_duplex7_roof_N", "house_duplex7_roof_E", "house_duplex7_roof_S", "house_duplex7_roof_W" ],
+    "fg": [ "house_duplex7_roof_N", "house_duplex7_roof_W", "house_duplex7_roof_S", "house_duplex7_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex8/house_duplex8.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex8/house_duplex8.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_duplex8" ],
-    "fg": [ "house_duplex8_N", "house_duplex8_E", "house_duplex8_S", "house_duplex8_W" ],
+    "fg": [ "house_duplex8_N", "house_duplex8_W", "house_duplex8_S", "house_duplex8_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_duplex8_roof" ],
-    "fg": [ "house_duplex8_roof_N", "house_duplex8_roof_E", "house_duplex8_roof_S", "house_duplex8_roof_W" ],
+    "fg": [ "house_duplex8_roof_N", "house_duplex8_roof_W", "house_duplex8_roof_S", "house_duplex8_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex9/house_duplex9.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_duplex9/house_duplex9.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_duplex9" ],
-    "fg": [ "house_duplex9_N", "house_duplex9_E", "house_duplex9_S", "house_duplex9_W" ],
+    "fg": [ "house_duplex9_N", "house_duplex9_W", "house_duplex9_S", "house_duplex9_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_duplex9_roof" ],
-    "fg": [ "house_duplex9_roof_N", "house_duplex9_roof_E", "house_duplex9_roof_S", "house_duplex9_roof_W" ],
+    "fg": [ "house_duplex9_roof_N", "house_duplex9_roof_W", "house_duplex9_roof_S", "house_duplex9_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_fortified/house_fortified.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_fortified/house_fortified.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_fortified" ],
-    "fg": [ "house_fortified_N", "house_fortified_E", "house_fortified_S", "house_fortified_W" ],
+    "fg": [ "house_fortified_N", "house_fortified_W", "house_fortified_S", "house_fortified_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_fortified_roof" ],
-    "fg": [ "house_fortified_roof_N", "house_fortified_roof_E", "house_fortified_roof_S", "house_fortified_roof_W" ],
+    "fg": [ "house_fortified_roof_N", "house_fortified_roof_W", "house_fortified_roof_S", "house_fortified_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
@@ -15,9 +15,9 @@
     "id": [ "house_fortified_basement" ],
     "fg": [
       "house_fortified_basement_N",
-      "house_fortified_basement_E",
+      "house_fortified_basement_W",
       "house_fortified_basement_S",
-      "house_fortified_basement_W"
+      "house_fortified_basement_E"
     ],
     "bg": [ "solid_earth" ],
     "rotates": true

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage/house_garage.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage/house_garage.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_garage" ],
-    "fg": [ "house_garage_N", "house_garage_E", "house_garage_S", "house_garage_W" ],
+    "fg": [ "house_garage_N", "house_garage_W", "house_garage_S", "house_garage_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_garage_roof" ],
-    "fg": [ "house_garage_roof_N", "house_garage_roof_E", "house_garage_roof_S", "house_garage_roof_W" ],
+    "fg": [ "house_garage_roof_N", "house_garage_roof_W", "house_garage_roof_S", "house_garage_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_garage_basement" ],
-    "fg": [ "house_garage_basement_N", "house_garage_basement_E", "house_garage_basement_S", "house_garage_basement_W" ],
+    "fg": [ "house_garage_basement_N", "house_garage_basement_W", "house_garage_basement_S", "house_garage_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage2/house_garage2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage2/house_garage2.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_garage2" ],
-    "fg": [ "house_garage2_N", "house_garage2_E", "house_garage2_S", "house_garage2_W" ],
+    "fg": [ "house_garage2_N", "house_garage2_W", "house_garage2_S", "house_garage2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_garage2_roof" ],
-    "fg": [ "house_garage2_roof_N", "house_garage2_roof_E", "house_garage2_roof_S", "house_garage2_roof_W" ],
+    "fg": [ "house_garage2_roof_N", "house_garage2_roof_W", "house_garage2_roof_S", "house_garage2_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_garage2_basement" ],
-    "fg": [ "house_garage2_basement_N", "house_garage2_basement_E", "house_garage2_basement_S", "house_garage2_basement_W" ],
+    "fg": [ "house_garage2_basement_N", "house_garage2_basement_W", "house_garage2_basement_S", "house_garage2_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage3/house_garage3.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage3/house_garage3.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_garage3" ],
-    "fg": [ "house_garage3_N", "house_garage3_E", "house_garage3_S", "house_garage3_W" ],
+    "fg": [ "house_garage3_N", "house_garage3_W", "house_garage3_S", "house_garage3_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_garage3_roof" ],
-    "fg": [ "house_garage3_roof_N", "house_garage3_roof_E", "house_garage3_roof_S", "house_garage3_roof_W" ],
+    "fg": [ "house_garage3_roof_N", "house_garage3_roof_W", "house_garage3_roof_S", "house_garage3_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_garage3_basement" ],
-    "fg": [ "house_garage3_basement_N", "house_garage3_basement_E", "house_garage3_basement_S", "house_garage3_basement_W" ],
+    "fg": [ "house_garage3_basement_N", "house_garage3_basement_W", "house_garage3_basement_S", "house_garage3_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage4/house_garage4.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage4/house_garage4.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_garage4" ],
-    "fg": [ "house_garage4_N", "house_garage4_E", "house_garage4_S", "house_garage4_W" ],
+    "fg": [ "house_garage4_N", "house_garage4_W", "house_garage4_S", "house_garage4_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_garage4_roof" ],
-    "fg": [ "house_garage4_roof_N", "house_garage4_roof_E", "house_garage4_roof_S", "house_garage4_roof_W" ],
+    "fg": [ "house_garage4_roof_N", "house_garage4_roof_W", "house_garage4_roof_S", "house_garage4_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_garage4_basement" ],
-    "fg": [ "house_garage4_basement_N", "house_garage4_basement_E", "house_garage4_basement_S", "house_garage4_basement_W" ],
+    "fg": [ "house_garage4_basement_N", "house_garage4_basement_W", "house_garage4_basement_S", "house_garage4_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage5/house_garage5.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage5/house_garage5.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_garage5" ],
-    "fg": [ "house_garage5_N", "house_garage5_E", "house_garage5_S", "house_garage5_W" ],
+    "fg": [ "house_garage5_N", "house_garage5_W", "house_garage5_S", "house_garage5_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_garage5_roof" ],
-    "fg": [ "house_garage5_roof_N", "house_garage5_roof_E", "house_garage5_roof_S", "house_garage5_roof_W" ],
+    "fg": [ "house_garage5_roof_N", "house_garage5_roof_W", "house_garage5_roof_S", "house_garage5_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_garage5_basement" ],
-    "fg": [ "house_garage5_basement_N", "house_garage5_basement_E", "house_garage5_basement_S", "house_garage5_basement_W" ],
+    "fg": [ "house_garage5_basement_N", "house_garage5_basement_W", "house_garage5_basement_S", "house_garage5_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage6/house_garage6.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage6/house_garage6.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_garage6" ],
-    "fg": [ "house_garage6_N", "house_garage6_E", "house_garage6_S", "house_garage6_W" ],
+    "fg": [ "house_garage6_N", "house_garage6_W", "house_garage6_S", "house_garage6_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_garage6_roof" ],
-    "fg": [ "house_garage6_roof_N", "house_garage6_roof_E", "house_garage6_roof_S", "house_garage6_roof_W" ],
+    "fg": [ "house_garage6_roof_N", "house_garage6_roof_W", "house_garage6_roof_S", "house_garage6_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_garage6_basement" ],
-    "fg": [ "house_garage6_basement_N", "house_garage6_basement_E", "house_garage6_basement_S", "house_garage6_basement_W" ],
+    "fg": [ "house_garage6_basement_N", "house_garage6_basement_W", "house_garage6_basement_S", "house_garage6_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage7/house_garage7.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage7/house_garage7.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_garage7" ],
-    "fg": [ "house_garage7_N", "house_garage7_E", "house_garage7_S", "house_garage7_W" ],
+    "fg": [ "house_garage7_N", "house_garage7_W", "house_garage7_S", "house_garage7_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_garage7_roof" ],
-    "fg": [ "house_garage7_roof_N", "house_garage7_roof_E", "house_garage7_roof_S", "house_garage7_roof_W" ],
+    "fg": [ "house_garage7_roof_N", "house_garage7_roof_W", "house_garage7_roof_S", "house_garage7_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_garage7_basement" ],
-    "fg": [ "house_garage7_basement_N", "house_garage7_basement_E", "house_garage7_basement_S", "house_garage7_basement_W" ],
+    "fg": [ "house_garage7_basement_N", "house_garage7_basement_W", "house_garage7_basement_S", "house_garage7_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage8/house_garage8.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_garage8/house_garage8.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_garage8" ],
-    "fg": [ "house_garage8_N", "house_garage8_E", "house_garage8_S", "house_garage8_W" ],
+    "fg": [ "house_garage8_N", "house_garage8_W", "house_garage8_S", "house_garage8_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_garage8_roof" ],
-    "fg": [ "house_garage8_roof_N", "house_garage8_roof_E", "house_garage8_roof_S", "house_garage8_roof_W" ],
+    "fg": [ "house_garage8_roof_N", "house_garage8_roof_W", "house_garage8_roof_S", "house_garage8_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_garage8_basement" ],
-    "fg": [ "house_garage8_basement_N", "house_garage8_basement_E", "house_garage8_basement_S", "house_garage8_basement_W" ],
+    "fg": [ "house_garage8_basement_N", "house_garage8_basement_W", "house_garage8_basement_S", "house_garage8_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_gardener/house_gardener.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_gardener/house_gardener.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_gardener" ],
-    "fg": [ "house_gardener_N", "house_gardener_E", "house_gardener_S", "house_gardener_W" ],
+    "fg": [ "house_gardener_N", "house_gardener_W", "house_gardener_S", "house_gardener_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_gardener_roof" ],
-    "fg": [ "house_gardener_roof_N", "house_gardener_roof_E", "house_gardener_roof_S", "house_gardener_roof_W" ],
+    "fg": [ "house_gardener_roof_N", "house_gardener_roof_W", "house_gardener_roof_S", "house_gardener_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_gardener_basement" ],
-    "fg": [ "house_gardener_basement_N", "house_gardener_basement_E", "house_gardener_basement_S", "house_gardener_basement_W" ],
+    "fg": [ "house_gardener_basement_N", "house_gardener_basement_W", "house_gardener_basement_S", "house_gardener_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_inner_garden/house_inner_garden.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_inner_garden/house_inner_garden.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_inner_garden" ],
-    "fg": [ "house_inner_garden_N", "house_inner_garden_E", "house_inner_garden_S", "house_inner_garden_W" ],
+    "fg": [ "house_inner_garden_N", "house_inner_garden_W", "house_inner_garden_S", "house_inner_garden_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_inner_garden_roof" ],
-    "fg": [ "house_inner_garden_roof_N", "house_inner_garden_roof_E", "house_inner_garden_roof_S", "house_inner_garden_roof_W" ],
+    "fg": [ "house_inner_garden_roof_N", "house_inner_garden_roof_W", "house_inner_garden_roof_S", "house_inner_garden_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_library/house_library.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_library/house_library.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "house_library" ],
-    "fg": [ "house_library_N", "house_library_E", "house_library_S", "house_library_W" ],
+    "fg": [ "house_library_N", "house_library_W", "house_library_S", "house_library_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_modern_1/house_modern_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_modern_1/house_modern_1.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_modern_1" ],
-    "fg": [ "house_modern_1_N", "house_modern_1_E", "house_modern_1_S", "house_modern_1_W" ],
+    "fg": [ "house_modern_1_N", "house_modern_1_W", "house_modern_1_S", "house_modern_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_modern_1_roof" ],
-    "fg": [ "house_modern_1_roof_N", "house_modern_1_roof_E", "house_modern_1_roof_S", "house_modern_1_roof_W" ],
+    "fg": [ "house_modern_1_roof_N", "house_modern_1_roof_W", "house_modern_1_roof_S", "house_modern_1_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_modern_1_basement" ],
-    "fg": [ "house_modern_1_basement_N", "house_modern_1_basement_E", "house_modern_1_basement_S", "house_modern_1_basement_W" ],
+    "fg": [ "house_modern_1_basement_N", "house_modern_1_basement_W", "house_modern_1_basement_S", "house_modern_1_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_patio/house_patio.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_patio/house_patio.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_patio" ],
-    "fg": [ "house_patio_N", "house_patio_E", "house_patio_S", "house_patio_W" ],
+    "fg": [ "house_patio_N", "house_patio_W", "house_patio_S", "house_patio_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_patio_roof" ],
-    "fg": [ "house_patio_roof_N", "house_patio_roof_E", "house_patio_roof_S", "house_patio_roof_W" ],
+    "fg": [ "house_patio_roof_N", "house_patio_roof_W", "house_patio_roof_S", "house_patio_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_patio_basement" ],
-    "fg": [ "house_patio_basement_N", "house_patio_basement_E", "house_patio_basement_S", "house_patio_basement_W" ],
+    "fg": [ "house_patio_basement_N", "house_patio_basement_W", "house_patio_basement_S", "house_patio_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_porch/house_porch.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_porch/house_porch.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_porch" ],
-    "fg": [ "house_porch_N", "house_porch_E", "house_porch_S", "house_porch_W" ],
+    "fg": [ "house_porch_N", "house_porch_W", "house_porch_S", "house_porch_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_porch_roof" ],
-    "fg": [ "house_porch_roof_N", "house_porch_roof_E", "house_porch_roof_S", "house_porch_roof_W" ],
+    "fg": [ "house_porch_roof_N", "house_porch_roof_W", "house_porch_roof_S", "house_porch_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_porch_basement" ],
-    "fg": [ "house_porch_basement_N", "house_porch_basement_E", "house_porch_basement_S", "house_porch_basement_W" ],
+    "fg": [ "house_porch_basement_N", "house_porch_basement_W", "house_porch_basement_S", "house_porch_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_prepper/house_prepper.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_prepper/house_prepper.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_prepper" ],
-    "fg": [ "house_prepper_N", "house_prepper_E", "house_prepper_S", "house_prepper_W" ],
+    "fg": [ "house_prepper_N", "house_prepper_W", "house_prepper_S", "house_prepper_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_prepper_basement" ],
-    "fg": [ "house_prepper_basement_N", "house_prepper_basement_E", "house_prepper_basement_S", "house_prepper_basement_W" ],
+    "fg": [ "house_prepper_basement_N", "house_prepper_basement_W", "house_prepper_basement_S", "house_prepper_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_prepper2/house_prepper2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_prepper2/house_prepper2.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_prepper2" ],
-    "fg": [ "house_prepper2_N", "house_prepper2_E", "house_prepper2_S", "house_prepper2_W" ],
+    "fg": [ "house_prepper2_N", "house_prepper2_W", "house_prepper2_S", "house_prepper2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_prepper2_roof" ],
-    "fg": [ "house_prepper2_roof_N", "house_prepper2_roof_E", "house_prepper2_roof_S", "house_prepper2_roof_W" ],
+    "fg": [ "house_prepper2_roof_N", "house_prepper2_roof_W", "house_prepper2_roof_S", "house_prepper2_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_prepper2_basement" ],
-    "fg": [ "house_prepper2_basement_N", "house_prepper2_basement_E", "house_prepper2_basement_S", "house_prepper2_basement_W" ],
+    "fg": [ "house_prepper2_basement_N", "house_prepper2_basement_W", "house_prepper2_basement_S", "house_prepper2_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_quiverfull/house_quiverfull.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_quiverfull/house_quiverfull.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "house_quiverfull" ],
-    "fg": [ "house_quiverfull_N", "house_quiverfull_E", "house_quiverfull_S", "house_quiverfull_W" ],
+    "fg": [ "house_quiverfull_N", "house_quiverfull_W", "house_quiverfull_S", "house_quiverfull_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_rv/house_rv.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_rv/house_rv.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_rv" ],
-    "fg": [ "house_rv_N", "house_rv_E", "house_rv_S", "house_rv_W" ],
+    "fg": [ "house_rv_N", "house_rv_W", "house_rv_S", "house_rv_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_rv_roof" ],
-    "fg": [ "house_rv_roof_N", "house_rv_roof_E", "house_rv_roof_S", "house_rv_roof_W" ],
+    "fg": [ "house_rv_roof_N", "house_rv_roof_W", "house_rv_roof_S", "house_rv_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_rv_basement" ],
-    "fg": [ "house_rv_basement_N", "house_rv_basement_E", "house_rv_basement_S", "house_rv_basement_W" ],
+    "fg": [ "house_rv_basement_N", "house_rv_basement_W", "house_rv_basement_S", "house_rv_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_suicide/house_suicide.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_suicide/house_suicide.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_suicide" ],
-    "fg": [ "house_suicide_N", "house_suicide_E", "house_suicide_S", "house_suicide_W" ],
+    "fg": [ "house_suicide_N", "house_suicide_W", "house_suicide_S", "house_suicide_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_suicide_roof" ],
-    "fg": [ "house_suicide_roof_N", "house_suicide_roof_E", "house_suicide_roof_S", "house_suicide_roof_W" ],
+    "fg": [ "house_suicide_roof_N", "house_suicide_roof_W", "house_suicide_roof_S", "house_suicide_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_toolshed/house_toolshed.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_toolshed/house_toolshed.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_toolshed" ],
-    "fg": [ "house_toolshed_N", "house_toolshed_E", "house_toolshed_S", "house_toolshed_W" ],
+    "fg": [ "house_toolshed_N", "house_toolshed_W", "house_toolshed_S", "house_toolshed_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_toolshed_roof" ],
-    "fg": [ "house_toolshed_roof_N", "house_toolshed_roof_E", "house_toolshed_roof_S", "house_toolshed_roof_W" ],
+    "fg": [ "house_toolshed_roof_N", "house_toolshed_roof_W", "house_toolshed_roof_S", "house_toolshed_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_toolshed_basement" ],
-    "fg": [ "house_toolshed_basement_N", "house_toolshed_basement_E", "house_toolshed_basement_S", "house_toolshed_basement_W" ],
+    "fg": [ "house_toolshed_basement_N", "house_toolshed_basement_W", "house_toolshed_basement_S", "house_toolshed_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_10/house_urban_10.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_10/house_urban_10.json
@@ -1,49 +1,49 @@
 [
   {
     "id": [ "urban_10_1" ],
-    "fg": [ "urban_10_1_N", "urban_10_1_E", "urban_10_1_S", "urban_10_1_W" ],
+    "fg": [ "urban_10_1_N", "urban_10_1_W", "urban_10_1_S", "urban_10_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_10_2" ],
-    "fg": [ "urban_10_2_N", "urban_10_2_E", "urban_10_2_S", "urban_10_2_W" ],
+    "fg": [ "urban_10_2_N", "urban_10_2_W", "urban_10_2_S", "urban_10_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_10_3" ],
-    "fg": [ "urban_10_3_N", "urban_10_3_E", "urban_10_3_S", "urban_10_3_W" ],
+    "fg": [ "urban_10_3_N", "urban_10_3_W", "urban_10_3_S", "urban_10_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_10_4" ],
-    "fg": [ "urban_10_4_N", "urban_10_4_E", "urban_10_4_S", "urban_10_4_W" ],
+    "fg": [ "urban_10_4_N", "urban_10_4_W", "urban_10_4_S", "urban_10_4_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_10_5" ],
-    "fg": [ "urban_10_5_N", "urban_10_5_E", "urban_10_5_S", "urban_10_5_W" ],
+    "fg": [ "urban_10_5_N", "urban_10_5_W", "urban_10_5_S", "urban_10_5_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_10_6" ],
-    "fg": [ "urban_10_6_N", "urban_10_6_E", "urban_10_6_S", "urban_10_6_W" ],
+    "fg": [ "urban_10_6_N", "urban_10_6_W", "urban_10_6_S", "urban_10_6_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_10_7" ],
-    "fg": [ "urban_10_7_N", "urban_10_7_E", "urban_10_7_S", "urban_10_7_W" ],
+    "fg": [ "urban_10_7_N", "urban_10_7_W", "urban_10_7_S", "urban_10_7_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   },
   {
     "id": [ "urban_10_8" ],
-    "fg": [ "urban_10_8_N", "urban_10_8_E", "urban_10_8_S", "urban_10_8_W" ],
+    "fg": [ "urban_10_8_N", "urban_10_8_W", "urban_10_8_S", "urban_10_8_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_11/house_urban_11.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_11/house_urban_11.json
@@ -1,37 +1,37 @@
 [
   {
     "id": [ "urban_11_1" ],
-    "fg": [ "urban_11_1_N", "urban_11_1_E", "urban_11_1_S", "urban_11_1_W" ],
+    "fg": [ "urban_11_1_N", "urban_11_1_W", "urban_11_1_S", "urban_11_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_11_2" ],
-    "fg": [ "urban_11_2_N", "urban_11_2_E", "urban_11_2_S", "urban_11_2_W" ],
+    "fg": [ "urban_11_2_N", "urban_11_2_W", "urban_11_2_S", "urban_11_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_11_3" ],
-    "fg": [ "urban_11_3_N", "urban_11_3_E", "urban_11_3_S", "urban_11_3_W" ],
+    "fg": [ "urban_11_3_N", "urban_11_3_W", "urban_11_3_S", "urban_11_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_11_4" ],
-    "fg": [ "urban_11_4_N", "urban_11_4_E", "urban_11_4_S", "urban_11_4_W" ],
+    "fg": [ "urban_11_4_N", "urban_11_4_W", "urban_11_4_S", "urban_11_4_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_11_5" ],
-    "fg": [ "urban_11_5_N", "urban_11_5_E", "urban_11_5_S", "urban_11_5_W" ],
+    "fg": [ "urban_11_5_N", "urban_11_5_W", "urban_11_5_S", "urban_11_5_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_11_6" ],
-    "fg": [ "urban_11_6_N", "urban_11_6_E", "urban_11_6_S", "urban_11_6_W" ],
+    "fg": [ "urban_11_6_N", "urban_11_6_W", "urban_11_6_S", "urban_11_6_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_12/house_urban_12.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_12/house_urban_12.json
@@ -1,37 +1,37 @@
 [
   {
     "id": [ "urban_12_1" ],
-    "fg": [ "urban_12_1_N", "urban_12_1_E", "urban_12_1_S", "urban_12_1_W" ],
+    "fg": [ "urban_12_1_N", "urban_12_1_W", "urban_12_1_S", "urban_12_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_12_2" ],
-    "fg": [ "urban_12_2_N", "urban_12_2_E", "urban_12_2_S", "urban_12_2_W" ],
+    "fg": [ "urban_12_2_N", "urban_12_2_W", "urban_12_2_S", "urban_12_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_12_3" ],
-    "fg": [ "urban_12_3_N", "urban_12_3_E", "urban_12_3_S", "urban_12_3_W" ],
+    "fg": [ "urban_12_3_N", "urban_12_3_W", "urban_12_3_S", "urban_12_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_12_4" ],
-    "fg": [ "urban_12_4_N", "urban_12_4_E", "urban_12_4_S", "urban_12_4_W" ],
+    "fg": [ "urban_12_4_N", "urban_12_4_W", "urban_12_4_S", "urban_12_4_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_12_5" ],
-    "fg": [ "urban_12_5_N", "urban_12_5_E", "urban_12_5_S", "urban_12_5_W" ],
+    "fg": [ "urban_12_5_N", "urban_12_5_W", "urban_12_5_S", "urban_12_5_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_12_6" ],
-    "fg": [ "urban_12_6_N", "urban_12_6_E", "urban_12_6_S", "urban_12_6_W" ],
+    "fg": [ "urban_12_6_N", "urban_12_6_W", "urban_12_6_S", "urban_12_6_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_15/house_urban_15.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_15/house_urban_15.json
@@ -1,37 +1,37 @@
 [
   {
     "id": [ "urban_15_1" ],
-    "fg": [ "urban_15_1_N", "urban_15_1_E", "urban_15_1_S", "urban_15_1_W" ],
+    "fg": [ "urban_15_1_N", "urban_15_1_W", "urban_15_1_S", "urban_15_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_15_2" ],
-    "fg": [ "urban_15_2_N", "urban_15_2_E", "urban_15_2_S", "urban_15_2_W" ],
+    "fg": [ "urban_15_2_N", "urban_15_2_W", "urban_15_2_S", "urban_15_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_15_3" ],
-    "fg": [ "urban_15_3_N", "urban_15_3_E", "urban_15_3_S", "urban_15_3_W" ],
+    "fg": [ "urban_15_3_N", "urban_15_3_W", "urban_15_3_S", "urban_15_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_15_4" ],
-    "fg": [ "urban_15_4_N", "urban_15_4_E", "urban_15_4_S", "urban_15_4_W" ],
+    "fg": [ "urban_15_4_N", "urban_15_4_W", "urban_15_4_S", "urban_15_4_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_15_5" ],
-    "fg": [ "urban_15_5_N", "urban_15_5_E", "urban_15_5_S", "urban_15_5_W" ],
+    "fg": [ "urban_15_5_N", "urban_15_5_W", "urban_15_5_S", "urban_15_5_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_15_6" ],
-    "fg": [ "urban_15_6_N", "urban_15_6_E", "urban_15_6_S", "urban_15_6_W" ],
+    "fg": [ "urban_15_6_N", "urban_15_6_W", "urban_15_6_S", "urban_15_6_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_16/house_urban_16.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_16/house_urban_16.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "urban_16_1" ],
-    "fg": [ "urban_16_1_N", "urban_16_1_E", "urban_16_1_S", "urban_16_1_W" ],
+    "fg": [ "urban_16_1_N", "urban_16_1_W", "urban_16_1_S", "urban_16_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_16_2" ],
-    "fg": [ "urban_16_2_N", "urban_16_2_E", "urban_16_2_S", "urban_16_2_W" ],
+    "fg": [ "urban_16_2_N", "urban_16_2_W", "urban_16_2_S", "urban_16_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_16_3" ],
-    "fg": [ "urban_16_3_N", "urban_16_3_E", "urban_16_3_S", "urban_16_3_W" ],
+    "fg": [ "urban_16_3_N", "urban_16_3_W", "urban_16_3_S", "urban_16_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_16_4" ],
-    "fg": [ "urban_16_4_N", "urban_16_4_E", "urban_16_4_S", "urban_16_4_W" ],
+    "fg": [ "urban_16_4_N", "urban_16_4_W", "urban_16_4_S", "urban_16_4_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_17/house_urban_17.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_17/house_urban_17.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "urban_17_1" ],
-    "fg": [ "urban_17_1_N", "urban_17_1_E", "urban_17_1_S", "urban_17_1_W" ],
+    "fg": [ "urban_17_1_N", "urban_17_1_E", "urban_17_1_S", "urban_17_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_17_2" ],
-    "fg": [ "urban_17_2_N", "urban_17_2_E", "urban_17_2_S", "urban_17_2_W" ],
+    "fg": [ "urban_17_2_N", "urban_17_2_E", "urban_17_2_S", "urban_17_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_17_3" ],
-    "fg": [ "urban_17_3_N", "urban_17_3_E", "urban_17_3_S", "urban_17_3_W" ],
+    "fg": [ "urban_17_3_N", "urban_17_3_E", "urban_17_3_S", "urban_17_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_17_4" ],
-    "fg": [ "urban_17_4_N", "urban_17_4_E", "urban_17_4_S", "urban_17_4_W" ],
+    "fg": [ "urban_17_4_N", "urban_17_4_E", "urban_17_4_S", "urban_17_4_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_8/house_urban_8.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_8/house_urban_8.json
@@ -1,31 +1,31 @@
 [
   {
     "id": [ "urban_8_1" ],
-    "fg": [ "urban_8_1_N", "urban_8_1_E", "urban_8_1_S", "urban_8_1_W" ],
+    "fg": [ "urban_8_1_N", "urban_8_1_W", "urban_8_1_S", "urban_8_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_8_2" ],
-    "fg": [ "urban_8_2_N", "urban_8_2_E", "urban_8_2_S", "urban_8_2_W" ],
+    "fg": [ "urban_8_2_N", "urban_8_2_W", "urban_8_2_S", "urban_8_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_8_3" ],
-    "fg": [ "urban_8_3_N", "urban_8_3_E", "urban_8_3_S", "urban_8_3_W" ],
+    "fg": [ "urban_8_3_N", "urban_8_3_W", "urban_8_3_S", "urban_8_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_8_4" ],
-    "fg": [ "urban_8_4_N", "urban_8_4_E", "urban_8_4_S", "urban_8_4_W" ],
+    "fg": [ "urban_8_4_N", "urban_8_4_W", "urban_8_4_S", "urban_8_4_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_8_6" ],
-    "fg": [ "urban_8_6_N", "urban_8_6_E", "urban_8_6_S", "urban_8_6_W" ],
+    "fg": [ "urban_8_6_N", "urban_8_6_W", "urban_8_6_S", "urban_8_6_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_9/house_urban_9.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_urban_9/house_urban_9.json
@@ -1,37 +1,37 @@
 [
   {
     "id": [ "urban_9_1" ],
-    "fg": [ "urban_9_1_N", "urban_9_1_E", "urban_9_1_S", "urban_9_1_W" ],
+    "fg": [ "urban_9_1_N", "urban_9_1_W", "urban_9_1_S", "urban_9_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_9_2" ],
-    "fg": [ "urban_9_2_N", "urban_9_2_E", "urban_9_2_S", "urban_9_2_W" ],
+    "fg": [ "urban_9_2_N", "urban_9_2_W", "urban_9_2_S", "urban_9_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "urban_9_3" ],
-    "fg": [ "urban_9_3_N", "urban_9_3_E", "urban_9_3_S", "urban_9_3_W" ],
+    "fg": [ "urban_9_3_N", "urban_9_3_W", "urban_9_3_S", "urban_9_3_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_9_4" ],
-    "fg": [ "urban_9_4_N", "urban_9_4_E", "urban_9_4_S", "urban_9_4_W" ],
+    "fg": [ "urban_9_4_N", "urban_9_4_W", "urban_9_4_S", "urban_9_4_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_9_5" ],
-    "fg": [ "urban_9_5_N", "urban_9_5_E", "urban_9_5_S", "urban_9_5_W" ],
+    "fg": [ "urban_9_5_N", "urban_9_5_W", "urban_9_5_S", "urban_9_5_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "urban_9_6" ],
-    "fg": [ "urban_9_6_N", "urban_9_6_E", "urban_9_6_S", "urban_9_6_W" ],
+    "fg": [ "urban_9_6_N", "urban_9_6_W", "urban_9_6_S", "urban_9_6_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_vacant/house_vacant.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_vacant/house_vacant.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "house_vacant" ],
-    "fg": [ "house_vacant_N", "house_vacant_E", "house_vacant_S", "house_vacant_W" ],
+    "fg": [ "house_vacant_N", "house_vacant_W", "house_vacant_S", "house_vacant_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_vacant2/house_vacant2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_vacant2/house_vacant2.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "house_vacant2" ],
-    "fg": [ "house_vacant2_N", "house_vacant2_E", "house_vacant2_S", "house_vacant2_W" ],
+    "fg": [ "house_vacant2_N", "house_vacant2_W", "house_vacant2_S", "house_vacant2_E" ],
     "bg": [ "field" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_w_1/house_w_1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_w_1/house_w_1.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_w_1" ],
-    "fg": [ "house_w_1_N", "house_w_1_E", "house_w_1_S", "house_w_1_W" ],
+    "fg": [ "house_w_1_N", "house_w_1_W", "house_w_1_S", "house_w_1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_w_1_roof" ],
-    "fg": [ "house_w_1_roof_N", "house_w_1_roof_E", "house_w_1_roof_S", "house_w_1_roof_W" ],
+    "fg": [ "house_w_1_roof_N", "house_w_1_roof_W", "house_w_1_roof_S", "house_w_1_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_w_1_basement" ],
-    "fg": [ "house_w_1_basement_N", "house_w_1_basement_E", "house_w_1_basement_S", "house_w_1_basement_W" ],
+    "fg": [ "house_w_1_basement_N", "house_w_1_basement_W", "house_w_1_basement_S", "house_w_1_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_w_2/house_w_2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_w_2/house_w_2.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_w_2" ],
-    "fg": [ "house_w_2_N", "house_w_2_E", "house_w_2_S", "house_w_2_W" ],
+    "fg": [ "house_w_2_N", "house_w_2_W", "house_w_2_S", "house_w_2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_w_2_roof" ],
-    "fg": [ "house_w_2_roof_N", "house_w_2_roof_E", "house_w_2_roof_S", "house_w_2_roof_W" ],
+    "fg": [ "house_w_2_roof_N", "house_w_2_roof_W", "house_w_2_roof_S", "house_w_2_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_w_2_basement" ],
-    "fg": [ "house_w_2_basement_N", "house_w_2_basement_E", "house_w_2_basement_S", "house_w_2_basement_W" ],
+    "fg": [ "house_w_2_basement_N", "house_w_2_basement_W", "house_w_2_basement_S", "house_w_2_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_w_3/house_w_3.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_w_3/house_w_3.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_w_3" ],
-    "fg": [ "house_w_3_N", "house_w_3_E", "house_w_3_S", "house_w_3_W" ],
+    "fg": [ "house_w_3_N", "house_w_3_W", "house_w_3_S", "house_w_3_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_w_3_roof" ],
-    "fg": [ "house_w_3_roof_N", "house_w_3_roof_E", "house_w_3_roof_S", "house_w_3_roof_W" ],
+    "fg": [ "house_w_3_roof_N", "house_w_3_roof_W", "house_w_3_roof_S", "house_w_3_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_w_3_basement" ],
-    "fg": [ "house_w_3_basement_N", "house_w_3_basement_E", "house_w_3_basement_S", "house_w_3_basement_W" ],
+    "fg": [ "house_w_3_basement_N", "house_w_3_basement_W", "house_w_3_basement_S", "house_w_3_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_w_4/house_w_4.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_w_4/house_w_4.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_w_4" ],
-    "fg": [ "house_w_4_N", "house_w_4_E", "house_w_4_S", "house_w_4_W" ],
+    "fg": [ "house_w_4_N", "house_w_4_W", "house_w_4_S", "house_w_4_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_w_4_roof" ],
-    "fg": [ "house_w_4_roof_N", "house_w_4_roof_E", "house_w_4_roof_S", "house_w_4_roof_W" ],
+    "fg": [ "house_w_4_roof_N", "house_w_4_roof_W", "house_w_4_roof_S", "house_w_4_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_w_4_basement" ],
-    "fg": [ "house_w_4_basement_N", "house_w_4_basement_E", "house_w_4_basement_S", "house_w_4_basement_W" ],
+    "fg": [ "house_w_4_basement_N", "house_w_4_basement_W", "house_w_4_basement_S", "house_w_4_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_w_5/house_w_5.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_w_5/house_w_5.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "house_w_5" ],
-    "fg": [ "house_w_5_N", "house_w_5_E", "house_w_5_S", "house_w_5_W" ],
+    "fg": [ "house_w_5_N", "house_w_5_W", "house_w_5_S", "house_w_5_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_w_5_roof" ],
-    "fg": [ "house_w_5_roof_N", "house_w_5_roof_E", "house_w_5_roof_S", "house_w_5_roof_W" ],
+    "fg": [ "house_w_5_roof_N", "house_w_5_roof_W", "house_w_5_roof_S", "house_w_5_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_w_5_basement" ],
-    "fg": [ "house_w_5_basement_N", "house_w_5_basement_E", "house_w_5_basement_S", "house_w_5_basement_W" ],
+    "fg": [ "house_w_5_basement_N", "house_w_5_basement_W", "house_w_5_basement_S", "house_w_5_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_w_6/house_w_6.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_w_6/house_w_6.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "house_w_6" ],
-    "fg": [ "house_w_6_N", "house_w_6_E", "house_w_6_S", "house_w_6_W" ],
+    "fg": [ "house_w_6_N", "house_w_6_W", "house_w_6_S", "house_w_6_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_w_6_2ndfloor" ],
-    "fg": [ "house_w_6_2ndfloor_N", "house_w_6_2ndfloor_E", "house_w_6_2ndfloor_S", "house_w_6_2ndfloor_W" ],
+    "fg": [ "house_w_6_2ndfloor_N", "house_w_6_2ndfloor_W", "house_w_6_2ndfloor_S", "house_w_6_2ndfloor_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_w_6_roof" ],
-    "fg": [ "house_w_6_roof_N", "house_w_6_roof_E", "house_w_6_roof_S", "house_w_6_roof_W" ],
+    "fg": [ "house_w_6_roof_N", "house_w_6_roof_W", "house_w_6_roof_S", "house_w_6_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "house_w_6_basement" ],
-    "fg": [ "house_w_6_basement_N", "house_w_6_basement_E", "house_w_6_basement_S", "house_w_6_basement_W" ],
+    "fg": [ "house_w_6_basement_N", "house_w_6_basement_W", "house_w_6_basement_S", "house_w_6_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_wooded/house_wooded.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/house_wooded/house_wooded.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "house_wooded" ],
-    "fg": [ "house_wooded_N", "house_wooded_E", "house_wooded_S", "house_wooded_W" ],
+    "fg": [ "house_wooded_N", "house_wooded_W", "house_wooded_S", "house_wooded_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "house_roof" ],
-    "fg": [ "house_wooded_roof_N", "house_wooded_roof_E", "house_wooded_roof_S", "house_wooded_roof_W" ],
+    "fg": [ "house_wooded_roof_N", "house_wooded_roof_W", "house_wooded_roof_S", "house_wooded_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/rural_house1/rural_house1.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/rural_house1/rural_house1.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "rural_house1" ],
-    "fg": [ "rural_house1_N", "rural_house1_E", "rural_house1_S", "rural_house1_W" ],
+    "fg": [ "rural_house1_N", "rural_house1_W", "rural_house1_S", "rural_house1_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "rural_house1_roof" ],
-    "fg": [ "rural_house1_roof_N", "rural_house1_roof_E", "rural_house1_roof_S", "rural_house1_roof_W" ],
+    "fg": [ "rural_house1_roof_N", "rural_house1_roof_W", "rural_house1_roof_S", "rural_house1_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   }

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/houses/rural_house2/rural_house2.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/houses/rural_house2/rural_house2.json
@@ -1,19 +1,19 @@
 [
   {
     "id": [ "rural_house2" ],
-    "fg": [ "rural_house2_N", "rural_house2_E", "rural_house2_S", "rural_house2_W" ],
+    "fg": [ "rural_house2_N", "rural_house2_W", "rural_house2_S", "rural_house2_E" ],
     "bg": [ "field" ],
     "rotates": true
   },
   {
     "id": [ "rural_house2_roof" ],
-    "fg": [ "rural_house2_roof_N", "rural_house2_roof_E", "rural_house2_roof_S", "rural_house2_roof_W" ],
+    "fg": [ "rural_house2_roof_N", "rural_house2_roof_W", "rural_house2_roof_S", "rural_house2_roof_E" ],
     "bg": [ "open_air" ],
     "rotates": true
   },
   {
     "id": [ "rural_house2_basement" ],
-    "fg": [ "rural_house2_basement_N", "rural_house2_basement_E", "rural_house2_basement_S", "rural_house2_basement_W" ],
+    "fg": [ "rural_house2_basement_N", "rural_house2_basement_W", "rural_house2_basement_S", "rural_house2_basement_E" ],
     "bg": [ "solid_earth" ],
     "rotates": true
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Update json to fix East/West building orientation.

#### Content of the change

Swap _W & _E in json files for houses.

#### Testing
I composed the tileset and checked the overmap using a mega city to confirm changes worked & don't cause errors.

#### Additional information
Simple swap in the json's IDs order so it is NWSE instead of NESW.