### PR TITLE
Add 2farm_11 house to house tile in overmap

### DIFF
--- a/gfx/MShockXotto+/pngs_overmap_32x32/Houses/single_house.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/Houses/single_house.json
@@ -70,7 +70,8 @@
       "urban_18_7",
       "urban_18_8",
       "urban_18_9",
-      "urban_18_10"
+      "urban_18_10",
+      "2farm_11"
     ],
     "fg": [ "single_house_roofN", "single_house_roofE", "single_house_roofS", "single_house_roofW" ],
     "bg": [  ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Add 2farm_11 house to house tile in overmap

#### Content of the change

Gives a house tile to one of the mutable farm tiles in MSXotto+

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
