### PR TITLE
Ultica Doc fix - broken link/ordering in summary

### DIFF
--- a/doc/style/UltimateCataclysm/summary.md
+++ b/doc/style/UltimateCataclysm/summary.md
@@ -2,7 +2,7 @@
 
 Rules and guidelines are divided between groups: 
 - [General](general.md)
-- [Items](items.md) (things on the floor)
-- [Overlay](overlay.md) (wielded/worn/mutations)
+- [Terrain/Furniture](terrain-furniture.md)
 - [Creatures](creatures.md)
-- [Terrain](terrain.md)
+- [Overlay](overlay.md) (wielded/worn/mutations)
+- [Items](items.md) (things on the floor)


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Per title; super simple documentation cleanup.

#### Content of the change
Re-orders the bullets on the summary page to match the rendered table of contents, plus fixed the link to the terrain-furniture page.

<!-- Explain what does this pull request contain. -->

#### Testing
Tested updated markdown in a markdown editor.
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->