### PR TITLE
[Larwick] Minor granularity changes and meadows

### DIFF
--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_granularity.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_granularity.json
@@ -62,17 +62,17 @@
   {
     "id": [ "forested_swampy$vague" ],
     "fg": "unknown_terrain_vague",
-    "bg": "small_tree_cyan"
+    "bg": "small_tree_green"
   },
   {
     "id": [ "forested_swampy$outlines" ],
     "fg": "unknown_terrain_outlines",
-    "bg": "small_tree_cyan"
+    "bg": "swamp_cyan"
   },
   {
     "id": [ "forested_swampy$details" ],
     "fg": "unknown_terrain_details",
-    "bg": "small_tree_cyan"
+    "bg": "swamp_cyan"
   },
   {
     "id": [ "open_land$vague" ],

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_granularity.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_granularity.json
@@ -32,17 +32,17 @@
   {
     "id": [ "isolated_tower$vague" ],
     "fg": "unknown_terrain_vague",
-    "bg": "tower_light_gray"
+    "bg": "watchtower_light_gray"
   },
   {
     "id": [ "isolated_tower$outlines" ],
     "fg": "unknown_terrain_outlines",
-    "bg": "tower_light_gray"
+    "bg": "watchtower_light_gray"
   },
   {
     "id": [ "isolated_tower$details" ],
     "fg": "unknown_terrain_details",
-    "bg": "tower_light_gray"
+    "bg": "watchtower_light_gray"
   },
   {
     "id": [ "forested$vague", "first_glance_forest$vague" ],

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_hardcoded.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_hardcoded.json
@@ -12,6 +12,13 @@
     "fg": "one_grass_brown"
   },
   {
+    "id": [
+      "meadow_end",
+      "meadow_core"
+    ],
+    "fg": "two_grass_brown"
+  },
+  {
     "id": "forest",
     "fg": "small_tree_green"
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Changes granular swamps to reflect what overmap claims they are, granular isolated towers to watchtower sprite, and adds meadows
<!-- Brief description  -->

#### Content of the change
Connects various meadows to "two_grass_brown"
Changes: 
 - Vague-level swamps look like forests
 - Outline and details-level swamps use swamp sprite instead of cyan tree
 - Isolated towers use watchtower sprite instead of (office building) tower

<!-- Explain what does this pull request contain. -->

#### Testing
_Before_
![lar_granbef](https://github.com/user-attachments/assets/b9352d8f-5e9b-4caf-a0da-5a7f12efb385)
_After_
![lar_granaft](https://github.com/user-attachments/assets/88d05203-5c6a-4acd-9c95-55176f543eea)


<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
