### PR TITLE
Add  `apartments_con_tower_115` 

### DIFF
--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
@@ -371,6 +371,7 @@
   },
   {
     "id": "apartments_con_tower_015",
+    "id": "apartments_con_tower_115",
     "fg": "open_air_blue"
   },
   {

--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_residential.json
@@ -370,8 +370,7 @@
     "fg": "tower_light_green"
   },
   {
-    "id": "apartments_con_tower_015",
-    "id": "apartments_con_tower_115",
+    "id": [ "apartments_con_tower_015", "apartments_con_tower_115" ],
     "fg": "open_air_blue"
   },
   {

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/apartment_tower/apartment_tower.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/apartment_tower/apartment_tower.json
@@ -152,9 +152,7 @@
     ]
   },
   {
-    "id": [
-      "apartments_con_tower_015", "apartments_mod_tower_shack_roof"
-    ],
+    "id": [ "apartments_con_tower_015", "apartments_con_tower_115", "apartments_mod_tower_shack_roof" ],
     "fg": "empty",
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/SurveyorsMap/pngs_overmap_24x24/apartment_towers/apartments_con_tower/apartments_con_tower.json
+++ b/gfx/SurveyorsMap/pngs_overmap_24x24/apartment_towers/apartments_con_tower/apartments_con_tower.json
@@ -88,7 +88,7 @@
       "rotates": true
     },
     {
-      "id": [ "apartments_con_tower_015" ],
+      "id": [ "apartments_con_tower_015", "apartments_con_tower_115" ],
       "fg": [
         "apartments_con_tower_015_S",
         "apartments_con_tower_015_E",

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/apartments_con_tower/apartments_con_tower.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/apartments_con_tower/apartments_con_tower.json
@@ -101,6 +101,7 @@
       "apartments_con_tower_112",
       "apartments_con_tower_113",
       "apartments_con_tower_114",
+      "apartments_con_tower_115",
       "apartments_mod_tower_111",
       "apartments_mod_tower_112",
       "apartments_mod_tower_113"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->
https://github.com/CleverRaven/Cataclysm-DDA/pull/75902 added a new overmap - `apartments_con_tower_115`
This pr makes JSON changes for it to be displayed on the map

#### Content of the change

<!-- Explain what does this pull request contain. -->
JSON changes.
`apartments_con_tower_115` looks like other tiles of same building below it in ultica
`apartments_con_tower_115` looks like `apartments_con_tower_015` in other tilesets

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->
The uppermost level of  `apartment_con_new`. Tile to the south of the character is the roof of the stair bulkhead (`apartments_con_tower_115`), which will be added by above mentioned pr. Tile to the west of it is elevator bulkhead's roof (`apartments_con_tower_015`, not changed).
![tops](https://github.com/user-attachments/assets/50f82f88-4ba9-4736-8252-6947d1a9b171)

#### Additional information
