### PR TITLE
[0.i] [Ultica] Add murky water layer JSON to recess

### DIFF
--- a/gfx/UltimateCataclysm/layering.json
+++ b/gfx/UltimateCataclysm/layering.json
@@ -210,10 +210,15 @@
       {
         "item": "water",
         "sprite": [{"id": "puddle_water", "weight": 1}],
-        "layer": 100
+        "layer": 90
       },
       {
         "item": "water_clean",
+        "sprite": [{"id": "puddle_water", "weight": 1}],
+        "layer": 90
+      },
+      {
+        "item": "water_murky",
         "sprite": [{"id": "puddle_water", "weight": 1}],
         "layer": 90
       }
@@ -225,10 +230,15 @@
       {
         "item": "water",
         "sprite": [{"id": "puddle_water", "weight": 1}],
-        "layer": 100
+        "layer": 90
       },
       {
         "item": "water_clean",
+        "sprite": [{"id": "puddle_water", "weight": 1}],
+        "layer": 90
+      },
+      {
+        "item": "water_murky",
         "sprite": [{"id": "puddle_water", "weight": 1}],
         "layer": 90
       }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->
Add murky water layer JSON to recess
#### Content of the change
Modified layering.json to make murky water use the same layer sprite as water and clean water for both recess terrain
<!-- Explain what does this pull request contain. -->

#### Testing
recess water got graphically visible once again :)
<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
0.i change as Cataclysm-DDA PR 76366 ( jsonifny water_from ) isn't backported to 0.H