### PR TITLE
[NeoDays] fix worn chainmail overlays

### DIFF
--- a/gfx/NeoDays/pngs_tiles_10x10/characters/overlay/worn/overlay_female_worn_chainmail_hands.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/characters/overlay/worn/overlay_female_worn_chainmail_hands.json
@@ -1,1 +1,1 @@
-{"id": "overlay_female_worn_chainmail_hands", "fg": ["overlay_female_worn_chainmail_hands"], "bg": []}
+{"id": ["overlay_female_worn_chainmail_junk_hands", "overlay_female_worn_lc_chainmail_hands", "overlay_female_worn_mc_chainmail_hands", "overlay_female_worn_hc_chainmail_hands", "overlay_female_worn_ch_chainmail_hands", "overlay_female_worn_qt_chainmail_hands"], "fg": ["overlay_female_worn_chainmail_hands"], "bg": []}

--- a/gfx/NeoDays/pngs_tiles_10x10/characters/overlay/worn/overlay_female_worn_chainmail_hauberk.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/characters/overlay/worn/overlay_female_worn_chainmail_hauberk.json
@@ -1,1 +1,1 @@
-{"id": "overlay_female_worn_chainmail_hauberk", "fg": ["overlay_female_worn_chainmail_hauberk"], "bg": []}
+{"id": ["overlay_female_worn_chainmail_junk_hauberk", "overlay_female_worn_lc_chainmail_hauberk", "overlay_female_worn_mc_chainmail_hauberk", "overlay_female_worn_hc_chainmail_hauberk", "overlay_female_worn_ch_chainmail_hauberk", "overlay_female_worn_qt_chainmail_hauberk"], "fg": ["overlay_female_worn_chainmail_hauberk"], "bg": []}

--- a/gfx/NeoDays/pngs_tiles_10x10/characters/overlay/worn/overlay_female_worn_chainmail_suit.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/characters/overlay/worn/overlay_female_worn_chainmail_suit.json
@@ -1,1 +1,1 @@
-{"id": "overlay_female_worn_chainmail_suit", "fg": ["overlay_female_worn_chainmail_suit"], "bg": []}
+{"id": ["overlay_female_worn_chainmail_junk_suit", "overlay_female_worn_lc_chainmail_suit", "overlay_female_worn_mc_chainmail_suit", "overlay_female_worn_hc_chainmail_suit", "overlay_female_worn_ch_chainmail_suit", "overlay_female_worn_qt_chainmail_suit"], "fg": ["overlay_female_worn_chainmail_suit"], "bg": []}

--- a/gfx/NeoDays/pngs_tiles_10x10/characters/overlay/worn/overlay_male_worn_chainmail_hands.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/characters/overlay/worn/overlay_male_worn_chainmail_hands.json
@@ -1,1 +1,1 @@
-{"id": "overlay_male_worn_chainmail_hands", "fg": ["overlay_male_worn_chainmail_hands"], "bg": []}
+{"id": ["overlay_male_worn_chainmail_junk_hands", "overlay_male_worn_lc_chainmail_hands", "overlay_male_worn_mc_chainmail_hands", "overlay_male_worn_hc_chainmail_hands", "overlay_male_worn_ch_chainmail_hands", "overlay_male_worn_qt_chainmail_hands"], "fg": ["overlay_male_worn_chainmail_hands"], "bg": []}

--- a/gfx/NeoDays/pngs_tiles_10x10/characters/overlay/worn/overlay_male_worn_chainmail_hauberk.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/characters/overlay/worn/overlay_male_worn_chainmail_hauberk.json
@@ -1,1 +1,1 @@
-{"id": "overlay_male_worn_chainmail_hauberk", "fg": ["overlay_male_worn_chainmail_hauberk"], "bg": []}
+{"id": ["overlay_male_worn_chainmail_junk_hauberk", "overlay_male_worn_lc_chainmail_hauberk", "overlay_male_worn_mc_chainmail_hauberk", "overlay_male_worn_hc_chainmail_hauberk", "overlay_male_worn_ch_chainmail_hauberk", "overlay_male_worn_qt_chainmail_hauberk"], "fg": ["overlay_male_worn_chainmail_hauberk"], "bg": []}

--- a/gfx/NeoDays/pngs_tiles_10x10/characters/overlay/worn/overlay_male_worn_chainmail_suit.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/characters/overlay/worn/overlay_male_worn_chainmail_suit.json
@@ -1,1 +1,1 @@
-{"id": "overlay_male_worn_chainmail_suit", "fg": ["overlay_male_worn_chainmail_suit"], "bg": []}
+{"id": ["overlay_male_worn_chainmail_junk_suit", "overlay_male_worn_lc_chainmail_suit", "overlay_male_worn_mc_chainmail_suit", "overlay_male_worn_hc_chainmail_suit", "overlay_male_worn_ch_chainmail_suit", "overlay_male_worn_qt_chainmail_suit"], "fg": ["overlay_male_worn_chainmail_suit"], "bg": []}


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->

With the chainmail graded steel updates, the overlay got broken. This should fix, AFAICT (and was able to test).

#### Content of the change

Add all new IDs.

#### Testing

Local build, spawn items, works.

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information

I've tried to point to base item instead, but I assume because they're abstract, it doesn't work.