### PR TITLE
[All Overmap Tilesets] Rename gun store ID fix

### DIFF
--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_commercial.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_commercial.json
@@ -276,55 +276,19 @@
     "fg": "shop_magenta"
   },
   {
-    "id": "s_gun",
+      "id": [
+      "s_gun_a",
+	  "s_gun_b_store",
+	  "s_gun_b_range"
+    ],
     "fg": "shop_red"
   },
   {
-    "id": "s_gun_roof",
-    "fg": "shop_red"
-  },
-  {
-    "id": "s_gun_1",
-    "fg": "shop_red"
-  },
-  {
-    "id": "s_gun_roof_1",
-    "fg": "shop_red"
-  },
-  {
-    "id": "s_gun_2",
-    "fg": "shop_red"
-  },
-  {
-    "id": "s_gun_3",
-    "fg": "shop_red"
-  },
-  {
-    "id": "s_gun_roof_3",
-    "fg": "shop_red"
-  },
-  {
-    "id": "s_gun_4",
-    "fg": "shop_red"
-  },
-  {
-    "id": "s_gun_2ndfloor_4",
-    "fg": "shop_red"
-  },
-  {
-    "id": "s_gun_roof_4",
-    "fg": "shop_red"
-  },
-  {
-    "id": "s_gunstore",
-    "fg": "shop_red"
-  },
-  {
-    "id": "s_gunstore_2ndfloor",
-    "fg": "shop_red"
-  },
-  {
-    "id": "s_gunstore_roof",
+    "id":  [
+	  "s_gun_a_roof",
+	  "s_gun_b_roof",
+	  "s_gun_b_range_roof"
+	], 
     "fg": "shop_red"
   },
   {


### PR DESCRIPTION
*Cut all old variants

*Write existed in game files(s_gun.json)

*Tested


#### Summary
After gunstore update it have new "om_terrain": IDs 
That cause to fallback sprite in all Overmap tilesets.

#### Content of the change

Correcting all old IDs in all overmaps tilesets 

Not against helping out if you want to - welcome

#### Testing


#### Additional information

It should be draft untill all overmap tilesets will be fixed
