### PR TITLE
[Chibi Ultica] Exclude MSX furniture and terrain from mods

### DIFF
--- a/gfx/Chibi_Ultica/tile_info.json
+++ b/gfx/Chibi_Ultica/tile_info.json
@@ -20,7 +20,24 @@
     "ChibiNormal.png": {
       "sprite_width": 32,
       "sprite_height": 32,
-      "exclude": [ "appliances", "field", "furniture", "item", "misc", "spell", "terrain", "trap", "vehicle" ]
+      "exclude": [
+        "appliances",
+        "field",
+        "furniture",
+        "item",
+        "misc",
+        "spell",
+        "terrain",
+        "trap",
+        "vehicle",
+        "mods/xedra_evolved/terrain",
+        "mods/xedra_evolved/furniture",
+        "mods/Magiclysm/terrain",
+        "mods/Magiclysm/furniture",
+        "mods/Aftershock/terrain",
+        "mods/Aftershock/furniture",
+        "mods/skyisland/furniture"
+      ]
     }
   },
   {
@@ -63,13 +80,7 @@
     "normal.png": { "filler": true, "exclude": [ "overlay/mutations", "overlay/wielded", "overlay/worn" ] }
   },
   {
-    "tall.png": {
-      "sprite_width": 32,
-      "sprite_height": 64,
-      "sprite_offset_y": -32,
-      "filler": true,
-      "exclude": [ "overlay" ]
-    }
+    "tall.png": { "sprite_width": 32, "sprite_height": 64, "sprite_offset_y": -32, "filler": true, "exclude": [ "overlay" ] }
   },
   {
     "huge.png": { "sprite_width": 64, "sprite_height": 96, "sprite_offset_x": -16, "sprite_offset_y": -64, "filler": true }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
[Chibi Ultica] Exclude MSX furniture and terrain from mods

#### Content of the change

Expand the list of MSX folders excluded from Chibi Ultica's composition to terrain and furniture in mods for 32x32 sprite, it fixes one composition error that cropped up recently and keeps Chibi Ultica more inline with what it's et up to be "MSX monster and Character in the Ultica environnement"

#### Testing

Compose without error
Some mods probably lost some coverage under chibi ultica, no idea how it looked to have MSx furniture/terrain popped in the middle of Ultica style

#### Additional information
