### PR TITLE
[MSX] Use VINES3 sprite for BLOODTHORNE_DRUID_AURA_OF_VINES

### DIFF
--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/xedra_evolved/character/mutations/BLOODTHORNE_DRUID_AURA_OF_VINES.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/xedra_evolved/character/mutations/BLOODTHORNE_DRUID_AURA_OF_VINES.json
@@ -1,0 +1,8 @@
+{
+  "id": [
+    "overlay_mutation_BLOODTHORNE_DRUID_AURA_OF_VINES"
+  ],
+  "fg": [
+    "2842_overlay_mutation_VINES2_0"
+  ]
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
[MSX] Use VINES3 sprite for BLOODTHORNE_DRUID_AURA_OF_VINES

#### Content of the change

Use VINES3 sprite for BLOODTHORNE_DRUID_AURA_OF_VINES

#### Testing

<img width="210" height="246" alt="image" src="https://github.com/user-attachments/assets/045ee407-c56c-4807-8a77-f6f2b88a58fe" />
#### Additional information
