### PR TITLE
[MSX] Point `overmap_horde_1` and `overmap_horde_2` to `overmap_horde_3` sprite

### DIFF
--- a/gfx/MShockXotto+/pngs_overmap_32x32/overmap_horde/overmap_horde.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/overmap_horde/overmap_horde.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": [ "overmap_horde_1", "overmap_horde_2" ],
+    "id": [ "overmap_horde_1", "overmap_horde_2", "overmap_horde_3" ],
     "fg": "overmap_horde_3",
     "rotates": false,
     "bg": [  ]

--- a/gfx/MShockXotto+/pngs_overmap_32x32/overmap_horde/overmap_horde.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/overmap_horde/overmap_horde.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": [ "overmap_horde_1", "overmap_horde_2" ],
+    "fg": "overmap_horde_3",
+    "rotates": false,
+    "bg": [  ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Point `overmap_horde_1` and `overmap_horde_2` to `overmap_horde_3` sprite

#### Content of the change
Basegame
- overmap_horde_1 and 2 (point at overmap_horde_3 sprite)

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->
![Screenshot_20250929_141338](https://github.com/user-attachments/assets/b2f1013b-cc65-4339-bfec-b97e06623463)


#### Additional information
