### PR TITLE
quick patch to fix horde displays

### DIFF
--- a/gfx/Larwick_Overmap/pngs_overmap_tall_16x20/hordes/horde.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_tall_16x20/hordes/horde.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": [ "overmap_horde_3", "overmap_horde_4" ],
+    "id": [ "overmap_horde_1", "overmap_horde_2", "overmap_horde_3", "overmap_horde_4" ],
     "fg": [ "overmap_horde_3" ],
     "rotates": false,
     "bg": [  ]


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
quick patch to fix horde displays in larwick overmap

#### Content of the change

hordes 2.0 uses the full range from 1 to 10 for sprites, the previous code only did 3 to 10, so the assets only specify for those

added 1 and 2 to the json definition (using the same tile as 3 and 4)

#### Testing

<img width="1680" height="943" alt="image" src="https://github.com/user-attachments/assets/ac391a46-36a5-466e-8385-419900eddc37" />

the two zombie icons marked here were not visible with larwick as it was in the repo previously.

#### Additional information

a more proper fix would involve adding at least one more image, but this at least does the minimum
