### PR TITLE
correct speedway road rotations to work after dda 86335

### DIFF
--- a/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_recreational.json
+++ b/gfx/Larwick_Overmap/pngs_overmap_16x16/go_overmap_terrain_recreational.json
@@ -276,22 +276,22 @@
   },
   {
     "id": ["speedway_1_0","speedway_0_1"],
-    "fg": ["speedway2_road_corner_nw","speedway2_road_corner_sw","speedway2_road_corner_se","speedway2_road_corner_ne"],
+    "fg": ["speedway2_road_corner_nw","speedway2_road_corner_ne","speedway2_road_corner_se","speedway2_road_corner_sw"],
     "rotates": true
   },
   {
     "id": "speedway_1_4",
-    "fg": ["speedway2_road_corner_ne","speedway2_road_corner_nw","speedway2_road_corner_sw","speedway2_road_corner_se"],
+    "fg": ["speedway2_road_corner_ne","speedway2_road_corner_se","speedway2_road_corner_sw","speedway2_road_corner_nw"],
     "rotates": true
   },
   {
     "id": "speedway_6_1",
-    "fg": ["speedway2_road_corner_sw","speedway2_road_corner_se","speedway2_road_corner_ne","speedway2_road_corner_nw"],
+    "fg": ["speedway2_road_corner_sw","speedway2_road_corner_nw","speedway2_road_corner_ne","speedway2_road_corner_se"],
     "rotates": true
   },
   {
     "id": ["speedway_7_4","speedway_6_5"],
-    "fg": ["speedway2_road_corner_se","speedway2_road_corner_ne","speedway2_road_corner_nw","speedway2_road_corner_sw"],
+    "fg": ["speedway2_road_corner_se","speedway2_road_corner_sw","speedway2_road_corner_nw","speedway2_road_corner_ne"],
     "rotates": true
   },
   {
@@ -306,22 +306,22 @@
   },
   {
     "id": ["speedway_6_4"],
-    "fg": ["speedway1_road_corner_nw","speedway1_road_corner_sw","speedway1_road_corner_se","speedway1_road_corner_ne"],
+    "fg": ["speedway1_road_corner_nw","speedway1_road_corner_ne","speedway1_road_corner_se","speedway1_road_corner_sw"],
     "rotates": true
   },
   {
     "id": ["speedway_6_0","speedway_7_1"],
-    "fg": ["speedway1_road_corner_ne","speedway1_road_corner_nw","speedway1_road_corner_sw","speedway1_road_corner_se"],
+    "fg": ["speedway1_road_corner_ne","speedway1_road_corner_se","speedway1_road_corner_sw","speedway1_road_corner_nw"],
     "rotates": true
   },
   {
     "id": ["speedway_0_4","speedway_1_5"],
-    "fg": ["speedway1_road_corner_sw","speedway1_road_corner_se","speedway1_road_corner_ne","speedway1_road_corner_nw"],
+    "fg": ["speedway1_road_corner_sw","speedway1_road_corner_nw","speedway1_road_corner_ne","speedway1_road_corner_se"],
     "rotates": true
   },
   {
     "id": ["speedway_1_1"],
-    "fg": ["speedway1_road_corner_se","speedway1_road_corner_ne","speedway1_road_corner_nw","speedway1_road_corner_sw"],
+    "fg": ["speedway1_road_corner_se","speedway1_road_corner_sw","speedway1_road_corner_nw","speedway1_road_corner_ne"],
     "rotates": true
   },
   {
@@ -354,27 +354,27 @@
   },
   {
     "id": "speedway_8_1",
-    "fg": ["road_corner_ne","road_corner_nw","road_corner_sw","road_corner_se"],
+    "fg": ["road_corner_ne","road_corner_se","road_corner_sw","road_corner_nw"],
     "rotates": true
   },
   {
     "id": "speedway_8_5",
-    "fg": ["road_t_connection_e","road_t_connection_n","road_t_connection_w","road_t_connection_s"],
+    "fg": ["road_t_connection_e","road_t_connection_s","road_t_connection_w","road_t_connection_n"],
     "rotates": true
   },
   {
     "id": "speedway_5_7",
-    "fg": ["road_t_connection_w","road_t_connection_s","road_t_connection_e","road_t_connection_n"],
+    "fg": ["road_t_connection_w","road_t_connection_n","road_t_connection_e","road_t_connection_s"],
     "rotates": true
   },
   {
     "id": "speedway_8_7",
-    "fg": ["road_corner_se","road_corner_ne","road_corner_nw","road_corner_sw"],
+    "fg": ["road_corner_se","road_corner_sw","road_corner_nw","road_corner_ne"],
     "rotates": true
   },
   {
     "id": "speedway_5_8",
-    "fg": ["road_t_connection_e","road_t_connection_n","road_t_connection_w","road_t_connection_s"],
+    "fg": ["road_t_connection_e","road_t_connection_s","road_t_connection_w","road_t_connection_n"],
     "rotates": true
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->
correct speedway road rotations to work upstream engine rotation fix

#### Content of the change

<!-- Explain what does this pull request contain. -->

in https://github.com/CleverRaven/Cataclysm-DDA/pull/86335 a long-standing error with tile rotations gets corrected, one which has been getting papered over with manual tileset configs for quite some time. unfortunately, now that it's been properly fixed, we have to unfix the uncorrect fixes.

fortunately, where this turns up, it's simply swapping the second and fourth (index 1 and 3) for corners, t-sections, and the like. unfortunately, there's going to be a lot of it.

#### Testing

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

before edits (but still after https://github.com/CleverRaven/Cataclysm-DDA/pull/86335) :

<img width="1333" height="941" alt="image" src="https://github.com/user-attachments/assets/0563a809-0335-4560-a793-adc1e05f26f1" />

after edits
<img width="1333" height="941" alt="image" src="https://github.com/user-attachments/assets/0c1f3ccc-8751-4f48-a062-6169afd51b7c" />


#### Additional information

we're going to be chasing these for a long time. :(  i'll try to pitch in with sets of fixes as i can.
