### PR TITLE
[PenAndpaper] Update rotations for the tile rotation fix

### DIFF
--- a/gfx/PenAndPaper/pngs_overmap_48x48/1x2/_template1x2_/template1x2.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/1x2/_template1x2_/template1x2.json
@@ -11,7 +11,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template1x2_var_00", "template1x2_var_01", "template1x2_var_03", "template1x2_var_02"
+      "template1x2_var_00", "template1x2_var_02", "template1x2_var_03", "template1x2_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -47,7 +47,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template1x2_var_03", "template1x2_var_02", "template1x2_var_00", "template1x2_var_01"
+      "template1x2_var_03", "template1x2_var_01", "template1x2_var_00", "template1x2_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/1x2/dock/dock.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/1x2/dock/dock.json
@@ -10,7 +10,7 @@
     ],
     "rotates": true,
     "fg": [
-      "dock_var_03", "dock_var_02", "dock_var_00", "dock_var_01"
+      "dock_var_03", "dock_var_01", "dock_var_00", "dock_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -46,7 +46,7 @@
     ],
     "rotates": true,
     "fg": [
-      "dock_var_00", "dock_var_01", "dock_var_03", "dock_var_02"
+      "dock_var_00", "dock_var_02", "dock_var_03", "dock_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/1x2/homeless_shelter/homeless_shelter.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/1x2/homeless_shelter/homeless_shelter.json
@@ -13,7 +13,7 @@
     ],
     "rotates": true,
     "fg": [
-      "homeless_shelter_var_03", "homeless_shelter_var_02", "homeless_shelter_var_00", "homeless_shelter_var_01"
+      "homeless_shelter_var_03", "homeless_shelter_var_01", "homeless_shelter_var_00", "homeless_shelter_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -52,7 +52,7 @@
     ],
     "rotates": true,
     "fg": [
-      "homeless_shelter_var_00", "homeless_shelter_var_01", "homeless_shelter_var_03", "homeless_shelter_var_02"
+      "homeless_shelter_var_00", "homeless_shelter_var_02", "homeless_shelter_var_03", "homeless_shelter_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/1x2/shooting_range/shooting_range.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/1x2/shooting_range/shooting_range.json
@@ -11,7 +11,7 @@
     ],
     "rotates": true,
     "fg": [
-      "shooting_range_var_00", "shooting_range_var_01", "shooting_range_var_03", "shooting_range_var_02"
+      "shooting_range_var_00", "shooting_range_var_02", "shooting_range_var_03", "shooting_range_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -47,7 +47,7 @@
     ],
     "rotates": true,
     "fg": [
-      "shooting_range_var_03", "shooting_range_var_02", "shooting_range_var_00", "shooting_range_var_01"
+      "shooting_range_var_03", "shooting_range_var_01", "shooting_range_var_00", "shooting_range_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/_template2x1_/template2x1.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/_template2x1_/template2x1.json
@@ -10,7 +10,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template2x1_var_01", "template2x1_var_03", "template2x1_var_02", "template2x1_var_00"
+      "template2x1_var_01", "template2x1_var_00", "template2x1_var_02", "template2x1_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -46,7 +46,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template2x1_var_02", "template2x1_var_00", "template2x1_var_01", "template2x1_var_03"
+      "template2x1_var_02", "template2x1_var_03", "template2x1_var_01", "template2x1_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/botanical_garden/botanical_garden.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/botanical_garden/botanical_garden.json
@@ -5,7 +5,7 @@
     ],
     "rotates": true,
     "fg": [
-      "botanical_garden_var_01", "botanical_garden_var_03", "botanical_garden_var_02", "botanical_garden_var_00"
+      "botanical_garden_var_01", "botanical_garden_var_00", "botanical_garden_var_02", "botanical_garden_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -41,7 +41,7 @@
     ],
     "rotates": true,
     "fg": [
-      "botanical_garden_var_02", "botanical_garden_var_00", "botanical_garden_var_01", "botanical_garden_var_03"
+      "botanical_garden_var_02", "botanical_garden_var_03", "botanical_garden_var_01", "botanical_garden_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/bus_station/bus_station.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/bus_station/bus_station.json
@@ -5,7 +5,7 @@
     ],
     "rotates": true,
     "fg": [
-      "bus_station_var_01", "bus_station_var_03", "bus_station_var_02", "bus_station_var_00"
+      "bus_station_var_01", "bus_station_var_00", "bus_station_var_02", "bus_station_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -41,7 +41,7 @@
     ],
     "rotates": true,
     "fg": [
-      "bus_station_var_02", "bus_station_var_00", "bus_station_var_01", "bus_station_var_03"
+      "bus_station_var_02", "bus_station_var_03", "bus_station_var_01", "bus_station_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/cemetery/cemetery.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/cemetery/cemetery.json
@@ -36,7 +36,7 @@
     ],
     "rotates": true,
     "fg": [
-      "cemetery_var_01", "cemetery_var_03", "cemetery_var_02", "cemetery_var_00"
+      "cemetery_var_01", "cemetery_var_00", "cemetery_var_02", "cemetery_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -72,7 +72,7 @@
     ],
     "rotates": true,
     "fg": [
-      "cemetery_var_02", "cemetery_var_00", "cemetery_var_01", "cemetery_var_03"
+      "cemetery_var_02", "cemetery_var_03", "cemetery_var_01", "cemetery_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/hunting_lodge/hunting_lodge.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/hunting_lodge/hunting_lodge.json
@@ -7,7 +7,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hunting_lodge_var_00", "hunting_lodge_var_01","hunting_lodge_var_03", "hunting_lodge_var_02"
+      "hunting_lodge_var_00", "hunting_lodge_var_02","hunting_lodge_var_03", "hunting_lodge_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -45,7 +45,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hunting_lodge_var_00", "hunting_lodge_var_01","hunting_lodge_var_03", "hunting_lodge_var_02"
+      "hunting_lodge_var_00", "hunting_lodge_var_02","hunting_lodge_var_03", "hunting_lodge_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/landscaping/landscaping.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/landscaping/landscaping.json
@@ -10,7 +10,7 @@
     ],
     "rotates": true,
     "fg": [
-      "landscaping_var_01", "landscaping_var_03", "landscaping_var_02", "landscaping_var_00"
+      "landscaping_var_01", "landscaping_var_00", "landscaping_var_02", "landscaping_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -46,7 +46,7 @@
     ],
     "rotates": true,
     "fg": [
-      "landscaping_var_02", "landscaping_var_00", "landscaping_var_01", "landscaping_var_03"
+      "landscaping_var_02", "landscaping_var_03", "landscaping_var_01", "landscaping_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/mi-go_camp/mi-go_camp.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/mi-go_camp/mi-go_camp.json
@@ -5,7 +5,7 @@
     ],
     "rotates": true,
     "fg": [
-      "mi-go_camp_var_01", "mi-go_camp_var_03", "mi-go_camp_var_02", "mi-go_camp_var_00"
+      "mi-go_camp_var_01", "mi-go_camp_var_00", "mi-go_camp_var_02", "mi-go_camp_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -41,7 +41,7 @@
     ],
     "rotates": true,
     "fg": [
-      "mi-go_camp_var_02", "mi-go_camp_var_00", "mi-go_camp_var_01", "mi-go_camp_var_03"
+      "mi-go_camp_var_02", "mi-go_camp_var_03", "mi-go_camp_var_01", "mi-go_camp_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/motel_twd/motel_twd.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/motel_twd/motel_twd.json
@@ -7,7 +7,7 @@
     ],
     "rotates": true,
     "fg": [
-      "motel_twd_var_01", "motel_twd_var_03", "motel_twd_var_02", "motel_twd_var_00"
+      "motel_twd_var_01", "motel_twd_var_00", "motel_twd_var_02", "motel_twd_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -44,7 +44,7 @@
     ],
     "rotates": true,
     "fg": [
-      "motel_twd_var_02", "motel_twd_var_00", "motel_twd_var_01", "motel_twd_var_03"
+      "motel_twd_var_02", "motel_twd_var_03", "motel_twd_var_01", "motel_twd_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/parking2x1/parking2x1.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/parking2x1/parking2x1.json
@@ -5,7 +5,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking2x1_var_01", "parking2x1_var_03", "parking2x1_var_02", "parking2x1_var_00"
+      "parking2x1_var_01", "parking2x1_var_00", "parking2x1_var_02", "parking2x1_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -41,7 +41,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking2x1_var_02", "parking2x1_var_00", "parking2x1_var_01", "parking2x1_var_03"
+      "parking2x1_var_02", "parking2x1_var_03", "parking2x1_var_01", "parking2x1_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/public_pond/public_pond.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/public_pond/public_pond.json
@@ -5,7 +5,7 @@
     ],
     "rotates": true,
     "fg": [
-      "public_pond_var_01", "public_pond_var_03", "public_pond_var_02", "public_pond_var_00"
+      "public_pond_var_01", "public_pond_var_00", "public_pond_var_02", "public_pond_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -41,7 +41,7 @@
     ],
     "rotates": true,
     "fg": [
-      "public_pond_var_02", "public_pond_var_00", "public_pond_var_01", "public_pond_var_03"
+      "public_pond_var_02", "public_pond_var_03", "public_pond_var_01", "public_pond_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/pump_station/pump_station.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/pump_station/pump_station.json
@@ -39,7 +39,7 @@
     ],
     "rotates": true,
     "fg": [
-      "pump_station_var_00", "pump_station_var_01", "pump_station_var_03", "pump_station_var_02"
+      "pump_station_var_00", "pump_station_var_02", "pump_station_var_03", "pump_station_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -76,7 +76,7 @@
     ],
     "rotates": true,
     "fg": [
-      "pump_station_var_03", "pump_station_var_02", "pump_station_var_00", "pump_station_var_01"
+      "pump_station_var_03", "pump_station_var_01", "pump_station_var_00", "pump_station_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/s_gun_b/s_gun_b.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/s_gun_b/s_gun_b.json
@@ -2,7 +2,7 @@
   {
     "id": [ "s_gun_b_store", "s_gun_b_roof" ],
     "rotates": true,
-    "fg": [ "s_gun_b_var_01", "s_gun_b_var_03", "s_gun_b_var_02", "s_gun_b_var_00" ],
+    "fg": [ "s_gun_b_var_01", "s_gun_b_var_00", "s_gun_b_var_02", "s_gun_b_var_03" ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -34,7 +34,7 @@
   {
     "id": [ "s_gun_b_range", "s_gun_b_range_roof" ],
     "rotates": true,
-    "fg": [ "s_gun_b_var_02", "s_gun_b_var_00", "s_gun_b_var_01", "s_gun_b_var_03" ],
+    "fg": [ "s_gun_b_var_02", "s_gun_b_var_03", "s_gun_b_var_01", "s_gun_b_var_00" ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/shipwreck/shipwreck.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/shipwreck/shipwreck.json
@@ -11,7 +11,7 @@
     ],
     "rotates": true,
     "fg": [
-      "shipwreck_var_01", "shipwreck_var_03", "shipwreck_var_02", "shipwreck_var_00"
+      "shipwreck_var_01", "shipwreck_var_00", "shipwreck_var_02", "shipwreck_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -48,7 +48,7 @@
     ],
     "rotates": true,
     "fg": [
-      "shipwreck_var_02", "shipwreck_var_00", "shipwreck_var_01", "shipwreck_var_03"
+      "shipwreck_var_02", "shipwreck_var_03", "shipwreck_var_01", "shipwreck_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x1/tree_farm/tree_farm.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x1/tree_farm/tree_farm.json
@@ -5,7 +5,7 @@
     ],
     "rotates": true,
     "fg": [
-      "tree_farm_var_01", "tree_farm_var_03", "tree_farm_var_02", "tree_farm_var_00"
+      "tree_farm_var_01", "tree_farm_var_00", "tree_farm_var_02", "tree_farm_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -41,7 +41,7 @@
     ],
     "rotates": true,
     "fg": [
-      "tree_farm_var_02", "tree_farm_var_00", "tree_farm_var_01", "tree_farm_var_03"
+      "tree_farm_var_02", "tree_farm_var_03", "tree_farm_var_01", "tree_farm_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/_template2x2_/template2x2.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/_template2x2_/template2x2.json
@@ -9,7 +9,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template2x2_var_00", "template2x2_var_02", "template2x2_var_03", "template2x2_var_01"
+      "template2x2_var_00", "template2x2_var_01", "template2x2_var_03", "template2x2_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -45,7 +45,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template2x2_var_01", "template2x2_var_00", "template2x2_var_02", "template2x2_var_03"
+      "template2x2_var_01", "template2x2_var_03", "template2x2_var_02", "template2x2_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -81,7 +81,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template2x2_var_02", "template2x2_var_03", "template2x2_var_01", "template2x2_var_00"
+      "template2x2_var_02", "template2x2_var_00", "template2x2_var_01", "template2x2_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -117,7 +117,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template2x2_var_03", "template2x2_var_01", "template2x2_var_00", "template2x2_var_02"
+      "template2x2_var_03", "template2x2_var_02", "template2x2_var_00", "template2x2_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/apartment_tower/apartment_tower.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/apartment_tower/apartment_tower.json
@@ -10,7 +10,7 @@
     ],
     "rotates": true,
     "fg": [
-      "apartment_tower_var_00", "apartment_tower_var_02", "apartment_tower_var_03", "apartment_tower_var_01"
+      "apartment_tower_var_00", "apartment_tower_var_01", "apartment_tower_var_03", "apartment_tower_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -47,7 +47,7 @@
     ],
     "rotates": true,
     "fg": [
-      "apartment_tower_var_01", "apartment_tower_var_00", "apartment_tower_var_02", "apartment_tower_var_03"
+      "apartment_tower_var_01", "apartment_tower_var_03", "apartment_tower_var_02", "apartment_tower_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -84,7 +84,7 @@
     ],
     "rotates": true,
     "fg": [
-      "apartment_tower_var_02", "apartment_tower_var_03", "apartment_tower_var_01", "apartment_tower_var_00"
+      "apartment_tower_var_02", "apartment_tower_var_00", "apartment_tower_var_01", "apartment_tower_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -121,7 +121,7 @@
     ],
     "rotates": true,
     "fg": [
-      "apartment_tower_var_03", "apartment_tower_var_01", "apartment_tower_var_00", "apartment_tower_var_02"
+      "apartment_tower_var_03", "apartment_tower_var_02", "apartment_tower_var_00", "apartment_tower_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/baseball_field/baseball_field.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/baseball_field/baseball_field.json
@@ -5,7 +5,7 @@
     ],
     "rotates": true,
     "fg": [
-      "baseball_field_var_00", "baseball_field_var_02", "baseball_field_var_03", "baseball_field_var_01"
+      "baseball_field_var_00", "baseball_field_var_01", "baseball_field_var_03", "baseball_field_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -41,7 +41,7 @@
     ],
     "rotates": true,
     "fg": [
-      "baseball_field_var_01", "baseball_field_var_00", "baseball_field_var_02", "baseball_field_var_03"
+      "baseball_field_var_01", "baseball_field_var_03", "baseball_field_var_02", "baseball_field_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -77,7 +77,7 @@
     ],
     "rotates": true,
     "fg": [
-      "baseball_field_var_02", "baseball_field_var_03", "baseball_field_var_01", "baseball_field_var_00"
+      "baseball_field_var_02", "baseball_field_var_00", "baseball_field_var_01", "baseball_field_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -113,7 +113,7 @@
     ],
     "rotates": true,
     "fg": [
-      "baseball_field_var_03", "baseball_field_var_01", "baseball_field_var_00", "baseball_field_var_02"
+      "baseball_field_var_03", "baseball_field_var_02", "baseball_field_var_00", "baseball_field_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/campground/campground.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/campground/campground.json
@@ -38,7 +38,7 @@
     ],
     "rotates": true,
     "fg": [
-      "campground_var_00", "campground_var_02", "campground_var_03", "campground_var_01"
+      "campground_var_00", "campground_var_01", "campground_var_03", "campground_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -74,7 +74,7 @@
     ],
     "rotates": true,
     "fg": [
-      "campground_var_01", "campground_var_00", "campground_var_02", "campground_var_03"
+      "campground_var_01", "campground_var_03", "campground_var_02", "campground_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -110,7 +110,7 @@
     ],
     "rotates": true,
     "fg": [
-      "campground_var_02", "campground_var_03", "campground_var_01", "campground_var_00"
+      "campground_var_02", "campground_var_00", "campground_var_01", "campground_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -146,7 +146,7 @@
     ],
     "rotates": true,
     "fg": [
-      "campground_var_03", "campground_var_01", "campground_var_00", "campground_var_02"
+      "campground_var_03", "campground_var_02", "campground_var_00", "campground_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/cathedral/cathedral.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/cathedral/cathedral.json
@@ -12,7 +12,7 @@
     ],
     "rotates": true,
     "fg": [
-      "cathedral_var_00", "cathedral_var_02", "cathedral_var_03", "cathedral_var_01"
+      "cathedral_var_00", "cathedral_var_01", "cathedral_var_03", "cathedral_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -51,7 +51,7 @@
     ],
     "rotates": true,
     "fg": [
-      "cathedral_var_01", "cathedral_var_00", "cathedral_var_02", "cathedral_var_03"
+      "cathedral_var_01", "cathedral_var_03", "cathedral_var_02", "cathedral_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -90,7 +90,7 @@
     ],
     "rotates": true,
     "fg": [
-      "cathedral_var_02", "cathedral_var_03", "cathedral_var_01", "cathedral_var_00"
+      "cathedral_var_02", "cathedral_var_00", "cathedral_var_01", "cathedral_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -129,7 +129,7 @@
     ],
     "rotates": true,
     "fg": [
-      "cathedral_var_03", "cathedral_var_01", "cathedral_var_00", "cathedral_var_02"
+      "cathedral_var_03", "cathedral_var_02", "cathedral_var_00", "cathedral_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/cemetery_4square/cemetery_4square.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/cemetery_4square/cemetery_4square.json
@@ -40,7 +40,7 @@
     ],
     "rotates": true,
     "fg": [
-      "cemetery_4square_var_00", "cemetery_4square_var_02", "cemetery_4square_var_03", "cemetery_4square_var_01"
+      "cemetery_4square_var_00", "cemetery_4square_var_01", "cemetery_4square_var_03", "cemetery_4square_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -76,7 +76,7 @@
     ],
     "rotates": true,
     "fg": [
-      "cemetery_4square_var_01", "cemetery_4square_var_00", "cemetery_4square_var_02", "cemetery_4square_var_03"
+      "cemetery_4square_var_01", "cemetery_4square_var_03", "cemetery_4square_var_02", "cemetery_4square_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -112,7 +112,7 @@
     ],
     "rotates": true,
     "fg": [
-      "cemetery_4square_var_02", "cemetery_4square_var_03", "cemetery_4square_var_01", "cemetery_4square_var_00"
+      "cemetery_4square_var_02", "cemetery_4square_var_00", "cemetery_4square_var_01", "cemetery_4square_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -148,7 +148,7 @@
     ],
     "rotates": true,
     "fg": [
-      "cemetery_4square_var_03", "cemetery_4square_var_01", "cemetery_4square_var_00", "cemetery_4square_var_02"
+      "cemetery_4square_var_03", "cemetery_4square_var_02", "cemetery_4square_var_00", "cemetery_4square_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/farm_supply_store/farm_supply_store.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/farm_supply_store/farm_supply_store.json
@@ -11,7 +11,7 @@
     ],
     "rotates": true,
     "fg": [
-      "farm_supply_store_var_00", "farm_supply_store_var_02", "farm_supply_store_var_03", "farm_supply_store_var_01"
+      "farm_supply_store_var_00", "farm_supply_store_var_01", "farm_supply_store_var_03", "farm_supply_store_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -49,7 +49,7 @@
     ],
     "rotates": true,
     "fg": [
-      "farm_supply_store_var_01", "farm_supply_store_var_00", "farm_supply_store_var_02", "farm_supply_store_var_03"
+      "farm_supply_store_var_01", "farm_supply_store_var_03", "farm_supply_store_var_02", "farm_supply_store_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -87,7 +87,7 @@
     ],
     "rotates": true,
     "fg": [
-      "farm_supply_store_var_02", "farm_supply_store_var_03", "farm_supply_store_var_01", "farm_supply_store_var_00"
+      "farm_supply_store_var_02", "farm_supply_store_var_00", "farm_supply_store_var_01", "farm_supply_store_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -125,7 +125,7 @@
     ],
     "rotates": true,
     "fg": [
-      "farm_supply_store_var_03", "farm_supply_store_var_01", "farm_supply_store_var_00", "farm_supply_store_var_02"
+      "farm_supply_store_var_03", "farm_supply_store_var_02", "farm_supply_store_var_00", "farm_supply_store_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/fishing_pond/fishing_pond.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/fishing_pond/fishing_pond.json
@@ -9,7 +9,7 @@
     ],
     "rotates": true,
     "fg": [
-      "fishing_pond_var_00", "fishing_pond_var_02", "fishing_pond_var_03", "fishing_pond_var_01"
+      "fishing_pond_var_00", "fishing_pond_var_01", "fishing_pond_var_03", "fishing_pond_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -45,7 +45,7 @@
     ],
     "rotates": true,
     "fg": [
-      "fishing_pond_var_01", "fishing_pond_var_00", "fishing_pond_var_02", "fishing_pond_var_03"
+      "fishing_pond_var_01", "fishing_pond_var_03", "fishing_pond_var_02", "fishing_pond_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -81,7 +81,7 @@
     ],
     "rotates": true,
     "fg": [
-      "fishing_pond_var_02", "fishing_pond_var_03", "fishing_pond_var_01", "fishing_pond_var_00"
+      "fishing_pond_var_02", "fishing_pond_var_00", "fishing_pond_var_01", "fishing_pond_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -117,7 +117,7 @@
     ],
     "rotates": true,
     "fg": [
-      "fishing_pond_var_03", "fishing_pond_var_01", "fishing_pond_var_00", "fishing_pond_var_02"
+      "fishing_pond_var_03", "fishing_pond_var_02", "fishing_pond_var_00", "fishing_pond_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/junkyard/junkyard.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/junkyard/junkyard.json
@@ -39,7 +39,7 @@
     ],
     "rotates": true,
     "fg": [
-      "junkyard_var_00", "junkyard_var_02", "junkyard_var_03", "junkyard_var_01"
+      "junkyard_var_00", "junkyard_var_01", "junkyard_var_03", "junkyard_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -75,7 +75,7 @@
     ],
     "rotates": true,
     "fg": [
-      "junkyard_var_01", "junkyard_var_00", "junkyard_var_02", "junkyard_var_03"
+      "junkyard_var_01", "junkyard_var_03", "junkyard_var_02", "junkyard_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -111,7 +111,7 @@
     ],
     "rotates": true,
     "fg": [
-      "junkyard_var_02", "junkyard_var_03", "junkyard_var_01", "junkyard_var_00"
+      "junkyard_var_02", "junkyard_var_00", "junkyard_var_01", "junkyard_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -147,7 +147,7 @@
     ],
     "rotates": true,
     "fg": [
-      "junkyard_var_03", "junkyard_var_01", "junkyard_var_00", "junkyard_var_02"
+      "junkyard_var_03", "junkyard_var_02", "junkyard_var_00", "junkyard_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/large_power_substation/large_power_substation.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/large_power_substation/large_power_substation.json
@@ -9,7 +9,7 @@
     ],
     "rotates": true,
     "fg": [
-      "large_power_substation_var_00", "large_power_substation_var_02", "large_power_substation_var_03", "large_power_substation_var_01"
+      "large_power_substation_var_00", "large_power_substation_var_01", "large_power_substation_var_03", "large_power_substation_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -45,7 +45,7 @@
     ],
     "rotates": true,
     "fg": [
-      "large_power_substation_var_01", "large_power_substation_var_00", "large_power_substation_var_02", "large_power_substation_var_03"
+      "large_power_substation_var_01", "large_power_substation_var_03", "large_power_substation_var_02", "large_power_substation_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -81,7 +81,7 @@
     ],
     "rotates": true,
     "fg": [
-      "large_power_substation_var_02", "large_power_substation_var_03", "large_power_substation_var_01", "large_power_substation_var_00"
+      "large_power_substation_var_02", "large_power_substation_var_00", "large_power_substation_var_01", "large_power_substation_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -117,7 +117,7 @@
     ],
     "rotates": true,
     "fg": [
-      "large_power_substation_var_03", "large_power_substation_var_01", "large_power_substation_var_00", "large_power_substation_var_02"
+      "large_power_substation_var_03", "large_power_substation_var_02", "large_power_substation_var_00", "large_power_substation_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/lumbermill/lumbermill.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/lumbermill/lumbermill.json
@@ -6,7 +6,7 @@
     ],
     "rotates": true,
     "fg": [
-      "lumbermill_var_00", "lumbermill_var_02", "lumbermill_var_03", "lumbermill_var_01"
+      "lumbermill_var_00", "lumbermill_var_01", "lumbermill_var_03", "lumbermill_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -43,7 +43,7 @@
     ],
     "rotates": true,
     "fg": [
-      "lumbermill_var_01", "lumbermill_var_00", "lumbermill_var_02", "lumbermill_var_03"
+      "lumbermill_var_01", "lumbermill_var_03", "lumbermill_var_02", "lumbermill_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -80,7 +80,7 @@
     ],
     "rotates": true,
     "fg": [
-      "lumbermill_var_02", "lumbermill_var_03", "lumbermill_var_01", "lumbermill_var_00"
+      "lumbermill_var_02", "lumbermill_var_00", "lumbermill_var_01", "lumbermill_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -117,7 +117,7 @@
     ],
     "rotates": true,
     "fg": [
-      "lumbermill_var_03", "lumbermill_var_01", "lumbermill_var_00", "lumbermill_var_02"
+      "lumbermill_var_03", "lumbermill_var_02", "lumbermill_var_00", "lumbermill_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/miniature_railway/miniature_railway.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/miniature_railway/miniature_railway.json
@@ -5,7 +5,7 @@
     ],
     "rotates": true,
     "fg": [
-      "miniature_railway_var_00", "miniature_railway_var_02", "miniature_railway_var_03", "miniature_railway_var_01"
+      "miniature_railway_var_00", "miniature_railway_var_01", "miniature_railway_var_03", "miniature_railway_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -41,7 +41,7 @@
     ],
     "rotates": true,
     "fg": [
-      "miniature_railway_var_01", "miniature_railway_var_00", "miniature_railway_var_02", "miniature_railway_var_03"
+      "miniature_railway_var_01", "miniature_railway_var_03", "miniature_railway_var_02", "miniature_railway_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -77,7 +77,7 @@
     ],
     "rotates": true,
     "fg": [
-      "miniature_railway_var_02", "miniature_railway_var_03", "miniature_railway_var_01", "miniature_railway_var_00"
+      "miniature_railway_var_02", "miniature_railway_var_00", "miniature_railway_var_01", "miniature_railway_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -113,7 +113,7 @@
     ],
     "rotates": true,
     "fg": [
-      "miniature_railway_var_03", "miniature_railway_var_01", "miniature_railway_var_00", "miniature_railway_var_02"
+      "miniature_railway_var_03", "miniature_railway_var_02", "miniature_railway_var_00", "miniature_railway_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/motel/motel.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/motel/motel.json
@@ -42,7 +42,7 @@
     ],
     "rotates": true,
     "fg": [
-      "motel_var_00", "motel_var_02", "motel_var_03", "motel_var_01"
+      "motel_var_00", "motel_var_01", "motel_var_03", "motel_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -80,7 +80,7 @@
     ],
     "rotates": true,
     "fg": [
-      "motel_var_01", "motel_var_00", "motel_var_02", "motel_var_03"
+      "motel_var_01", "motel_var_03", "motel_var_02", "motel_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -118,7 +118,7 @@
     ],
     "rotates": true,
     "fg": [
-      "motel_var_02", "motel_var_03", "motel_var_01", "motel_var_00"
+      "motel_var_02", "motel_var_00", "motel_var_01", "motel_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -156,7 +156,7 @@
     ],
     "rotates": true,
     "fg": [
-      "motel_var_03", "motel_var_01", "motel_var_00", "motel_var_02"
+      "motel_var_03", "motel_var_02", "motel_var_00", "motel_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/office_building/office_building.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/office_building/office_building.json
@@ -5,7 +5,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_building_var_00", "office_building_var_02", "office_building_var_03", "office_building_var_01"
+      "office_building_var_00", "office_building_var_01", "office_building_var_03", "office_building_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -41,7 +41,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_building_var_01", "office_building_var_00", "office_building_var_02", "office_building_var_03"
+      "office_building_var_01", "office_building_var_03", "office_building_var_02", "office_building_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -77,7 +77,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_building_var_02", "office_building_var_03", "office_building_var_01", "office_building_var_00"
+      "office_building_var_02", "office_building_var_00", "office_building_var_01", "office_building_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -113,7 +113,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_building_var_03", "office_building_var_01", "office_building_var_00", "office_building_var_02"
+      "office_building_var_03", "office_building_var_02", "office_building_var_00", "office_building_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/office_skyscraper/office_skyscraper.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/office_skyscraper/office_skyscraper.json
@@ -12,7 +12,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_skyscraper_var_00", "office_skyscraper_var_02", "office_skyscraper_var_03", "office_skyscraper_var_01"
+      "office_skyscraper_var_00", "office_skyscraper_var_01", "office_skyscraper_var_03", "office_skyscraper_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -55,7 +55,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_skyscraper_var_01", "office_skyscraper_var_00", "office_skyscraper_var_02", "office_skyscraper_var_03"
+      "office_skyscraper_var_01", "office_skyscraper_var_03", "office_skyscraper_var_02", "office_skyscraper_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -98,7 +98,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_skyscraper_var_02", "office_skyscraper_var_03", "office_skyscraper_var_01", "office_skyscraper_var_00"
+      "office_skyscraper_var_02", "office_skyscraper_var_00", "office_skyscraper_var_01", "office_skyscraper_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -141,7 +141,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_skyscraper_var_03", "office_skyscraper_var_01", "office_skyscraper_var_00", "office_skyscraper_var_02"
+      "office_skyscraper_var_03", "office_skyscraper_var_02", "office_skyscraper_var_00", "office_skyscraper_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/office_tower/office_tower.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/office_tower/office_tower.json
@@ -9,7 +9,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_var_00", "office_tower_var_02", "office_tower_var_03", "office_tower_var_01"
+      "office_tower_var_00", "office_tower_var_01", "office_tower_var_03", "office_tower_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -49,7 +49,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_var_01", "office_tower_var_00", "office_tower_var_02", "office_tower_var_03"
+      "office_tower_var_01", "office_tower_var_03", "office_tower_var_02", "office_tower_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -89,7 +89,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_var_02", "office_tower_var_03", "office_tower_var_01", "office_tower_var_00"
+      "office_tower_var_02", "office_tower_var_00", "office_tower_var_01", "office_tower_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -129,7 +129,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_var_03", "office_tower_var_01", "office_tower_var_00", "office_tower_var_02"
+      "office_tower_var_03", "office_tower_var_02", "office_tower_var_00", "office_tower_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/parking_2x2/parking_2x2.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/parking_2x2/parking_2x2.json
@@ -9,7 +9,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking_2x2_var_00", "parking_2x2_var_02", "parking_2x2_var_03", "parking_2x2_var_01"
+      "parking_2x2_var_00", "parking_2x2_var_01", "parking_2x2_var_03", "parking_2x2_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -45,7 +45,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking_2x2_var_01", "parking_2x2_var_00", "parking_2x2_var_02", "parking_2x2_var_03"
+      "parking_2x2_var_01", "parking_2x2_var_03", "parking_2x2_var_02", "parking_2x2_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -81,7 +81,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking_2x2_var_02", "parking_2x2_var_03", "parking_2x2_var_01", "parking_2x2_var_00"
+      "parking_2x2_var_02", "parking_2x2_var_00", "parking_2x2_var_01", "parking_2x2_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -117,7 +117,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking_2x2_var_03", "parking_2x2_var_01", "parking_2x2_var_00", "parking_2x2_var_02"
+      "parking_2x2_var_03", "parking_2x2_var_02", "parking_2x2_var_00", "parking_2x2_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/parking_garage/parking_garage.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/parking_garage/parking_garage.json
@@ -10,7 +10,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking_garage_2x2_var_00", "parking_garage_2x2_var_02", "parking_garage_2x2_var_03", "parking_garage_2x2_var_01"
+      "parking_garage_2x2_var_00", "parking_garage_2x2_var_01", "parking_garage_2x2_var_03", "parking_garage_2x2_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -51,7 +51,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking_garage_2x2_var_01", "parking_garage_2x2_var_00", "parking_garage_2x2_var_02", "parking_garage_2x2_var_03"
+      "parking_garage_2x2_var_01", "parking_garage_2x2_var_03", "parking_garage_2x2_var_02", "parking_garage_2x2_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -92,7 +92,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking_garage_2x2_var_02", "parking_garage_2x2_var_03", "parking_garage_2x2_var_01", "parking_garage_2x2_var_00"
+      "parking_garage_2x2_var_02", "parking_garage_2x2_var_00", "parking_garage_2x2_var_01", "parking_garage_2x2_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -133,7 +133,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking_garage_2x2_var_03", "parking_garage_2x2_var_01", "parking_garage_2x2_var_00", "parking_garage_2x2_var_02"
+      "parking_garage_2x2_var_03", "parking_garage_2x2_var_02", "parking_garage_2x2_var_00", "parking_garage_2x2_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/public_works/public_works.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/public_works/public_works.json
@@ -10,7 +10,7 @@
     ],
     "rotates": true,
     "fg": [
-      "public_works_var_00", "public_works_var_02", "public_works_var_03", "public_works_var_01"
+      "public_works_var_00", "public_works_var_01", "public_works_var_03", "public_works_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -47,7 +47,7 @@
     ],
     "rotates": true,
     "fg": [
-      "public_works_var_01", "public_works_var_00", "public_works_var_02", "public_works_var_03"
+      "public_works_var_01", "public_works_var_03", "public_works_var_02", "public_works_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -84,7 +84,7 @@
     ],
     "rotates": true,
     "fg": [
-      "public_works_var_02", "public_works_var_03", "public_works_var_01", "public_works_var_00"
+      "public_works_var_02", "public_works_var_00", "public_works_var_01", "public_works_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -121,7 +121,7 @@
     ],
     "rotates": true,
     "fg": [
-      "public_works_var_03", "public_works_var_01", "public_works_var_00", "public_works_var_02"
+      "public_works_var_03", "public_works_var_02", "public_works_var_00", "public_works_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/sewage_treatment_plant2x2/sewage_treatment_plant2x2.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/sewage_treatment_plant2x2/sewage_treatment_plant2x2.json
@@ -10,7 +10,7 @@
     ],
     "rotates": true,
     "fg": [
-      "sewage_treatment_plant2x2_var_00", "sewage_treatment_plant2x2_var_02", "sewage_treatment_plant2x2_var_03", "sewage_treatment_plant2x2_var_01"
+      "sewage_treatment_plant2x2_var_00", "sewage_treatment_plant2x2_var_01", "sewage_treatment_plant2x2_var_03", "sewage_treatment_plant2x2_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -47,7 +47,7 @@
     ],
     "rotates": true,
     "fg": [
-      "sewage_treatment_plant2x2_var_01", "sewage_treatment_plant2x2_var_00", "sewage_treatment_plant2x2_var_02", "sewage_treatment_plant2x2_var_03"
+      "sewage_treatment_plant2x2_var_01", "sewage_treatment_plant2x2_var_03", "sewage_treatment_plant2x2_var_02", "sewage_treatment_plant2x2_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -84,7 +84,7 @@
     ],
     "rotates": true,
     "fg": [
-      "sewage_treatment_plant2x2_var_02", "sewage_treatment_plant2x2_var_03", "sewage_treatment_plant2x2_var_01", "sewage_treatment_plant2x2_var_00"
+      "sewage_treatment_plant2x2_var_02", "sewage_treatment_plant2x2_var_00", "sewage_treatment_plant2x2_var_01", "sewage_treatment_plant2x2_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -121,7 +121,7 @@
     ],
     "rotates": true,
     "fg": [
-      "sewage_treatment_plant2x2_var_03", "sewage_treatment_plant2x2_var_01", "sewage_treatment_plant2x2_var_00", "sewage_treatment_plant2x2_var_02"
+      "sewage_treatment_plant2x2_var_03", "sewage_treatment_plant2x2_var_02", "sewage_treatment_plant2x2_var_00", "sewage_treatment_plant2x2_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/townhall/townhall.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/townhall/townhall.json
@@ -5,7 +5,7 @@
     ],
     "rotates": true,
     "fg": [
-      "townhall_var_00", "townhall_var_02", "townhall_var_03", "townhall_var_01"
+      "townhall_var_00", "townhall_var_01", "townhall_var_03", "townhall_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -41,7 +41,7 @@
     ],
     "rotates": true,
     "fg": [
-      "townhall_var_01", "townhall_var_00", "townhall_var_02", "townhall_var_03"
+      "townhall_var_01", "townhall_var_03", "townhall_var_02", "townhall_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -77,7 +77,7 @@
     ],
     "rotates": true,
     "fg": [
-      "townhall_var_02", "townhall_var_03", "townhall_var_01", "townhall_var_00"
+      "townhall_var_02", "townhall_var_00", "townhall_var_01", "townhall_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -113,7 +113,7 @@
     ],
     "rotates": true,
     "fg": [
-      "townhall_var_03", "townhall_var_01", "townhall_var_00", "townhall_var_02"
+      "townhall_var_03", "townhall_var_02", "townhall_var_00", "townhall_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x2/wooden_fort/wooden_fort.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x2/wooden_fort/wooden_fort.json
@@ -10,7 +10,7 @@
     ],
     "rotates": true,
     "fg": [
-      "wooden_fort_var_00", "wooden_fort_var_02", "wooden_fort_var_03", "wooden_fort_var_01"
+      "wooden_fort_var_00", "wooden_fort_var_01", "wooden_fort_var_03", "wooden_fort_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -47,7 +47,7 @@
     ],
     "rotates": true,
     "fg": [
-      "wooden_fort_var_01", "wooden_fort_var_00", "wooden_fort_var_02", "wooden_fort_var_03"
+      "wooden_fort_var_01", "wooden_fort_var_03", "wooden_fort_var_02", "wooden_fort_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -84,7 +84,7 @@
     ],
     "rotates": true,
     "fg": [
-      "wooden_fort_var_02", "wooden_fort_var_03", "wooden_fort_var_01", "wooden_fort_var_00"
+      "wooden_fort_var_02", "wooden_fort_var_00", "wooden_fort_var_01", "wooden_fort_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -121,7 +121,7 @@
     ],
     "rotates": true,
     "fg": [
-      "wooden_fort_var_03", "wooden_fort_var_01", "wooden_fort_var_00", "wooden_fort_var_02"
+      "wooden_fort_var_03", "wooden_fort_var_02", "wooden_fort_var_00", "wooden_fort_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x3/hdwr_large/hdwr_large.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x3/hdwr_large/hdwr_large.json
@@ -10,7 +10,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hdwr_large_var_00", "hdwr_large_var_02", "hdwr_large_var_03", "hdwr_large_var_01"
+      "hdwr_large_var_00", "hdwr_large_var_01", "hdwr_large_var_03", "hdwr_large_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -47,7 +47,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hdwr_large_var_01", "hdwr_large_var_00", "hdwr_large_var_02", "hdwr_large_var_03"
+      "hdwr_large_var_01", "hdwr_large_var_03", "hdwr_large_var_02", "hdwr_large_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -84,7 +84,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hdwr_large_var_02", "hdwr_large_var_03", "hdwr_large_var_01", "hdwr_large_var_00"
+      "hdwr_large_var_02", "hdwr_large_var_00", "hdwr_large_var_01", "hdwr_large_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -121,7 +121,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hdwr_large_var_03", "hdwr_large_var_01", "hdwr_large_var_00", "hdwr_large_var_02"
+      "hdwr_large_var_03", "hdwr_large_var_02", "hdwr_large_var_00", "hdwr_large_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x3/hdwr_large/hdwr_large_parking.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x3/hdwr_large/hdwr_large_parking.json
@@ -5,7 +5,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking2x1_var_01", "parking2x1_var_03", "parking2x1_var_02", "parking2x1_var_00"
+      "parking2x1_var_01", "parking2x1_var_00", "parking2x1_var_02", "parking2x1_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -41,7 +41,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking2x1_var_02", "parking2x1_var_00", "parking2x1_var_01", "parking2x1_var_03"
+      "parking2x1_var_02", "parking2x1_var_03", "parking2x1_var_01", "parking2x1_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/2x3/light_industry/light_industry.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/2x3/light_industry/light_industry.json
@@ -11,7 +11,7 @@
     ],
     "rotates": true,
     "fg": [
-      "light_industry_var_00", "light_industry_var_07", "light_industry_var_11", "light_industry_var_04"
+      "light_industry_var_00", "light_industry_var_04", "light_industry_var_11", "light_industry_var_07"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -48,7 +48,7 @@
     ],
     "rotates": true,
     "fg": [
-      "light_industry_var_01", "light_industry_var_02", "light_industry_var_10", "light_industry_var_09"
+      "light_industry_var_01", "light_industry_var_09", "light_industry_var_10", "light_industry_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -85,7 +85,7 @@
     ],
     "rotates": true,
     "fg": [
-      "light_industry_var_05", "light_industry_var_08", "light_industry_var_06", "light_industry_var_03"
+      "light_industry_var_05", "light_industry_var_03", "light_industry_var_06", "light_industry_var_08"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -122,7 +122,7 @@
     ],
     "rotates": true,
     "fg": [
-      "light_industry_var_06", "light_industry_var_03", "light_industry_var_05", "light_industry_var_08"
+      "light_industry_var_06", "light_industry_var_08", "light_industry_var_05", "light_industry_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -159,7 +159,7 @@
     ],
     "rotates": true,
     "fg": [
-      "light_industry_var_10", "light_industry_var_09", "light_industry_var_01", "light_industry_var_02"
+      "light_industry_var_10", "light_industry_var_02", "light_industry_var_01", "light_industry_var_09"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -196,7 +196,7 @@
     ],
     "rotates": true,
     "fg": [
-      "light_industry_var_11", "light_industry_var_04", "light_industry_var_00", "light_industry_var_07"
+      "light_industry_var_11", "light_industry_var_07", "light_industry_var_00", "light_industry_var_04"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x1/_template3x1_/template3x1.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x1/_template3x1_/template3x1.json
@@ -10,7 +10,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x1_var_01", "template3x1_var_08", "template3x1_var_03", "template3x1_var_00"
+      "template3x1_var_01", "template3x1_var_00", "template3x1_var_03", "template3x1_var_08"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -82,7 +82,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x1_var_03", "template3x1_var_00", "template3x1_var_01", "template3x1_var_08"
+      "template3x1_var_03", "template3x1_var_08", "template3x1_var_01", "template3x1_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x1/parking_lot_3x1/parking_lot_3x1.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x1/parking_lot_3x1/parking_lot_3x1.json
@@ -10,7 +10,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking_lot_3x1_var_01", "parking_lot_3x1_var_08", "parking_lot_3x1_var_03", "parking_lot_3x1_var_00"
+      "parking_lot_3x1_var_01", "parking_lot_3x1_var_00", "parking_lot_3x1_var_03", "parking_lot_3x1_var_08"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -82,7 +82,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking_lot_3x1_var_03", "parking_lot_3x1_var_00", "parking_lot_3x1_var_01", "parking_lot_3x1_var_08"
+      "parking_lot_3x1_var_03", "parking_lot_3x1_var_08", "parking_lot_3x1_var_01", "parking_lot_3x1_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x2/_template3x2_/template3x2.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x2/_template3x2_/template3x2.json
@@ -10,7 +10,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x2_var_02", "template3x2_var_10", "template3x2_var_09", "template3x2_var_01"
+      "template3x2_var_02", "template3x2_var_01", "template3x2_var_09", "template3x2_var_10"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -46,7 +46,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x2_var_03", "template3x2_var_05", "template3x2_var_08", "template3x2_var_06"
+      "template3x2_var_03", "template3x2_var_06", "template3x2_var_08", "template3x2_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -82,7 +82,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x2_var_04", "template3x2_var_00", "template3x2_var_07", "template3x2_var_11"
+      "template3x2_var_04", "template3x2_var_11", "template3x2_var_07", "template3x2_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -118,7 +118,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x2_var_07", "template3x2_var_11", "template3x2_var_04", "template3x2_var_00"
+      "template3x2_var_07", "template3x2_var_00", "template3x2_var_04", "template3x2_var_11"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -154,7 +154,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x2_var_08", "template3x2_var_06", "template3x2_var_03", "template3x2_var_05"
+      "template3x2_var_08", "template3x2_var_05", "template3x2_var_03", "template3x2_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -190,7 +190,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x2_var_09", "template3x2_var_01", "template3x2_var_02", "template3x2_var_10"
+      "template3x2_var_09", "template3x2_var_10", "template3x2_var_02", "template3x2_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x2/hospital_urban/hospital_parking.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x2/hospital_urban/hospital_parking.json
@@ -5,7 +5,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking2x1_var_03", "parking2x1_var_02", "parking2x1_var_00", "parking2x1_var_01"
+      "parking2x1_var_03", "parking2x1_var_01", "parking2x1_var_00", "parking2x1_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -41,7 +41,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking2x1_var_00", "parking2x1_var_01", "parking2x1_var_03", "parking2x1_var_02"
+      "parking2x1_var_00", "parking2x1_var_02", "parking2x1_var_03", "parking2x1_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x2/hospital_urban/hospital_urban.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x2/hospital_urban/hospital_urban.json
@@ -16,7 +16,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hospital_urban_var_00", "hospital_urban_var_02", "hospital_urban_var_03", "hospital_urban_var_01"
+      "hospital_urban_var_00", "hospital_urban_var_01", "hospital_urban_var_03", "hospital_urban_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -59,7 +59,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hospital_urban_var_01", "hospital_urban_var_00", "hospital_urban_var_02", "hospital_urban_var_03"
+      "hospital_urban_var_01", "hospital_urban_var_03", "hospital_urban_var_02", "hospital_urban_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -102,7 +102,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hospital_urban_var_02", "hospital_urban_var_03", "hospital_urban_var_01", "hospital_urban_var_00"
+      "hospital_urban_var_02", "hospital_urban_var_00", "hospital_urban_var_01", "hospital_urban_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -145,7 +145,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hospital_urban_var_03", "hospital_urban_var_01", "hospital_urban_var_00", "hospital_urban_var_02"
+      "hospital_urban_var_03", "hospital_urban_var_02", "hospital_urban_var_00", "hospital_urban_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x2/office_tower_2/office_tower_2.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x2/office_tower_2/office_tower_2.json
@@ -14,7 +14,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_2_var_02", "office_tower_2_var_10", "office_tower_2_var_09", "office_tower_2_var_01"
+      "office_tower_2_var_02", "office_tower_2_var_01", "office_tower_2_var_09", "office_tower_2_var_10"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -53,7 +53,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_2_var_03", "office_tower_2_var_05", "office_tower_2_var_08", "office_tower_2_var_06"
+      "office_tower_2_var_03", "office_tower_2_var_06", "office_tower_2_var_08", "office_tower_2_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -92,7 +92,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_2_var_04", "office_tower_2_var_00", "office_tower_2_var_07", "office_tower_2_var_11"
+      "office_tower_2_var_04", "office_tower_2_var_11", "office_tower_2_var_07", "office_tower_2_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -132,7 +132,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_2_var_07", "office_tower_2_var_11", "office_tower_2_var_04", "office_tower_2_var_00"
+      "office_tower_2_var_07", "office_tower_2_var_00", "office_tower_2_var_04", "office_tower_2_var_11"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -172,7 +172,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_2_var_08", "office_tower_2_var_06", "office_tower_2_var_03", "office_tower_2_var_05"
+      "office_tower_2_var_08", "office_tower_2_var_05", "office_tower_2_var_03", "office_tower_2_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -211,7 +211,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_2_var_09", "office_tower_2_var_01", "office_tower_2_var_02", "office_tower_2_var_10"
+      "office_tower_2_var_09", "office_tower_2_var_10", "office_tower_2_var_02", "office_tower_2_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x2/office_tower_collapsed/office_tower_collapsed.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x2/office_tower_collapsed/office_tower_collapsed.json
@@ -11,7 +11,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_collapsed_var_02", "office_tower_collapsed_var_10", "office_tower_collapsed_var_09", "office_tower_collapsed_var_01"
+      "office_tower_collapsed_var_02", "office_tower_collapsed_var_01", "office_tower_collapsed_var_09", "office_tower_collapsed_var_10"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -48,7 +48,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_collapsed_var_03", "office_tower_collapsed_var_05", "office_tower_collapsed_var_08", "office_tower_collapsed_var_06"
+      "office_tower_collapsed_var_03", "office_tower_collapsed_var_06", "office_tower_collapsed_var_08", "office_tower_collapsed_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -85,7 +85,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_collapsed_var_04", "office_tower_collapsed_var_00", "office_tower_collapsed_var_07", "office_tower_collapsed_var_11"
+      "office_tower_collapsed_var_04", "office_tower_collapsed_var_11", "office_tower_collapsed_var_07", "office_tower_collapsed_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -122,7 +122,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_collapsed_var_07", "office_tower_collapsed_var_11", "office_tower_collapsed_var_04", "office_tower_collapsed_var_00"
+      "office_tower_collapsed_var_07", "office_tower_collapsed_var_00", "office_tower_collapsed_var_04", "office_tower_collapsed_var_11"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -159,7 +159,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_collapsed_var_08", "office_tower_collapsed_var_06", "office_tower_collapsed_var_03", "office_tower_collapsed_var_05"
+      "office_tower_collapsed_var_08", "office_tower_collapsed_var_05", "office_tower_collapsed_var_03", "office_tower_collapsed_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -196,7 +196,7 @@
     ],
     "rotates": true,
     "fg": [
-      "office_tower_collapsed_var_09", "office_tower_collapsed_var_01", "office_tower_collapsed_var_02", "office_tower_collapsed_var_10"
+      "office_tower_collapsed_var_09", "office_tower_collapsed_var_10", "office_tower_collapsed_var_02", "office_tower_collapsed_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x2/sewage_treatment_plant/sewage_treatment_plant.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x2/sewage_treatment_plant/sewage_treatment_plant.json
@@ -10,7 +10,7 @@
     ],
     "rotates": true,
     "fg": [
-      "sewage_treatment_plant_var_02", "sewage_treatment_plant_var_10", "sewage_treatment_plant_var_09", "sewage_treatment_plant_var_01"
+      "sewage_treatment_plant_var_02", "sewage_treatment_plant_var_01", "sewage_treatment_plant_var_09", "sewage_treatment_plant_var_10"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -46,7 +46,7 @@
     ],
     "rotates": true,
     "fg": [
-      "sewage_treatment_plant_var_03", "sewage_treatment_plant_var_05", "sewage_treatment_plant_var_08", "sewage_treatment_plant_var_06"
+      "sewage_treatment_plant_var_03", "sewage_treatment_plant_var_06", "sewage_treatment_plant_var_08", "sewage_treatment_plant_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -82,7 +82,7 @@
     ],
     "rotates": true,
     "fg": [
-      "sewage_treatment_plant_var_04", "sewage_treatment_plant_var_00", "sewage_treatment_plant_var_07", "sewage_treatment_plant_var_11"
+      "sewage_treatment_plant_var_04", "sewage_treatment_plant_var_11", "sewage_treatment_plant_var_07", "sewage_treatment_plant_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -118,7 +118,7 @@
     ],
     "rotates": true,
     "fg": [
-      "sewage_treatment_plant_var_07", "sewage_treatment_plant_var_11", "sewage_treatment_plant_var_04", "sewage_treatment_plant_var_00"
+      "sewage_treatment_plant_var_07", "sewage_treatment_plant_var_00", "sewage_treatment_plant_var_04", "sewage_treatment_plant_var_11"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -154,7 +154,7 @@
     ],
     "rotates": true,
     "fg": [
-      "sewage_treatment_plant_var_08", "sewage_treatment_plant_var_06", "sewage_treatment_plant_var_03", "sewage_treatment_plant_var_05"
+      "sewage_treatment_plant_var_08", "sewage_treatment_plant_var_05", "sewage_treatment_plant_var_03", "sewage_treatment_plant_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -190,7 +190,7 @@
     ],
     "rotates": true,
     "fg": [
-      "sewage_treatment_plant_var_09", "sewage_treatment_plant_var_01", "sewage_treatment_plant_var_02", "sewage_treatment_plant_var_10"
+      "sewage_treatment_plant_var_09", "sewage_treatment_plant_var_10", "sewage_treatment_plant_var_02", "sewage_treatment_plant_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x3/_template3x3_/template3x3.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x3/_template3x3_/template3x3.json
@@ -14,7 +14,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x3_var_00", "template3x3_var_06", "template3x3_var_08", "template3x3_var_02"
+      "template3x3_var_00", "template3x3_var_02", "template3x3_var_08", "template3x3_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -50,7 +50,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x3_var_01", "template3x3_var_03", "template3x3_var_07", "template3x3_var_05"
+      "template3x3_var_01", "template3x3_var_05", "template3x3_var_07", "template3x3_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -86,7 +86,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x3_var_02", "template3x3_var_00", "template3x3_var_06", "template3x3_var_08"
+      "template3x3_var_02", "template3x3_var_08", "template3x3_var_06", "template3x3_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -126,7 +126,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x3_var_03", "template3x3_var_07", "template3x3_var_05", "template3x3_var_01"
+      "template3x3_var_03", "template3x3_var_01", "template3x3_var_05", "template3x3_var_07"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -198,7 +198,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x3_var_05", "template3x3_var_01", "template3x3_var_03", "template3x3_var_07"
+      "template3x3_var_05", "template3x3_var_07", "template3x3_var_03", "template3x3_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -238,7 +238,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x3_var_06", "template3x3_var_08", "template3x3_var_02", "template3x3_var_00"
+      "template3x3_var_06", "template3x3_var_00", "template3x3_var_02", "template3x3_var_08"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -274,7 +274,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x3_var_07", "template3x3_var_05", "template3x3_var_01", "template3x3_var_03"
+      "template3x3_var_07", "template3x3_var_03", "template3x3_var_01", "template3x3_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -310,7 +310,7 @@
     ],
     "rotates": true,
     "fg": [
-      "template3x3_var_08", "template3x3_var_02", "template3x3_var_00", "template3x3_var_06"
+      "template3x3_var_08", "template3x3_var_06", "template3x3_var_00", "template3x3_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x3/apartment_complex/apartment_complex.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x3/apartment_complex/apartment_complex.json
@@ -15,7 +15,7 @@
     ],
     "rotates": true,
     "fg": [
-      "apartment_complex_var_01", "apartment_complex_var_03", "apartment_complex_var_07", "apartment_complex_var_05"
+      "apartment_complex_var_01", "apartment_complex_var_05", "apartment_complex_var_07", "apartment_complex_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -117,7 +117,7 @@
     ],
     "rotates": true,
     "fg": [
-      "apartment_complex_var_06", "apartment_complex_var_08", "apartment_complex_var_02", "apartment_complex_var_00"
+      "apartment_complex_var_06", "apartment_complex_var_00", "apartment_complex_var_02", "apartment_complex_var_08"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -167,7 +167,7 @@
     ],
     "rotates": true,
     "fg": [
-      "apartment_complex_var_07", "apartment_complex_var_05", "apartment_complex_var_01", "apartment_complex_var_03"
+      "apartment_complex_var_07", "apartment_complex_var_03", "apartment_complex_var_01", "apartment_complex_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x3/beehive/beehive.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x3/beehive/beehive.json
@@ -15,7 +15,7 @@
     ],
     "rotates": true,
     "fg": [
-      "beehive_var_00", "beehive_var_06", "beehive_var_08", "beehive_var_02"
+      "beehive_var_00", "beehive_var_02", "beehive_var_08", "beehive_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -52,7 +52,7 @@
     ],
     "rotates": true,
     "fg": [
-      "beehive_var_01", "beehive_var_03", "beehive_var_07", "beehive_var_05"
+      "beehive_var_01", "beehive_var_05", "beehive_var_07", "beehive_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -89,7 +89,7 @@
     ],
     "rotates": true,
     "fg": [
-      "beehive_var_02", "beehive_var_00", "beehive_var_06", "beehive_var_08"
+      "beehive_var_02", "beehive_var_08", "beehive_var_06", "beehive_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -130,7 +130,7 @@
     ],
     "rotates": true,
     "fg": [
-      "beehive_var_03", "beehive_var_07", "beehive_var_05", "beehive_var_01"
+      "beehive_var_03", "beehive_var_01", "beehive_var_05", "beehive_var_07"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -204,7 +204,7 @@
     ],
     "rotates": true,
     "fg": [
-      "beehive_var_05", "beehive_var_01", "beehive_var_03", "beehive_var_07"
+      "beehive_var_05", "beehive_var_07", "beehive_var_03", "beehive_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -245,7 +245,7 @@
     ],
     "rotates": true,
     "fg": [
-      "beehive_var_06", "beehive_var_08", "beehive_var_02", "beehive_var_00"
+      "beehive_var_06", "beehive_var_00", "beehive_var_02", "beehive_var_08"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -282,7 +282,7 @@
     ],
     "rotates": true,
     "fg": [
-      "beehive_var_07", "beehive_var_05", "beehive_var_01", "beehive_var_03"
+      "beehive_var_07", "beehive_var_03", "beehive_var_01", "beehive_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -319,7 +319,7 @@
     ],
     "rotates": true,
     "fg": [
-      "beehive_var_08", "beehive_var_02", "beehive_var_00", "beehive_var_06"
+      "beehive_var_08", "beehive_var_06", "beehive_var_00", "beehive_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x3/fema_camp/fema_camp.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x3/fema_camp/fema_camp.json
@@ -5,7 +5,7 @@
     ],
     "rotates": true,
     "fg": [
-      "fema_camp_var_00", "fema_camp_var_06", "fema_camp_var_08", "fema_camp_var_02"
+      "fema_camp_var_00", "fema_camp_var_02", "fema_camp_var_08", "fema_camp_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -41,7 +41,7 @@
     ],
     "rotates": true,
     "fg": [
-      "fema_camp_var_01", "fema_camp_var_03", "fema_camp_var_07", "fema_camp_var_05"
+      "fema_camp_var_01", "fema_camp_var_05", "fema_camp_var_07", "fema_camp_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -77,7 +77,7 @@
     ],
     "rotates": true,
     "fg": [
-      "fema_camp_var_02", "fema_camp_var_00", "fema_camp_var_06", "fema_camp_var_08"
+      "fema_camp_var_02", "fema_camp_var_08", "fema_camp_var_06", "fema_camp_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -117,7 +117,7 @@
     ],
     "rotates": true,
     "fg": [
-      "fema_camp_var_03", "fema_camp_var_07", "fema_camp_var_05", "fema_camp_var_01"
+      "fema_camp_var_03", "fema_camp_var_01", "fema_camp_var_05", "fema_camp_var_07"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -189,7 +189,7 @@
     ],
     "rotates": true,
     "fg": [
-      "fema_camp_var_05", "fema_camp_var_01", "fema_camp_var_03", "fema_camp_var_07"
+      "fema_camp_var_05", "fema_camp_var_07", "fema_camp_var_03", "fema_camp_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -229,7 +229,7 @@
     ],
     "rotates": true,
     "fg": [
-      "fema_camp_var_06", "fema_camp_var_08", "fema_camp_var_02", "fema_camp_var_00"
+      "fema_camp_var_06", "fema_camp_var_00", "fema_camp_var_02", "fema_camp_var_08"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -265,7 +265,7 @@
     ],
     "rotates": true,
     "fg": [
-      "fema_camp_var_07", "fema_camp_var_05", "fema_camp_var_01", "fema_camp_var_03"
+      "fema_camp_var_07", "fema_camp_var_03", "fema_camp_var_01", "fema_camp_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -301,7 +301,7 @@
     ],
     "rotates": true,
     "fg": [
-      "fema_camp_var_08", "fema_camp_var_02", "fema_camp_var_00", "fema_camp_var_06"
+      "fema_camp_var_08", "fema_camp_var_06", "fema_camp_var_00", "fema_camp_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x3/hospital/hospital.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x3/hospital/hospital.json
@@ -15,7 +15,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hospital_var_00", "hospital_var_06", "hospital_var_08", "hospital_var_02"
+      "hospital_var_00", "hospital_var_02", "hospital_var_08", "hospital_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -52,7 +52,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hospital_var_01", "hospital_var_03", "hospital_var_07", "hospital_var_05"
+      "hospital_var_01", "hospital_var_05", "hospital_var_07", "hospital_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -89,7 +89,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hospital_var_02", "hospital_var_00", "hospital_var_06", "hospital_var_08"
+      "hospital_var_02", "hospital_var_08", "hospital_var_06", "hospital_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -130,7 +130,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hospital_var_03", "hospital_var_07", "hospital_var_05", "hospital_var_01"
+      "hospital_var_03", "hospital_var_01", "hospital_var_05", "hospital_var_07"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -204,7 +204,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hospital_var_05", "hospital_var_01", "hospital_var_03", "hospital_var_07"
+      "hospital_var_05", "hospital_var_07", "hospital_var_03", "hospital_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -245,7 +245,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hospital_var_06", "hospital_var_08", "hospital_var_02", "hospital_var_00"
+      "hospital_var_06", "hospital_var_00", "hospital_var_02", "hospital_var_08"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -282,7 +282,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hospital_var_07", "hospital_var_05", "hospital_var_01", "hospital_var_03"
+      "hospital_var_07", "hospital_var_03", "hospital_var_01", "hospital_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -319,7 +319,7 @@
     ],
     "rotates": true,
     "fg": [
-      "hospital_var_08", "hospital_var_02", "hospital_var_00", "hospital_var_06"
+      "hospital_var_08", "hospital_var_06", "hospital_var_00", "hospital_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x3/mansion/mansion.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x3/mansion/mansion.json
@@ -168,7 +168,7 @@
     ],
     "rotates": true,
     "fg": [
-      "mansion_var_00", "mansion_var_06", "mansion_var_08", "mansion_var_02"
+      "mansion_var_00", "mansion_var_02", "mansion_var_08", "mansion_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -204,7 +204,7 @@
     ],
     "rotates": true,
     "fg": [
-      "mansion_var_01", "mansion_var_03", "mansion_var_07", "mansion_var_05"
+      "mansion_var_01", "mansion_var_05", "mansion_var_07", "mansion_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -240,7 +240,7 @@
     ],
     "rotates": true,
     "fg": [
-      "mansion_var_02", "mansion_var_00", "mansion_var_06", "mansion_var_08"
+      "mansion_var_02", "mansion_var_08", "mansion_var_06", "mansion_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -280,7 +280,7 @@
     ],
     "rotates": true,
     "fg": [
-      "mansion_var_03", "mansion_var_07", "mansion_var_05", "mansion_var_01"
+      "mansion_var_03", "mansion_var_01", "mansion_var_05", "mansion_var_07"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -352,7 +352,7 @@
     ],
     "rotates": true,
     "fg": [
-      "mansion_var_05", "mansion_var_01", "mansion_var_03", "mansion_var_07"
+      "mansion_var_05", "mansion_var_07", "mansion_var_03", "mansion_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -392,7 +392,7 @@
     ],
     "rotates": true,
     "fg": [
-      "mansion_var_06", "mansion_var_08", "mansion_var_02", "mansion_var_00"
+      "mansion_var_06", "mansion_var_00", "mansion_var_02", "mansion_var_08"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -428,7 +428,7 @@
     ],
     "rotates": true,
     "fg": [
-      "mansion_var_07", "mansion_var_05", "mansion_var_01", "mansion_var_03"
+      "mansion_var_07", "mansion_var_03", "mansion_var_01", "mansion_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -464,7 +464,7 @@
     ],
     "rotates": true,
     "fg": [
-      "mansion_var_08", "mansion_var_02", "mansion_var_00", "mansion_var_06"
+      "mansion_var_08", "mansion_var_06", "mansion_var_00", "mansion_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x3/prison/prison.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x3/prison/prison.json
@@ -17,7 +17,7 @@
     ],
     "rotates": true,
     "fg": [
-      "prison_var_00", "prison_var_06", "prison_var_08", "prison_var_02"
+      "prison_var_00", "prison_var_02", "prison_var_08", "prison_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -56,7 +56,7 @@
     ],
     "rotates": true,
     "fg": [
-      "prison_var_01", "prison_var_03", "prison_var_07", "prison_var_05"
+      "prison_var_01", "prison_var_05", "prison_var_07", "prison_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -95,7 +95,7 @@
     ],
     "rotates": true,
     "fg": [
-      "prison_var_02", "prison_var_00", "prison_var_06", "prison_var_08"
+      "prison_var_02", "prison_var_08", "prison_var_06", "prison_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -138,7 +138,7 @@
     ],
     "rotates": true,
     "fg": [
-      "prison_var_03", "prison_var_07", "prison_var_05", "prison_var_01"
+      "prison_var_03", "prison_var_01", "prison_var_05", "prison_var_07"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -216,7 +216,7 @@
     ],
     "rotates": true,
     "fg": [
-      "prison_var_05", "prison_var_01", "prison_var_03", "prison_var_07"
+      "prison_var_05", "prison_var_07", "prison_var_03", "prison_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -260,7 +260,7 @@
     ],
     "rotates": true,
     "fg": [
-      "prison_var_06", "prison_var_08", "prison_var_02", "prison_var_00"
+      "prison_var_06", "prison_var_00", "prison_var_02", "prison_var_08"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -300,7 +300,7 @@
     ],
     "rotates": true,
     "fg": [
-      "prison_var_07", "prison_var_05", "prison_var_01", "prison_var_03"
+      "prison_var_07", "prison_var_03", "prison_var_01", "prison_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -340,7 +340,7 @@
     ],
     "rotates": true,
     "fg": [
-      "prison_var_08", "prison_var_02", "prison_var_00", "prison_var_06"
+      "prison_var_08", "prison_var_06", "prison_var_00", "prison_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/3x3/triffid_tree/triffid.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/3x3/triffid_tree/triffid.json
@@ -137,7 +137,7 @@
     ],
     "rotates": true,
     "fg": [
-      "tf_roots_var_08", "tf_roots_var_02", "tf_roots_var_00", "tf_roots_var_06"
+      "tf_roots_var_08", "tf_roots_var_06", "tf_roots_var_00", "tf_roots_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -173,7 +173,7 @@
     ],
     "rotates": true,
     "fg": [
-      "tf_roots_var_07", "tf_roots_var_05", "tf_roots_var_01", "tf_roots_var_03"
+      "tf_roots_var_07", "tf_roots_var_03", "tf_roots_var_01", "tf_roots_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -209,7 +209,7 @@
     ],
     "rotates": true,
     "fg": [
-      "tf_roots_var_06", "tf_roots_var_08", "tf_roots_var_02", "tf_roots_var_00"
+      "tf_roots_var_06", "tf_roots_var_00", "tf_roots_var_02", "tf_roots_var_08"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -245,7 +245,7 @@
     ],
     "rotates": true,
     "fg": [
-      "tf_roots_var_05", "tf_roots_var_01", "tf_roots_var_03", "tf_roots_var_07"
+      "tf_roots_var_05", "tf_roots_var_07", "tf_roots_var_03", "tf_roots_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -317,7 +317,7 @@
     ],
     "rotates": true,
     "fg": [
-      "tf_roots_var_03", "tf_roots_var_07", "tf_roots_var_05", "tf_roots_var_01"
+      "tf_roots_var_03", "tf_roots_var_01", "tf_roots_var_05", "tf_roots_var_07"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -353,7 +353,7 @@
     ],
     "rotates": true,
     "fg": [
-      "tf_roots_var_02", "tf_roots_var_00", "tf_roots_var_06", "tf_roots_var_08"
+      "tf_roots_var_02", "tf_roots_var_08", "tf_roots_var_06", "tf_roots_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -389,7 +389,7 @@
     ],
     "rotates": true,
     "fg": [
-      "tf_roots_var_01", "tf_roots_var_03", "tf_roots_var_07", "tf_roots_var_05"
+      "tf_roots_var_01", "tf_roots_var_05", "tf_roots_var_07", "tf_roots_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -425,7 +425,7 @@
     ],
     "rotates": true,
     "fg": [
-      "tf_roots_var_00", "tf_roots_var_06", "tf_roots_var_08", "tf_roots_var_02"
+      "tf_roots_var_00", "tf_roots_var_02", "tf_roots_var_08", "tf_roots_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/4x3/dairy_farm_twd/dairy_farm_twd.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/4x3/dairy_farm_twd/dairy_farm_twd.json
@@ -140,23 +140,23 @@
     "rotates": true,
     "fg": [
       { "weight": 1,
-        "sprite": [ "dirt_v1_corner_nw", "dirt_v1_corner_sw", "dirt_v1_corner_se", "dirt_v1_corner_ne" ]
+        "sprite": [ "dirt_v1_corner_nw", "dirt_v1_corner_ne", "dirt_v1_corner_se", "dirt_v1_corner_sw" ]
       },
       {
         "weight": 1,
-        "sprite": [ "dirt_v2_corner_nw", "dirt_v2_corner_sw", "dirt_v2_corner_se", "dirt_v2_corner_ne" ]
+        "sprite": [ "dirt_v2_corner_nw", "dirt_v2_corner_ne", "dirt_v2_corner_se", "dirt_v2_corner_sw" ]
       },
       {
         "weight": 1,
-        "sprite": [ "dirt_v3_corner_nw", "dirt_v3_corner_sw", "dirt_v3_corner_se", "dirt_v3_corner_ne" ]
+        "sprite": [ "dirt_v3_corner_nw", "dirt_v3_corner_ne", "dirt_v3_corner_se", "dirt_v3_corner_sw" ]
       },
       {
         "weight": 1,
-        "sprite": [ "dirt_v4_corner_nw", "dirt_v4_corner_sw", "dirt_v4_corner_se", "dirt_v4_corner_ne" ]
+        "sprite": [ "dirt_v4_corner_nw", "dirt_v4_corner_ne", "dirt_v4_corner_se", "dirt_v4_corner_sw" ]
       },
       {
         "weight": 1,
-        "sprite": [ "dirt_v5_corner_nw", "dirt_v5_corner_sw", "dirt_v5_corner_se", "dirt_v5_corner_ne" ]
+        "sprite": [ "dirt_v5_corner_nw", "dirt_v5_corner_ne", "dirt_v5_corner_se", "dirt_v5_corner_sw" ]
       }
     ],
     "bg": [

--- a/gfx/PenAndPaper/pngs_overmap_48x48/4x3/nursing_home/nursing_home.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/4x3/nursing_home/nursing_home.json
@@ -12,7 +12,7 @@
     ],
     "rotates": true,
     "fg": [
-      "nursing_home_var_02", "nursing_home_var_10", "nursing_home_var_09", "nursing_home_var_01"
+      "nursing_home_var_02", "nursing_home_var_01", "nursing_home_var_09", "nursing_home_var_10"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -50,7 +50,7 @@
     ],
     "rotates": true,
     "fg": [
-      "nursing_home_var_03", "nursing_home_var_05", "nursing_home_var_08", "nursing_home_var_06"
+      "nursing_home_var_03", "nursing_home_var_06", "nursing_home_var_08", "nursing_home_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -88,7 +88,7 @@
     ],
     "rotates": true,
     "fg": [
-      "nursing_home_var_04", "nursing_home_var_00", "nursing_home_var_07", "nursing_home_var_11"
+      "nursing_home_var_04", "nursing_home_var_11", "nursing_home_var_07", "nursing_home_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -126,7 +126,7 @@
     ],
     "rotates": true,
     "fg": [
-      "nursing_home_var_07", "nursing_home_var_11", "nursing_home_var_04", "nursing_home_var_00"
+      "nursing_home_var_07", "nursing_home_var_00", "nursing_home_var_04", "nursing_home_var_11"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -164,7 +164,7 @@
     ],
     "rotates": true,
     "fg": [
-      "nursing_home_var_08", "nursing_home_var_06", "nursing_home_var_03", "nursing_home_var_05"
+      "nursing_home_var_08", "nursing_home_var_05", "nursing_home_var_03", "nursing_home_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -202,7 +202,7 @@
     ],
     "rotates": true,
     "fg": [
-      "nursing_home_var_09", "nursing_home_var_01", "nursing_home_var_02", "nursing_home_var_10"
+      "nursing_home_var_09", "nursing_home_var_10", "nursing_home_var_02", "nursing_home_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -396,7 +396,7 @@
     ],
     "rotates": true,
     "fg": [
-      "nursing_home_sh_var_02", "nursing_home_sh_var_10", "nursing_home_sh_var_09", "nursing_home_sh_var_01"
+      "nursing_home_sh_var_02", "nursing_home_sh_var_01", "nursing_home_sh_var_09", "nursing_home_sh_var_10"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -432,7 +432,7 @@
     ],
     "rotates": true,
     "fg": [
-      "nursing_home_sh_var_03", "nursing_home_sh_var_05", "nursing_home_sh_var_08", "nursing_home_sh_var_06"
+      "nursing_home_sh_var_03", "nursing_home_sh_var_06", "nursing_home_sh_var_08", "nursing_home_sh_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -468,7 +468,7 @@
     ],
     "rotates": true,
     "fg": [
-      "nursing_home_sh_var_04", "nursing_home_sh_var_00", "nursing_home_sh_var_07", "nursing_home_sh_var_11"
+      "nursing_home_sh_var_04", "nursing_home_sh_var_11", "nursing_home_sh_var_07", "nursing_home_sh_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -504,7 +504,7 @@
     ],
     "rotates": true,
     "fg": [
-      "nursing_home_sh_var_07", "nursing_home_sh_var_11", "nursing_home_sh_var_04", "nursing_home_sh_var_00"
+      "nursing_home_sh_var_07", "nursing_home_sh_var_00", "nursing_home_sh_var_04", "nursing_home_sh_var_11"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -540,7 +540,7 @@
     ],
     "rotates": true,
     "fg": [
-      "nursing_home_sh_var_08", "nursing_home_sh_var_06", "nursing_home_sh_var_03", "nursing_home_sh_var_05"
+      "nursing_home_sh_var_08", "nursing_home_sh_var_05", "nursing_home_sh_var_03", "nursing_home_sh_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -576,7 +576,7 @@
     ],
     "rotates": true,
     "fg": [
-      "nursing_home_sh_var_09", "nursing_home_sh_var_01", "nursing_home_sh_var_02", "nursing_home_sh_var_10"
+      "nursing_home_sh_var_09", "nursing_home_sh_var_10", "nursing_home_sh_var_02", "nursing_home_sh_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/4x3/nursing_home/nursing_home_parking.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/4x3/nursing_home/nursing_home_parking.json
@@ -11,7 +11,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking_lot_3x1_var_01", "parking_lot_3x1_var_08", "parking_lot_3x1_var_03", "parking_lot_3x1_var_00"
+      "parking_lot_3x1_var_01", "parking_lot_3x1_var_00", "parking_lot_3x1_var_03", "parking_lot_3x1_var_08"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -85,7 +85,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking_lot_3x1_var_03", "parking_lot_3x1_var_00", "parking_lot_3x1_var_01", "parking_lot_3x1_var_08"
+      "parking_lot_3x1_var_03", "parking_lot_3x1_var_08", "parking_lot_3x1_var_01", "parking_lot_3x1_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/4x3/nursing_home/nursing_home_road.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/4x3/nursing_home/nursing_home_road.json
@@ -8,23 +8,23 @@
     "fg": [
       {
         "weight": 1,
-        "sprite": [ "road_v1_t_connection_e", "road_v1_t_connection_n", "road_v1_t_connection_w", "road_v1_t_connection_s" ]
+        "sprite": [ "road_v1_t_connection_e", "road_v1_t_connection_s", "road_v1_t_connection_w", "road_v1_t_connection_n" ]
       },
       {
         "weight": 1,
-        "sprite": [ "road_v2_t_connection_e", "road_v2_t_connection_n", "road_v2_t_connection_w", "road_v2_t_connection_s" ]
+        "sprite": [ "road_v2_t_connection_e", "road_v2_t_connection_s", "road_v2_t_connection_w", "road_v2_t_connection_n" ]
       },
       {
         "weight": 1,
-        "sprite": [ "road_v3_t_connection_e", "road_v3_t_connection_n", "road_v3_t_connection_w", "road_v3_t_connection_s" ]
+        "sprite": [ "road_v3_t_connection_e", "road_v3_t_connection_s", "road_v3_t_connection_w", "road_v3_t_connection_n" ]
       },
       {
         "weight": 1,
-        "sprite": [ "road_v4_t_connection_e", "road_v4_t_connection_n", "road_v4_t_connection_w", "road_v4_t_connection_s" ]
+        "sprite": [ "road_v4_t_connection_e", "road_v4_t_connection_s", "road_v4_t_connection_w", "road_v4_t_connection_n" ]
       },
       {
         "weight": 1,
-        "sprite": [ "road_v5_t_connection_e", "road_v5_t_connection_n", "road_v5_t_connection_w", "road_v5_t_connection_s" ]
+        "sprite": [ "road_v5_t_connection_e", "road_v5_t_connection_s", "road_v5_t_connection_w", "road_v5_t_connection_n" ]
       }
     ],
     "bg": [
@@ -103,11 +103,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "road_v1_corner_ne", "road_v1_corner_nw", "road_v1_corner_sw", "road_v1_corner_se" ] },
-      { "weight": 1, "sprite": [ "road_v2_corner_ne", "road_v2_corner_nw", "road_v2_corner_sw", "road_v2_corner_se" ] },
-      { "weight": 1, "sprite": [ "road_v3_corner_ne", "road_v3_corner_nw", "road_v3_corner_sw", "road_v3_corner_se" ] },
-      { "weight": 1, "sprite": [ "road_v4_corner_ne", "road_v4_corner_nw", "road_v4_corner_sw", "road_v4_corner_se" ] },
-      { "weight": 1, "sprite": [ "road_v5_corner_ne", "road_v5_corner_nw", "road_v5_corner_sw", "road_v5_corner_se" ] }
+      { "weight": 1, "sprite": [ "road_v1_corner_ne", "road_v1_corner_se", "road_v1_corner_sw", "road_v1_corner_nw" ] },
+      { "weight": 1, "sprite": [ "road_v2_corner_ne", "road_v2_corner_se", "road_v2_corner_sw", "road_v2_corner_nw" ] },
+      { "weight": 1, "sprite": [ "road_v3_corner_ne", "road_v3_corner_se", "road_v3_corner_sw", "road_v3_corner_nw" ] },
+      { "weight": 1, "sprite": [ "road_v4_corner_ne", "road_v4_corner_se", "road_v4_corner_sw", "road_v4_corner_nw" ] },
+      { "weight": 1, "sprite": [ "road_v5_corner_ne", "road_v5_corner_se", "road_v5_corner_sw", "road_v5_corner_nw" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/4x4/biker_dump/biker_dump.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/4x4/biker_dump/biker_dump.json
@@ -4,7 +4,7 @@
       "ws_biker_dump_0_0"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_00", "biker_dump_var_12", "biker_dump_var_15", "biker_dump_var_03"],
+    "fg": ["biker_dump_var_00", "biker_dump_var_03", "biker_dump_var_15", "biker_dump_var_12"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -38,7 +38,7 @@
       "ws_biker_dump_1_0"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_01", "biker_dump_var_08", "biker_dump_var_14", "biker_dump_var_07"],
+    "fg": ["biker_dump_var_01", "biker_dump_var_07", "biker_dump_var_14", "biker_dump_var_08"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -72,7 +72,7 @@
       "ws_biker_dump_2_0"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_02", "biker_dump_var_04", "biker_dump_var_13", "biker_dump_var_11"],
+    "fg": ["biker_dump_var_02", "biker_dump_var_11", "biker_dump_var_13", "biker_dump_var_04"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -106,7 +106,7 @@
       "ws_biker_dump_3_0"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_03", "biker_dump_var_00", "biker_dump_var_12", "biker_dump_var_15"],
+    "fg": ["biker_dump_var_03", "biker_dump_var_15", "biker_dump_var_12", "biker_dump_var_00"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -144,7 +144,7 @@
       "ws_biker_dump_0_1"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_04", "biker_dump_var_13", "biker_dump_var_11", "biker_dump_var_02"],
+    "fg": ["biker_dump_var_04", "biker_dump_var_02", "biker_dump_var_11", "biker_dump_var_13"],
         "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -178,7 +178,7 @@
       "ws_biker_dump_1_1"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_05", "biker_dump_var_09", "biker_dump_var_10", "biker_dump_var_06"],
+    "fg": ["biker_dump_var_05", "biker_dump_var_06", "biker_dump_var_10", "biker_dump_var_09"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -212,7 +212,7 @@
       "ws_biker_dump_2_1"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_06", "biker_dump_var_05", "biker_dump_var_09", "biker_dump_var_10"],
+    "fg": ["biker_dump_var_06", "biker_dump_var_10", "biker_dump_var_09", "biker_dump_var_05"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -246,7 +246,7 @@
       "ws_biker_dump_3_1"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_07", "biker_dump_var_01", "biker_dump_var_08", "biker_dump_var_14"],
+    "fg": ["biker_dump_var_07", "biker_dump_var_14", "biker_dump_var_08", "biker_dump_var_01"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -284,7 +284,7 @@
       "ws_biker_dump_0_2"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_08", "biker_dump_var_14", "biker_dump_var_07", "biker_dump_var_01"],
+    "fg": ["biker_dump_var_08", "biker_dump_var_01", "biker_dump_var_07", "biker_dump_var_14"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -318,7 +318,7 @@
       "ws_biker_dump_1_2"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_09", "biker_dump_var_10", "biker_dump_var_06", "biker_dump_var_05"],
+    "fg": ["biker_dump_var_09", "biker_dump_var_05", "biker_dump_var_06", "biker_dump_var_10"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -352,7 +352,7 @@
       "ws_biker_dump_2_2"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_10", "biker_dump_var_06", "biker_dump_var_05", "biker_dump_var_09"],
+    "fg": ["biker_dump_var_10", "biker_dump_var_09", "biker_dump_var_05", "biker_dump_var_06"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -386,7 +386,7 @@
       "ws_biker_dump_3_2"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_11", "biker_dump_var_02", "biker_dump_var_04", "biker_dump_var_13"],
+    "fg": ["biker_dump_var_11", "biker_dump_var_13", "biker_dump_var_04", "biker_dump_var_02"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -424,7 +424,7 @@
       "ws_biker_dump_0_3"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_12", "biker_dump_var_15", "biker_dump_var_03", "biker_dump_var_00"],
+    "fg": ["biker_dump_var_12", "biker_dump_var_00", "biker_dump_var_03", "biker_dump_var_15"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -458,7 +458,7 @@
       "ws_biker_dump_1_3"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_13", "biker_dump_var_11", "biker_dump_var_02", "biker_dump_var_04"],
+    "fg": ["biker_dump_var_13", "biker_dump_var_04", "biker_dump_var_02", "biker_dump_var_11"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -492,7 +492,7 @@
       "ws_biker_dump_2_3"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_14", "biker_dump_var_07", "biker_dump_var_01", "biker_dump_var_08"],
+    "fg": ["biker_dump_var_14", "biker_dump_var_08", "biker_dump_var_01", "biker_dump_var_07"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -526,7 +526,7 @@
       "ws_biker_dump_3_3"
     ],
     "rotates": true,
-    "fg": ["biker_dump_var_15", "biker_dump_var_03", "biker_dump_var_00", "biker_dump_var_12"],
+    "fg": ["biker_dump_var_15", "biker_dump_var_12", "biker_dump_var_00", "biker_dump_var_03"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/4x4/exodii_base/exodii_base.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/4x4/exodii_base/exodii_base.json
@@ -8,7 +8,7 @@
       "exodii_base_x0y0z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_00", "exodii_base_var_12", "exodii_base_var_15", "exodii_base_var_03"],
+    "fg": ["exodii_base_var_00", "exodii_base_var_03", "exodii_base_var_15", "exodii_base_var_12"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -46,7 +46,7 @@
       "exodii_base_x1y0z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_01", "exodii_base_var_08", "exodii_base_var_14", "exodii_base_var_07"],
+    "fg": ["exodii_base_var_01", "exodii_base_var_07", "exodii_base_var_14", "exodii_base_var_08"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -84,7 +84,7 @@
       "exodii_base_x2y0z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_02", "exodii_base_var_04", "exodii_base_var_13", "exodii_base_var_11"],
+    "fg": ["exodii_base_var_02", "exodii_base_var_11", "exodii_base_var_13", "exodii_base_var_04"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -122,7 +122,7 @@
       "exodii_base_x3y0z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_03", "exodii_base_var_00", "exodii_base_var_12", "exodii_base_var_15"],
+    "fg": ["exodii_base_var_03", "exodii_base_var_15", "exodii_base_var_12", "exodii_base_var_00"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -164,7 +164,7 @@
       "exodii_base_x0y1z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_04", "exodii_base_var_13", "exodii_base_var_11", "exodii_base_var_02"],
+    "fg": ["exodii_base_var_04", "exodii_base_var_02", "exodii_base_var_11", "exodii_base_var_13"],
         "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -202,7 +202,7 @@
       "exodii_base_x1y1z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_05", "exodii_base_var_09", "exodii_base_var_10", "exodii_base_var_06"],
+    "fg": ["exodii_base_var_05", "exodii_base_var_06", "exodii_base_var_10", "exodii_base_var_09"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -240,7 +240,7 @@
       "exodii_base_x2y1z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_06", "exodii_base_var_05", "exodii_base_var_09", "exodii_base_var_10"],
+    "fg": ["exodii_base_var_06", "exodii_base_var_10", "exodii_base_var_09", "exodii_base_var_05"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -278,7 +278,7 @@
       "exodii_base_x3y1z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_07", "exodii_base_var_01", "exodii_base_var_08", "exodii_base_var_14"],
+    "fg": ["exodii_base_var_07", "exodii_base_var_14", "exodii_base_var_08", "exodii_base_var_01"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -320,7 +320,7 @@
       "exodii_base_x0y2z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_08", "exodii_base_var_14", "exodii_base_var_07", "exodii_base_var_01"],
+    "fg": ["exodii_base_var_08", "exodii_base_var_01", "exodii_base_var_07", "exodii_base_var_14"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -358,7 +358,7 @@
       "exodii_base_x1y2z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_09", "exodii_base_var_10", "exodii_base_var_06", "exodii_base_var_05"],
+    "fg": ["exodii_base_var_09", "exodii_base_var_05", "exodii_base_var_06", "exodii_base_var_10"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -396,7 +396,7 @@
       "exodii_base_x2y2z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_10", "exodii_base_var_06", "exodii_base_var_05", "exodii_base_var_09"],
+    "fg": ["exodii_base_var_10", "exodii_base_var_09", "exodii_base_var_05", "exodii_base_var_06"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -434,7 +434,7 @@
       "exodii_base_x3y2z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_11", "exodii_base_var_02", "exodii_base_var_04", "exodii_base_var_13"],
+    "fg": ["exodii_base_var_11", "exodii_base_var_13", "exodii_base_var_04", "exodii_base_var_02"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -476,7 +476,7 @@
       "exodii_base_x0y3z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_12", "exodii_base_var_15", "exodii_base_var_03", "exodii_base_var_00"],
+    "fg": ["exodii_base_var_12", "exodii_base_var_00", "exodii_base_var_03", "exodii_base_var_15"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -514,7 +514,7 @@
       "exodii_base_x1y3z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_13", "exodii_base_var_11", "exodii_base_var_02", "exodii_base_var_04"],
+    "fg": ["exodii_base_var_13", "exodii_base_var_04", "exodii_base_var_02", "exodii_base_var_11"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -552,7 +552,7 @@
       "exodii_base_x2y3z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_14", "exodii_base_var_07", "exodii_base_var_01", "exodii_base_var_08"],
+    "fg": ["exodii_base_var_14", "exodii_base_var_08", "exodii_base_var_01", "exodii_base_var_07"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -590,7 +590,7 @@
       "exodii_base_x3y3z4"
     ],
     "rotates": true,
-    "fg": ["exodii_base_var_15", "exodii_base_var_03", "exodii_base_var_00", "exodii_base_var_12"],
+    "fg": ["exodii_base_var_15", "exodii_base_var_12", "exodii_base_var_00", "exodii_base_var_03"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/4x4/regional_dump/regional_dump.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/4x4/regional_dump/regional_dump.json
@@ -4,7 +4,7 @@
       "ws_regional_dump_0_0"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_00", "regional_dump_var_12", "regional_dump_var_15", "regional_dump_var_03"],
+    "fg": ["regional_dump_var_00", "regional_dump_var_03", "regional_dump_var_15", "regional_dump_var_12"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -38,7 +38,7 @@
       "ws_regional_dump_1_0"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_01", "regional_dump_var_08", "regional_dump_var_14", "regional_dump_var_07"],
+    "fg": ["regional_dump_var_01", "regional_dump_var_07", "regional_dump_var_14", "regional_dump_var_08"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -72,7 +72,7 @@
       "ws_regional_dump_2_0"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_02", "regional_dump_var_04", "regional_dump_var_13", "regional_dump_var_11"],
+    "fg": ["regional_dump_var_02", "regional_dump_var_11", "regional_dump_var_13", "regional_dump_var_04"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -106,7 +106,7 @@
       "ws_regional_dump_3_0"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_03", "regional_dump_var_00", "regional_dump_var_12", "regional_dump_var_15"],
+    "fg": ["regional_dump_var_03", "regional_dump_var_15", "regional_dump_var_12", "regional_dump_var_00"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -144,7 +144,7 @@
       "ws_regional_dump_0_1"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_04", "regional_dump_var_13", "regional_dump_var_11", "regional_dump_var_02"],
+    "fg": ["regional_dump_var_04", "regional_dump_var_02", "regional_dump_var_11", "regional_dump_var_13"],
         "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -178,7 +178,7 @@
       "ws_regional_dump_1_1"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_05", "regional_dump_var_09", "regional_dump_var_10", "regional_dump_var_06"],
+    "fg": ["regional_dump_var_05", "regional_dump_var_06", "regional_dump_var_10", "regional_dump_var_09"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -212,7 +212,7 @@
       "ws_regional_dump_2_1"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_06", "regional_dump_var_05", "regional_dump_var_09", "regional_dump_var_10"],
+    "fg": ["regional_dump_var_06", "regional_dump_var_10", "regional_dump_var_09", "regional_dump_var_05"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -246,7 +246,7 @@
       "ws_regional_dump_3_1"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_07", "regional_dump_var_01", "regional_dump_var_08", "regional_dump_var_14"],
+    "fg": ["regional_dump_var_07", "regional_dump_var_14", "regional_dump_var_08", "regional_dump_var_01"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -284,7 +284,7 @@
       "ws_regional_dump_0_2"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_08", "regional_dump_var_14", "regional_dump_var_07", "regional_dump_var_01"],
+    "fg": ["regional_dump_var_08", "regional_dump_var_01", "regional_dump_var_07", "regional_dump_var_14"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -318,7 +318,7 @@
       "ws_regional_dump_1_2"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_09", "regional_dump_var_10", "regional_dump_var_06", "regional_dump_var_05"],
+    "fg": ["regional_dump_var_09", "regional_dump_var_05", "regional_dump_var_06", "regional_dump_var_10"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -352,7 +352,7 @@
       "ws_regional_dump_2_2"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_10", "regional_dump_var_06", "regional_dump_var_05", "regional_dump_var_09"],
+    "fg": ["regional_dump_var_10", "regional_dump_var_09", "regional_dump_var_05", "regional_dump_var_06"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -386,7 +386,7 @@
       "ws_regional_dump_3_2"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_11", "regional_dump_var_02", "regional_dump_var_04", "regional_dump_var_13"],
+    "fg": ["regional_dump_var_11", "regional_dump_var_13", "regional_dump_var_04", "regional_dump_var_02"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -424,7 +424,7 @@
       "ws_regional_dump_0_3"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_12", "regional_dump_var_15", "regional_dump_var_03", "regional_dump_var_00"],
+    "fg": ["regional_dump_var_12", "regional_dump_var_00", "regional_dump_var_03", "regional_dump_var_15"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -458,7 +458,7 @@
       "ws_regional_dump_1_3"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_13", "regional_dump_var_11", "regional_dump_var_02", "regional_dump_var_04"],
+    "fg": ["regional_dump_var_13", "regional_dump_var_04", "regional_dump_var_02", "regional_dump_var_11"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -492,7 +492,7 @@
       "ws_regional_dump_2_3"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_14", "regional_dump_var_07", "regional_dump_var_01", "regional_dump_var_08"],
+    "fg": ["regional_dump_var_14", "regional_dump_var_08", "regional_dump_var_01", "regional_dump_var_07"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -526,7 +526,7 @@
       "ws_regional_dump_3_3"
     ],
     "rotates": true,
-    "fg": ["regional_dump_var_15", "regional_dump_var_03", "regional_dump_var_00", "regional_dump_var_12"],
+    "fg": ["regional_dump_var_15", "regional_dump_var_12", "regional_dump_var_00", "regional_dump_var_03"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/4x4/stadium_baseball/stadium_baseball.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/4x4/stadium_baseball/stadium_baseball.json
@@ -6,7 +6,7 @@
       "stadium_0_1_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_00", "stadium_baseball_var_12", "stadium_baseball_var_15", "stadium_baseball_var_03"],
+    "fg": ["stadium_baseball_var_00", "stadium_baseball_var_03", "stadium_baseball_var_15", "stadium_baseball_var_12"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -42,7 +42,7 @@
       "stadium_1_1_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_01", "stadium_baseball_var_08", "stadium_baseball_var_14", "stadium_baseball_var_07"],
+    "fg": ["stadium_baseball_var_01", "stadium_baseball_var_07", "stadium_baseball_var_14", "stadium_baseball_var_08"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -78,7 +78,7 @@
       "stadium_2_1_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_02", "stadium_baseball_var_04", "stadium_baseball_var_13", "stadium_baseball_var_11"],
+    "fg": ["stadium_baseball_var_02", "stadium_baseball_var_11", "stadium_baseball_var_13", "stadium_baseball_var_04"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -114,7 +114,7 @@
       "stadium_3_1_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_03", "stadium_baseball_var_00", "stadium_baseball_var_12", "stadium_baseball_var_15"],
+    "fg": ["stadium_baseball_var_03", "stadium_baseball_var_15", "stadium_baseball_var_12", "stadium_baseball_var_00"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -154,7 +154,7 @@
       "stadium_0_2_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_04", "stadium_baseball_var_13", "stadium_baseball_var_11", "stadium_baseball_var_02"],
+    "fg": ["stadium_baseball_var_04", "stadium_baseball_var_02", "stadium_baseball_var_11", "stadium_baseball_var_13"],
         "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -190,7 +190,7 @@
       "stadium_1_2_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_05", "stadium_baseball_var_09", "stadium_baseball_var_10", "stadium_baseball_var_06"],
+    "fg": ["stadium_baseball_var_05", "stadium_baseball_var_06", "stadium_baseball_var_10", "stadium_baseball_var_09"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -226,7 +226,7 @@
       "stadium_2_2_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_06", "stadium_baseball_var_05", "stadium_baseball_var_09", "stadium_baseball_var_10"],
+    "fg": ["stadium_baseball_var_06", "stadium_baseball_var_10", "stadium_baseball_var_09", "stadium_baseball_var_05"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -262,7 +262,7 @@
       "stadium_3_2_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_07", "stadium_baseball_var_01", "stadium_baseball_var_08", "stadium_baseball_var_14"],
+    "fg": ["stadium_baseball_var_07", "stadium_baseball_var_14", "stadium_baseball_var_08", "stadium_baseball_var_01"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -302,7 +302,7 @@
       "stadium_0_3_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_08", "stadium_baseball_var_14", "stadium_baseball_var_07", "stadium_baseball_var_01"],
+    "fg": ["stadium_baseball_var_08", "stadium_baseball_var_01", "stadium_baseball_var_07", "stadium_baseball_var_14"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -338,7 +338,7 @@
       "stadium_1_3_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_09", "stadium_baseball_var_10", "stadium_baseball_var_06", "stadium_baseball_var_05"],
+    "fg": ["stadium_baseball_var_09", "stadium_baseball_var_05", "stadium_baseball_var_06", "stadium_baseball_var_10"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -374,7 +374,7 @@
       "stadium_2_3_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_10", "stadium_baseball_var_06", "stadium_baseball_var_05", "stadium_baseball_var_09"],
+    "fg": ["stadium_baseball_var_10", "stadium_baseball_var_09", "stadium_baseball_var_05", "stadium_baseball_var_06"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -410,7 +410,7 @@
       "stadium_3_3_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_11", "stadium_baseball_var_02", "stadium_baseball_var_04", "stadium_baseball_var_13"],
+    "fg": ["stadium_baseball_var_11", "stadium_baseball_var_13", "stadium_baseball_var_04", "stadium_baseball_var_02"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -450,7 +450,7 @@
       "stadium_0_4_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_12", "stadium_baseball_var_15", "stadium_baseball_var_03", "stadium_baseball_var_00"],
+    "fg": ["stadium_baseball_var_12", "stadium_baseball_var_00", "stadium_baseball_var_03", "stadium_baseball_var_15"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -486,7 +486,7 @@
       "stadium_1_4_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_13", "stadium_baseball_var_11", "stadium_baseball_var_02", "stadium_baseball_var_04"],
+    "fg": ["stadium_baseball_var_13", "stadium_baseball_var_04", "stadium_baseball_var_02", "stadium_baseball_var_11"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -522,7 +522,7 @@
       "stadium_2_4_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_14", "stadium_baseball_var_07", "stadium_baseball_var_01", "stadium_baseball_var_08"],
+    "fg": ["stadium_baseball_var_14", "stadium_baseball_var_08", "stadium_baseball_var_01", "stadium_baseball_var_07"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -558,7 +558,7 @@
       "stadium_3_4_2"
     ],
     "rotates": true,
-    "fg": ["stadium_baseball_var_15", "stadium_baseball_var_03", "stadium_baseball_var_00", "stadium_baseball_var_12"],
+    "fg": ["stadium_baseball_var_15", "stadium_baseball_var_12", "stadium_baseball_var_00", "stadium_baseball_var_03"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/4x4/stadium_baseball/stadium_baseball_parking.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/4x4/stadium_baseball/stadium_baseball_parking.json
@@ -6,7 +6,7 @@
     ],
     "rotates": true,
     "fg": [
-      "stadium_baseball_parking_var_01", "stadium_baseball_parking_var_03", "stadium_baseball_parking_var_02", "stadium_baseball_parking_var_00"
+      "stadium_baseball_parking_var_01", "stadium_baseball_parking_var_00", "stadium_baseball_parking_var_02", "stadium_baseball_parking_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -43,7 +43,7 @@
     ],
     "rotates": true,
     "fg": [
-      "stadium_baseball_parking_var_02", "stadium_baseball_parking_var_00", "stadium_baseball_parking_var_01", "stadium_baseball_parking_var_03"
+      "stadium_baseball_parking_var_02", "stadium_baseball_parking_var_03", "stadium_baseball_parking_var_01", "stadium_baseball_parking_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/common_terrain/river/bridge.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/common_terrain/river/bridge.json
@@ -5,11 +5,11 @@
       "bridgehead_ramp"
     ],
     "fg": [
-      { "weight": 1, "sprite": [ "bridge_v1_end_piece_n", "bridge_v1_end_piece_w", "bridge_v1_end_piece_s", "bridge_v1_end_piece_e" ] },
-      { "weight": 1, "sprite": [ "bridge_v2_end_piece_n", "bridge_v2_end_piece_w", "bridge_v2_end_piece_s", "bridge_v2_end_piece_e" ] },
-      { "weight": 1, "sprite": [ "bridge_v3_end_piece_n", "bridge_v3_end_piece_w", "bridge_v3_end_piece_s", "bridge_v3_end_piece_e" ] },
-      { "weight": 1, "sprite": [ "bridge_v4_end_piece_n", "bridge_v4_end_piece_w", "bridge_v4_end_piece_s", "bridge_v4_end_piece_e" ] },
-      { "weight": 1, "sprite": [ "bridge_v5_end_piece_n", "bridge_v5_end_piece_w", "bridge_v5_end_piece_s", "bridge_v5_end_piece_e" ] }
+      { "weight": 1, "sprite": [ "bridge_v1_end_piece_n", "bridge_v1_end_piece_e", "bridge_v1_end_piece_s", "bridge_v1_end_piece_w" ] },
+      { "weight": 1, "sprite": [ "bridge_v2_end_piece_n", "bridge_v2_end_piece_e", "bridge_v2_end_piece_s", "bridge_v2_end_piece_w" ] },
+      { "weight": 1, "sprite": [ "bridge_v3_end_piece_n", "bridge_v3_end_piece_e", "bridge_v3_end_piece_s", "bridge_v3_end_piece_w" ] },
+      { "weight": 1, "sprite": [ "bridge_v4_end_piece_n", "bridge_v4_end_piece_e", "bridge_v4_end_piece_s", "bridge_v4_end_piece_w" ] },
+      { "weight": 1, "sprite": [ "bridge_v5_end_piece_n", "bridge_v5_end_piece_e", "bridge_v5_end_piece_s", "bridge_v5_end_piece_w" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/common_terrain/river/river.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/common_terrain/river/river.json
@@ -303,11 +303,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "river_v1_t_connection_n", "river_v1_t_connection_w", "river_v1_t_connection_s", "river_v1_t_connection_e" ] },
-      { "weight": 1, "sprite": [ "river_v2_t_connection_n", "river_v2_t_connection_w", "river_v2_t_connection_s", "river_v2_t_connection_e" ] },
-      { "weight": 1, "sprite": [ "river_v3_t_connection_n", "river_v3_t_connection_w", "river_v3_t_connection_s", "river_v3_t_connection_e" ] },
-      { "weight": 1, "sprite": [ "river_v4_t_connection_n", "river_v4_t_connection_w", "river_v4_t_connection_s", "river_v4_t_connection_e" ] },
-      { "weight": 1, "sprite": [ "river_v5_t_connection_n", "river_v5_t_connection_w", "river_v5_t_connection_s", "river_v5_t_connection_e" ] }
+      { "weight": 1, "sprite": [ "river_v1_t_connection_n", "river_v1_t_connection_e", "river_v1_t_connection_s", "river_v1_t_connection_w" ] },
+      { "weight": 1, "sprite": [ "river_v2_t_connection_n", "river_v2_t_connection_e", "river_v2_t_connection_s", "river_v2_t_connection_w" ] },
+      { "weight": 1, "sprite": [ "river_v3_t_connection_n", "river_v3_t_connection_e", "river_v3_t_connection_s", "river_v3_t_connection_w" ] },
+      { "weight": 1, "sprite": [ "river_v4_t_connection_n", "river_v4_t_connection_e", "river_v4_t_connection_s", "river_v4_t_connection_w" ] },
+      { "weight": 1, "sprite": [ "river_v5_t_connection_n", "river_v5_t_connection_e", "river_v5_t_connection_s", "river_v5_t_connection_w" ] }
     ],
   "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/common_terrain/roads/roads_trailer.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/common_terrain/roads/roads_trailer.json
@@ -126,11 +126,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "road_v1_t_connection_n", "road_v1_t_connection_w", "road_v1_t_connection_s", "road_v1_t_connection_e" ] },
-      { "weight": 1, "sprite": [ "road_v2_t_connection_n", "road_v2_t_connection_w", "road_v2_t_connection_s", "road_v2_t_connection_e" ] },
-      { "weight": 1, "sprite": [ "road_v3_t_connection_n", "road_v3_t_connection_w", "road_v3_t_connection_s", "road_v3_t_connection_e" ] },
-      { "weight": 1, "sprite": [ "road_v4_t_connection_n", "road_v4_t_connection_w", "road_v4_t_connection_s", "road_v4_t_connection_e" ] },
-      { "weight": 1, "sprite": [ "road_v5_t_connection_n", "road_v5_t_connection_w", "road_v5_t_connection_s", "road_v5_t_connection_e" ] }
+      { "weight": 1, "sprite": [ "road_v1_t_connection_n", "road_v1_t_connection_e", "road_v1_t_connection_s", "road_v1_t_connection_w" ] },
+      { "weight": 1, "sprite": [ "road_v2_t_connection_n", "road_v2_t_connection_e", "road_v2_t_connection_s", "road_v2_t_connection_w" ] },
+      { "weight": 1, "sprite": [ "road_v3_t_connection_n", "road_v3_t_connection_e", "road_v3_t_connection_s", "road_v3_t_connection_w" ] },
+      { "weight": 1, "sprite": [ "road_v4_t_connection_n", "road_v4_t_connection_e", "road_v4_t_connection_s", "road_v4_t_connection_w" ] },
+      { "weight": 1, "sprite": [ "road_v5_t_connection_n", "road_v5_t_connection_e", "road_v5_t_connection_s", "road_v5_t_connection_w" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -166,11 +166,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "road_v1_corner_ne", "road_v1_corner_nw", "road_v1_corner_sw", "road_v1_corner_se" ] },
-      { "weight": 1, "sprite": [ "road_v2_corner_ne", "road_v2_corner_nw", "road_v2_corner_sw", "road_v2_corner_se" ] },
-      { "weight": 1, "sprite": [ "road_v3_corner_ne", "road_v3_corner_nw", "road_v3_corner_sw", "road_v3_corner_se" ] },
-      { "weight": 1, "sprite": [ "road_v4_corner_ne", "road_v4_corner_nw", "road_v4_corner_sw", "road_v4_corner_se" ] },
-      { "weight": 1, "sprite": [ "road_v5_corner_ne", "road_v5_corner_nw", "road_v5_corner_sw", "road_v5_corner_se" ] }
+      { "weight": 1, "sprite": [ "road_v1_corner_ne", "road_v1_corner_se", "road_v1_corner_sw", "road_v1_corner_nw" ] },
+      { "weight": 1, "sprite": [ "road_v2_corner_ne", "road_v2_corner_se", "road_v2_corner_sw", "road_v2_corner_nw" ] },
+      { "weight": 1, "sprite": [ "road_v3_corner_ne", "road_v3_corner_se", "road_v3_corner_sw", "road_v3_corner_nw" ] },
+      { "weight": 1, "sprite": [ "road_v4_corner_ne", "road_v4_corner_se", "road_v4_corner_sw", "road_v4_corner_nw" ] },
+      { "weight": 1, "sprite": [ "road_v5_corner_ne", "road_v5_corner_se", "road_v5_corner_sw", "road_v5_corner_nw" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/common_terrain/stream/stream.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/common_terrain/stream/stream.json
@@ -76,11 +76,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "stream_v1_corner_se", "stream_v1_corner_ne", "stream_v1_corner_nw", "stream_v1_corner_sw" ] },
-      { "weight": 1, "sprite": [ "stream_v2_corner_se", "stream_v2_corner_ne", "stream_v2_corner_nw", "stream_v2_corner_sw" ] },
-      { "weight": 1, "sprite": [ "stream_v3_corner_se", "stream_v3_corner_ne", "stream_v3_corner_nw", "stream_v3_corner_sw" ] },
-      { "weight": 1, "sprite": [ "stream_v4_corner_se", "stream_v4_corner_ne", "stream_v4_corner_nw", "stream_v4_corner_sw" ] },
-      { "weight": 1, "sprite": [ "stream_v5_corner_se", "stream_v5_corner_ne", "stream_v5_corner_nw", "stream_v5_corner_sw" ] }
+      { "weight": 1, "sprite": [ "stream_v1_corner_se", "stream_v1_corner_sw", "stream_v1_corner_nw", "stream_v1_corner_ne" ] },
+      { "weight": 1, "sprite": [ "stream_v2_corner_se", "stream_v2_corner_sw", "stream_v2_corner_nw", "stream_v2_corner_ne" ] },
+      { "weight": 1, "sprite": [ "stream_v3_corner_se", "stream_v3_corner_sw", "stream_v3_corner_nw", "stream_v3_corner_ne" ] },
+      { "weight": 1, "sprite": [ "stream_v4_corner_se", "stream_v4_corner_sw", "stream_v4_corner_nw", "stream_v4_corner_ne" ] },
+      { "weight": 1, "sprite": [ "stream_v5_corner_se", "stream_v5_corner_sw", "stream_v5_corner_nw", "stream_v5_corner_ne" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/irregular/airliner/airliner_debris.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/irregular/airliner/airliner_debris.json
@@ -50,7 +50,7 @@
     ],
     "rotates": true,
     "fg": [
-      "airliner_var_01", "airliner_var_03", "airliner_var_07", "airliner_var_05"
+      "airliner_var_01", "airliner_var_05", "airliner_var_07", "airliner_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -86,7 +86,7 @@
     ],
     "rotates": true,
     "fg": [
-      "airliner_var_02", "airliner_var_00", "airliner_var_06", "airliner_var_08"
+      "airliner_var_02", "airliner_var_08", "airliner_var_06", "airliner_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -126,7 +126,7 @@
     ],
     "rotates": true,
     "fg": [
-      "airliner_var_03", "airliner_var_07", "airliner_var_05", "airliner_var_01"
+      "airliner_var_03", "airliner_var_01", "airliner_var_05", "airliner_var_07"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -198,7 +198,7 @@
     ],
     "rotates": true,
     "fg": [
-      "airliner_var_05", "airliner_var_01", "airliner_var_03", "airliner_var_07"
+      "airliner_var_05", "airliner_var_07", "airliner_var_03", "airliner_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -238,7 +238,7 @@
     ],
     "rotates": true,
     "fg": [
-      "airliner_var_06", "airliner_var_08", "airliner_var_02", "airliner_var_00"
+      "airliner_var_06", "airliner_var_00", "airliner_var_02", "airliner_var_08"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -274,7 +274,7 @@
     ],
     "rotates": true,
     "fg": [
-      "airliner_var_07", "airliner_var_05", "airliner_var_01", "airliner_var_03"
+      "airliner_var_07", "airliner_var_03", "airliner_var_01", "airliner_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -310,7 +310,7 @@
     ],
     "rotates": true,
     "fg": [
-      "airliner_var_08", "airliner_var_02", "airliner_var_00", "airliner_var_06"
+      "airliner_var_08", "airliner_var_06", "airliner_var_00", "airliner_var_02"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/irregular/airport_small/airport_small.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/irregular/airport_small/airport_small.json
@@ -40,7 +40,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking2x1_var_01", "parking2x1_var_03", "parking2x1_var_02", "parking2x1_var_00"
+      "parking2x1_var_01", "parking2x1_var_00", "parking2x1_var_02", "parking2x1_var_03"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -76,7 +76,7 @@
     ],
     "rotates": true,
     "fg": [
-      "parking2x1_var_02", "parking2x1_var_00", "parking2x1_var_01", "parking2x1_var_03"
+      "parking2x1_var_02", "parking2x1_var_03", "parking2x1_var_01", "parking2x1_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/irregular/refugee_center/evac_center.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/irregular/refugee_center/evac_center.json
@@ -2,7 +2,7 @@
   {
     "id": "evac_center_1",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_00", "rfgctr_evac_var_20", "rfgctr_evac_var_24", "rfgctr_evac_var_04"],
+    "fg": ["rfgctr_evac_var_00", "rfgctr_evac_var_04", "rfgctr_evac_var_24", "rfgctr_evac_var_20"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -34,7 +34,7 @@
   {
     "id": "evac_center_2",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_01", "rfgctr_evac_var_15", "rfgctr_evac_var_23", "rfgctr_evac_var_09"],
+    "fg": ["rfgctr_evac_var_01", "rfgctr_evac_var_09", "rfgctr_evac_var_23", "rfgctr_evac_var_15"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -66,7 +66,7 @@
   {
     "id": "evac_center_3",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_02", "rfgctr_evac_var_10", "rfgctr_evac_var_22", "rfgctr_evac_var_14"],
+    "fg": ["rfgctr_evac_var_02", "rfgctr_evac_var_14", "rfgctr_evac_var_22", "rfgctr_evac_var_10"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -98,7 +98,7 @@
   {
     "id": "evac_center_4",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_03", "rfgctr_evac_var_05", "rfgctr_evac_var_21", "rfgctr_evac_var_19"],
+    "fg": ["rfgctr_evac_var_03", "rfgctr_evac_var_19", "rfgctr_evac_var_21", "rfgctr_evac_var_05"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -130,7 +130,7 @@
   {
     "id": "evac_center_5",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_04", "rfgctr_evac_var_00", "rfgctr_evac_var_20", "rfgctr_evac_var_24"],
+    "fg": ["rfgctr_evac_var_04", "rfgctr_evac_var_24", "rfgctr_evac_var_20", "rfgctr_evac_var_00"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -166,7 +166,7 @@
   {
     "id": "evac_center_6",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_05", "rfgctr_evac_var_21", "rfgctr_evac_var_19", "rfgctr_evac_var_03"],
+    "fg": ["rfgctr_evac_var_05", "rfgctr_evac_var_03", "rfgctr_evac_var_19", "rfgctr_evac_var_21"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -198,7 +198,7 @@
   {
     "id": "evac_center_7",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_06", "rfgctr_evac_var_16", "rfgctr_evac_var_18", "rfgctr_evac_var_08"],
+    "fg": ["rfgctr_evac_var_06", "rfgctr_evac_var_08", "rfgctr_evac_var_18", "rfgctr_evac_var_16"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -230,7 +230,7 @@
   {
     "id": "evac_center_8",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_07", "rfgctr_evac_var_11", "rfgctr_evac_var_17", "rfgctr_evac_var_13"],
+    "fg": ["rfgctr_evac_var_07", "rfgctr_evac_var_13", "rfgctr_evac_var_17", "rfgctr_evac_var_11"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -262,7 +262,7 @@
   {
     "id": "evac_center_9",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_08", "rfgctr_evac_var_06", "rfgctr_evac_var_16", "rfgctr_evac_var_18"],
+    "fg": ["rfgctr_evac_var_08", "rfgctr_evac_var_18", "rfgctr_evac_var_16", "rfgctr_evac_var_06"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -294,7 +294,7 @@
   {
     "id": "evac_center_10",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_09", "rfgctr_evac_var_01", "rfgctr_evac_var_15", "rfgctr_evac_var_23"],
+    "fg": ["rfgctr_evac_var_09", "rfgctr_evac_var_23", "rfgctr_evac_var_15", "rfgctr_evac_var_01"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -330,7 +330,7 @@
   {
     "id": "evac_center_11",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_10", "rfgctr_evac_var_22", "rfgctr_evac_var_14", "rfgctr_evac_var_02"],
+    "fg": ["rfgctr_evac_var_10", "rfgctr_evac_var_02", "rfgctr_evac_var_14", "rfgctr_evac_var_22"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -362,7 +362,7 @@
   {
     "id": "evac_center_12",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_11", "rfgctr_evac_var_17", "rfgctr_evac_var_13", "rfgctr_evac_var_07"],
+    "fg": ["rfgctr_evac_var_11", "rfgctr_evac_var_07", "rfgctr_evac_var_13", "rfgctr_evac_var_17"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -426,7 +426,7 @@
   {
     "id": "evac_center_14",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_13", "rfgctr_evac_var_07", "rfgctr_evac_var_11", "rfgctr_evac_var_17"],
+    "fg": ["rfgctr_evac_var_13", "rfgctr_evac_var_17", "rfgctr_evac_var_11", "rfgctr_evac_var_07"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -458,7 +458,7 @@
   {
     "id": "evac_center_15",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_14", "rfgctr_evac_var_02", "rfgctr_evac_var_10", "rfgctr_evac_var_22"],
+    "fg": ["rfgctr_evac_var_14", "rfgctr_evac_var_22", "rfgctr_evac_var_10", "rfgctr_evac_var_02"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -494,7 +494,7 @@
   {
     "id": "evac_center_16",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_15", "rfgctr_evac_var_23", "rfgctr_evac_var_09", "rfgctr_evac_var_01"],
+    "fg": ["rfgctr_evac_var_15", "rfgctr_evac_var_01", "rfgctr_evac_var_09", "rfgctr_evac_var_23"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -526,7 +526,7 @@
   {
     "id": "evac_center_17",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_16", "rfgctr_evac_var_18", "rfgctr_evac_var_08", "rfgctr_evac_var_06"],
+    "fg": ["rfgctr_evac_var_16", "rfgctr_evac_var_06", "rfgctr_evac_var_08", "rfgctr_evac_var_18"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -558,7 +558,7 @@
   {
     "id": "evac_center_18",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_17", "rfgctr_evac_var_13", "rfgctr_evac_var_07", "rfgctr_evac_var_11"],
+    "fg": ["rfgctr_evac_var_17", "rfgctr_evac_var_11", "rfgctr_evac_var_07", "rfgctr_evac_var_13"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -590,7 +590,7 @@
   {
     "id": "evac_center_19",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_18", "rfgctr_evac_var_08", "rfgctr_evac_var_06", "rfgctr_evac_var_16"],
+    "fg": ["rfgctr_evac_var_18", "rfgctr_evac_var_16", "rfgctr_evac_var_06", "rfgctr_evac_var_08"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -622,7 +622,7 @@
   {
     "id": "evac_center_20",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_19", "rfgctr_evac_var_03", "rfgctr_evac_var_05", "rfgctr_evac_var_21"],
+    "fg": ["rfgctr_evac_var_19", "rfgctr_evac_var_21", "rfgctr_evac_var_05", "rfgctr_evac_var_03"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -658,7 +658,7 @@
   {
     "id": "evac_center_21",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_20", "rfgctr_evac_var_24", "rfgctr_evac_var_04", "rfgctr_evac_var_00"],
+    "fg": ["rfgctr_evac_var_20", "rfgctr_evac_var_00", "rfgctr_evac_var_04", "rfgctr_evac_var_24"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -690,7 +690,7 @@
   {
     "id": "evac_center_22",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_21", "rfgctr_evac_var_19", "rfgctr_evac_var_03", "rfgctr_evac_var_05"],
+    "fg": ["rfgctr_evac_var_21", "rfgctr_evac_var_05", "rfgctr_evac_var_03", "rfgctr_evac_var_19"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -722,7 +722,7 @@
   {
     "id": "evac_center_23",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_22", "rfgctr_evac_var_14", "rfgctr_evac_var_02", "rfgctr_evac_var_10"],
+    "fg": ["rfgctr_evac_var_22", "rfgctr_evac_var_10", "rfgctr_evac_var_02", "rfgctr_evac_var_14"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -754,7 +754,7 @@
   {
     "id": "evac_center_24",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_23", "rfgctr_evac_var_09", "rfgctr_evac_var_01", "rfgctr_evac_var_15"],
+    "fg": ["rfgctr_evac_var_23", "rfgctr_evac_var_15", "rfgctr_evac_var_01", "rfgctr_evac_var_09"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -786,7 +786,7 @@
   {
     "id": "evac_center_25",
     "rotates": true,
-    "fg": ["rfgctr_evac_var_24", "rfgctr_evac_var_04", "rfgctr_evac_var_00", "rfgctr_evac_var_20"],
+    "fg": ["rfgctr_evac_var_24", "rfgctr_evac_var_20", "rfgctr_evac_var_00", "rfgctr_evac_var_04"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/irregular/refugee_center/refugee_center.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/irregular/refugee_center/refugee_center.json
@@ -139,7 +139,7 @@
     ],
     "rotates": true,
     "fg": [
-      "rfgctr_fence_var_06", "rfgctr_fence_var_01", "rfgctr_fence_var_00", "rfgctr_fence_var_05"
+      "rfgctr_fence_var_06", "rfgctr_fence_var_05", "rfgctr_fence_var_00", "rfgctr_fence_var_01"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -175,7 +175,7 @@
     ],
     "rotates": true,
     "fg": [
-      "rfgctr_fence_var_05", "rfgctr_fence_var_06", "rfgctr_fence_var_01", "rfgctr_fence_var_00"
+      "rfgctr_fence_var_05", "rfgctr_fence_var_00", "rfgctr_fence_var_01", "rfgctr_fence_var_06"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -211,7 +211,7 @@
     ],
     "rotates": true,
     "fg": [
-      "rfgctr_fence_var_01", "rfgctr_fence_var_00", "rfgctr_fence_var_05", "rfgctr_fence_var_06"
+      "rfgctr_fence_var_01", "rfgctr_fence_var_06", "rfgctr_fence_var_05", "rfgctr_fence_var_00"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -247,7 +247,7 @@
     ],
     "rotates": true,
     "fg": [
-      "rfgctr_fence_var_00", "rfgctr_fence_var_05", "rfgctr_fence_var_06", "rfgctr_fence_var_01"
+      "rfgctr_fence_var_00", "rfgctr_fence_var_01", "rfgctr_fence_var_06", "rfgctr_fence_var_05"
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/irregular/retirement_community.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/irregular/retirement_community.json
@@ -178,23 +178,23 @@
     "fg": [
       {
         "weight": 1,
-        "sprite": [ "sewers_v1_corner_ne", "sewers_v1_corner_nw", "sewers_v1_corner_sw", "sewers_v1_corner_se"  ]
+        "sprite": [ "sewers_v1_corner_ne", "sewers_v1_corner_se", "sewers_v1_corner_sw", "sewers_v1_corner_nw"  ]
       },
       {
         "weight": 1,
-        "sprite": [ "sewers_v2_corner_ne", "sewers_v2_corner_nw", "sewers_v2_corner_sw", "sewers_v2_corner_se"  ]
+        "sprite": [ "sewers_v2_corner_ne", "sewers_v2_corner_se", "sewers_v2_corner_sw", "sewers_v2_corner_nw"  ]
       },
       {
         "weight": 1,
-        "sprite": [ "sewers_v3_corner_ne", "sewers_v3_corner_nw", "sewers_v3_corner_sw", "sewers_v3_corner_se"  ]
+        "sprite": [ "sewers_v3_corner_ne", "sewers_v3_corner_se", "sewers_v3_corner_sw", "sewers_v3_corner_nw"  ]
       },
       {
         "weight": 1,
-        "sprite": [ "sewers_v4_corner_ne", "sewers_v4_corner_nw", "sewers_v4_corner_sw", "sewers_v4_corner_se"  ]
+        "sprite": [ "sewers_v4_corner_ne", "sewers_v4_corner_se", "sewers_v4_corner_sw", "sewers_v4_corner_nw"  ]
       },
       {
         "weight": 1,
-        "sprite": [ "sewers_v5_corner_ne", "sewers_v5_corner_nw", "sewers_v5_corner_sw", "sewers_v5_corner_se"  ]
+        "sprite": [ "sewers_v5_corner_ne", "sewers_v5_corner_se", "sewers_v5_corner_sw", "sewers_v5_corner_nw"  ]
       }
     ],
     "bg": [
@@ -535,23 +535,23 @@
     "fg": [
       {
         "weight": 1,
-        "sprite": [ "road_v1_t_connection_n", "road_v1_t_connection_w", "road_v1_t_connection_s", "road_v1_t_connection_e" ]
+        "sprite": [ "road_v1_t_connection_n", "road_v1_t_connection_e", "road_v1_t_connection_s", "road_v1_t_connection_w" ]
       },
       {
         "weight": 1,
-        "sprite": [ "road_v2_t_connection_n", "road_v2_t_connection_w", "road_v2_t_connection_s", "road_v2_t_connection_e" ]
+        "sprite": [ "road_v2_t_connection_n", "road_v2_t_connection_e", "road_v2_t_connection_s", "road_v2_t_connection_w" ]
       },
       {
         "weight": 1,
-        "sprite": [ "road_v3_t_connection_n", "road_v3_t_connection_w", "road_v3_t_connection_s", "road_v3_t_connection_e" ]
+        "sprite": [ "road_v3_t_connection_n", "road_v3_t_connection_e", "road_v3_t_connection_s", "road_v3_t_connection_w" ]
       },
       {
         "weight": 1,
-        "sprite": [ "road_v4_t_connection_n", "road_v4_t_connection_w", "road_v4_t_connection_s", "road_v4_t_connection_e" ]
+        "sprite": [ "road_v4_t_connection_n", "road_v4_t_connection_e", "road_v4_t_connection_s", "road_v4_t_connection_w" ]
       },
       {
         "weight": 1,
-        "sprite": [ "road_v5_t_connection_n", "road_v5_t_connection_w", "road_v5_t_connection_s", "road_v5_t_connection_e" ]
+        "sprite": [ "road_v5_t_connection_n", "road_v5_t_connection_e", "road_v5_t_connection_s", "road_v5_t_connection_w" ]
       }
     ],
     "bg": [
@@ -591,23 +591,23 @@
     "fg": [
       {
         "weight": 1,
-        "sprite": [ "road_v1_t_connection_s", "road_v1_t_connection_e", "road_v1_t_connection_n", "road_v1_t_connection_w" ]
+        "sprite": [ "road_v1_t_connection_s", "road_v1_t_connection_w", "road_v1_t_connection_n", "road_v1_t_connection_e" ]
       },
       {
         "weight": 1,
-        "sprite": [ "road_v2_t_connection_s", "road_v2_t_connection_e", "road_v2_t_connection_n", "road_v2_t_connection_w" ]
+        "sprite": [ "road_v2_t_connection_s", "road_v2_t_connection_w", "road_v2_t_connection_n", "road_v2_t_connection_e" ]
       },
       {
         "weight": 1,
-        "sprite": [ "road_v3_t_connection_s", "road_v3_t_connection_e", "road_v3_t_connection_n", "road_v3_t_connection_w" ]
+        "sprite": [ "road_v3_t_connection_s", "road_v3_t_connection_w", "road_v3_t_connection_n", "road_v3_t_connection_e" ]
       },
       {
         "weight": 1,
-        "sprite": [ "road_v4_t_connection_s", "road_v4_t_connection_e", "road_v4_t_connection_n", "road_v4_t_connection_w" ]
+        "sprite": [ "road_v4_t_connection_s", "road_v4_t_connection_w", "road_v4_t_connection_n", "road_v4_t_connection_e" ]
       },
       {
         "weight": 1,
-        "sprite": [ "road_v5_t_connection_s", "road_v5_t_connection_e", "road_v5_t_connection_n", "road_v5_t_connection_w" ]
+        "sprite": [ "road_v5_t_connection_s", "road_v5_t_connection_w", "road_v5_t_connection_n", "road_v5_t_connection_e" ]
       }
     ],
     "bg": [

--- a/gfx/PenAndPaper/pngs_overmap_48x48/irregular/speedway/speedway_parking_lot.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/irregular/speedway/speedway_parking_lot.json
@@ -40,11 +40,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "dirt_v1_corner_nw", "dirt_v1_corner_sw", "dirt_v1_corner_se", "dirt_v1_corner_ne" ] },
-      { "weight": 1, "sprite": [ "dirt_v2_corner_nw", "dirt_v2_corner_sw", "dirt_v2_corner_se", "dirt_v2_corner_ne" ] },
-      { "weight": 1, "sprite": [ "dirt_v3_corner_nw", "dirt_v3_corner_sw", "dirt_v3_corner_se", "dirt_v3_corner_ne" ] },
-      { "weight": 1, "sprite": [ "dirt_v4_corner_nw", "dirt_v4_corner_sw", "dirt_v4_corner_se", "dirt_v4_corner_ne" ] },
-      { "weight": 1, "sprite": [ "dirt_v5_corner_nw", "dirt_v5_corner_sw", "dirt_v5_corner_se", "dirt_v5_corner_ne" ] }
+      { "weight": 1, "sprite": [ "dirt_v1_corner_nw", "dirt_v1_corner_ne", "dirt_v1_corner_se", "dirt_v1_corner_sw" ] },
+      { "weight": 1, "sprite": [ "dirt_v2_corner_nw", "dirt_v2_corner_ne", "dirt_v2_corner_se", "dirt_v2_corner_sw" ] },
+      { "weight": 1, "sprite": [ "dirt_v3_corner_nw", "dirt_v3_corner_ne", "dirt_v3_corner_se", "dirt_v3_corner_sw" ] },
+      { "weight": 1, "sprite": [ "dirt_v4_corner_nw", "dirt_v4_corner_ne", "dirt_v4_corner_se", "dirt_v4_corner_sw" ] },
+      { "weight": 1, "sprite": [ "dirt_v5_corner_nw", "dirt_v5_corner_ne", "dirt_v5_corner_se", "dirt_v5_corner_sw" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -83,11 +83,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "dirt_v1_corner_sw", "dirt_v1_corner_se", "dirt_v1_corner_ne", "dirt_v1_corner_nw" ] },
-      { "weight": 1, "sprite": [ "dirt_v2_corner_sw", "dirt_v2_corner_se", "dirt_v2_corner_ne", "dirt_v2_corner_nw" ] },
-      { "weight": 1, "sprite": [ "dirt_v3_corner_sw", "dirt_v3_corner_se", "dirt_v3_corner_ne", "dirt_v3_corner_nw" ] },
-      { "weight": 1, "sprite": [ "dirt_v4_corner_sw", "dirt_v4_corner_se", "dirt_v4_corner_ne", "dirt_v4_corner_nw" ] },
-      { "weight": 1, "sprite": [ "dirt_v5_corner_sw", "dirt_v5_corner_se", "dirt_v5_corner_ne", "dirt_v5_corner_nw" ] }
+      { "weight": 1, "sprite": [ "dirt_v1_corner_sw", "dirt_v1_corner_nw", "dirt_v1_corner_ne", "dirt_v1_corner_se" ] },
+      { "weight": 1, "sprite": [ "dirt_v2_corner_sw", "dirt_v2_corner_nw", "dirt_v2_corner_ne", "dirt_v2_corner_se" ] },
+      { "weight": 1, "sprite": [ "dirt_v3_corner_sw", "dirt_v3_corner_nw", "dirt_v3_corner_ne", "dirt_v3_corner_se" ] },
+      { "weight": 1, "sprite": [ "dirt_v4_corner_sw", "dirt_v4_corner_nw", "dirt_v4_corner_ne", "dirt_v4_corner_se" ] },
+      { "weight": 1, "sprite": [ "dirt_v5_corner_sw", "dirt_v5_corner_nw", "dirt_v5_corner_ne", "dirt_v5_corner_se" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -126,11 +126,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "dirt_v1_corner_se", "dirt_v1_corner_ne", "dirt_v1_corner_nw", "dirt_v1_corner_sw" ] },
-      { "weight": 1, "sprite": [ "dirt_v2_corner_se", "dirt_v2_corner_ne", "dirt_v2_corner_nw", "dirt_v2_corner_sw" ] },
-      { "weight": 1, "sprite": [ "dirt_v3_corner_se", "dirt_v3_corner_ne", "dirt_v3_corner_nw", "dirt_v3_corner_sw" ] },
-      { "weight": 1, "sprite": [ "dirt_v4_corner_se", "dirt_v4_corner_ne", "dirt_v4_corner_nw", "dirt_v4_corner_sw" ] },
-      { "weight": 1, "sprite": [ "dirt_v5_corner_se", "dirt_v5_corner_ne", "dirt_v5_corner_nw", "dirt_v5_corner_sw" ] }
+      { "weight": 1, "sprite": [ "dirt_v1_corner_se", "dirt_v1_corner_sw", "dirt_v1_corner_nw", "dirt_v1_corner_ne" ] },
+      { "weight": 1, "sprite": [ "dirt_v2_corner_se", "dirt_v2_corner_sw", "dirt_v2_corner_nw", "dirt_v2_corner_ne" ] },
+      { "weight": 1, "sprite": [ "dirt_v3_corner_se", "dirt_v3_corner_sw", "dirt_v3_corner_nw", "dirt_v3_corner_ne" ] },
+      { "weight": 1, "sprite": [ "dirt_v4_corner_se", "dirt_v4_corner_sw", "dirt_v4_corner_nw", "dirt_v4_corner_ne" ] },
+      { "weight": 1, "sprite": [ "dirt_v5_corner_se", "dirt_v5_corner_sw", "dirt_v5_corner_nw", "dirt_v5_corner_ne" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -169,11 +169,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "dirt_v1_corner_ne", "dirt_v1_corner_nw", "dirt_v1_corner_sw", "dirt_v1_corner_se" ] },
-      { "weight": 1, "sprite": [ "dirt_v2_corner_ne", "dirt_v2_corner_nw", "dirt_v2_corner_sw", "dirt_v2_corner_se" ] },
-      { "weight": 1, "sprite": [ "dirt_v3_corner_ne", "dirt_v3_corner_nw", "dirt_v3_corner_sw", "dirt_v3_corner_se" ] },
-      { "weight": 1, "sprite": [ "dirt_v4_corner_ne", "dirt_v4_corner_nw", "dirt_v4_corner_sw", "dirt_v4_corner_se" ] },
-      { "weight": 1, "sprite": [ "dirt_v5_corner_ne", "dirt_v5_corner_nw", "dirt_v5_corner_sw", "dirt_v5_corner_se" ] }
+      { "weight": 1, "sprite": [ "dirt_v1_corner_ne", "dirt_v1_corner_se", "dirt_v1_corner_sw", "dirt_v1_corner_nw" ] },
+      { "weight": 1, "sprite": [ "dirt_v2_corner_ne", "dirt_v2_corner_se", "dirt_v2_corner_sw", "dirt_v2_corner_nw" ] },
+      { "weight": 1, "sprite": [ "dirt_v3_corner_ne", "dirt_v3_corner_se", "dirt_v3_corner_sw", "dirt_v3_corner_nw" ] },
+      { "weight": 1, "sprite": [ "dirt_v4_corner_ne", "dirt_v4_corner_se", "dirt_v4_corner_sw", "dirt_v4_corner_nw" ] },
+      { "weight": 1, "sprite": [ "dirt_v5_corner_ne", "dirt_v5_corner_se", "dirt_v5_corner_sw", "dirt_v5_corner_nw" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -212,11 +212,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "dirt_v1_t_connection_w", "dirt_v1_t_connection_s", "dirt_v1_t_connection_e", "dirt_v1_t_connection_n" ] },
-      { "weight": 1, "sprite": [ "dirt_v2_t_connection_w", "dirt_v2_t_connection_s", "dirt_v2_t_connection_e", "dirt_v2_t_connection_n" ] },
-      { "weight": 1, "sprite": [ "dirt_v3_t_connection_w", "dirt_v3_t_connection_s", "dirt_v3_t_connection_e", "dirt_v3_t_connection_n" ] },
-      { "weight": 1, "sprite": [ "dirt_v4_t_connection_w", "dirt_v4_t_connection_s", "dirt_v4_t_connection_e", "dirt_v4_t_connection_n" ] },
-      { "weight": 1, "sprite": [ "dirt_v5_t_connection_w", "dirt_v5_t_connection_s", "dirt_v5_t_connection_e", "dirt_v5_t_connection_n" ] }
+      { "weight": 1, "sprite": [ "dirt_v1_t_connection_w", "dirt_v1_t_connection_n", "dirt_v1_t_connection_e", "dirt_v1_t_connection_s" ] },
+      { "weight": 1, "sprite": [ "dirt_v2_t_connection_w", "dirt_v2_t_connection_n", "dirt_v2_t_connection_e", "dirt_v2_t_connection_s" ] },
+      { "weight": 1, "sprite": [ "dirt_v3_t_connection_w", "dirt_v3_t_connection_n", "dirt_v3_t_connection_e", "dirt_v3_t_connection_s" ] },
+      { "weight": 1, "sprite": [ "dirt_v4_t_connection_w", "dirt_v4_t_connection_n", "dirt_v4_t_connection_e", "dirt_v4_t_connection_s" ] },
+      { "weight": 1, "sprite": [ "dirt_v5_t_connection_w", "dirt_v5_t_connection_n", "dirt_v5_t_connection_e", "dirt_v5_t_connection_s" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/irregular/speedway/speedway_roads.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/irregular/speedway/speedway_roads.json
@@ -8,11 +8,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "road_v1_corner_nw", "road_v1_corner_sw", "road_v1_corner_se", "road_v1_corner_ne" ] },
-      { "weight": 1, "sprite": [ "road_v2_corner_nw", "road_v2_corner_sw", "road_v2_corner_se", "road_v2_corner_ne" ] },
-      { "weight": 1, "sprite": [ "road_v3_corner_nw", "road_v3_corner_sw", "road_v3_corner_se", "road_v3_corner_ne" ] },
-      { "weight": 1, "sprite": [ "road_v4_corner_nw", "road_v4_corner_sw", "road_v4_corner_se", "road_v4_corner_ne" ] },
-      { "weight": 1, "sprite": [ "road_v5_corner_nw", "road_v5_corner_sw", "road_v5_corner_se", "road_v5_corner_ne" ] }
+      { "weight": 1, "sprite": [ "road_v1_corner_nw", "road_v1_corner_ne", "road_v1_corner_se", "road_v1_corner_sw" ] },
+      { "weight": 1, "sprite": [ "road_v2_corner_nw", "road_v2_corner_ne", "road_v2_corner_se", "road_v2_corner_sw" ] },
+      { "weight": 1, "sprite": [ "road_v3_corner_nw", "road_v3_corner_ne", "road_v3_corner_se", "road_v3_corner_sw" ] },
+      { "weight": 1, "sprite": [ "road_v4_corner_nw", "road_v4_corner_ne", "road_v4_corner_se", "road_v4_corner_sw" ] },
+      { "weight": 1, "sprite": [ "road_v5_corner_nw", "road_v5_corner_ne", "road_v5_corner_se", "road_v5_corner_sw" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -51,11 +51,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "road_v1_corner_ne", "road_v1_corner_nw", "road_v1_corner_sw", "road_v1_corner_se" ] },
-      { "weight": 1, "sprite": [ "road_v2_corner_ne", "road_v2_corner_nw", "road_v2_corner_sw", "road_v2_corner_se" ] },
-      { "weight": 1, "sprite": [ "road_v3_corner_ne", "road_v3_corner_nw", "road_v3_corner_sw", "road_v3_corner_se" ] },
-      { "weight": 1, "sprite": [ "road_v4_corner_ne", "road_v4_corner_nw", "road_v4_corner_sw", "road_v4_corner_se" ] },
-      { "weight": 1, "sprite": [ "road_v5_corner_ne", "road_v5_corner_nw", "road_v5_corner_sw", "road_v5_corner_se" ] }
+      { "weight": 1, "sprite": [ "road_v1_corner_ne", "road_v1_corner_se", "road_v1_corner_sw", "road_v1_corner_nw" ] },
+      { "weight": 1, "sprite": [ "road_v2_corner_ne", "road_v2_corner_se", "road_v2_corner_sw", "road_v2_corner_nw" ] },
+      { "weight": 1, "sprite": [ "road_v3_corner_ne", "road_v3_corner_se", "road_v3_corner_sw", "road_v3_corner_nw" ] },
+      { "weight": 1, "sprite": [ "road_v4_corner_ne", "road_v4_corner_se", "road_v4_corner_sw", "road_v4_corner_nw" ] },
+      { "weight": 1, "sprite": [ "road_v5_corner_ne", "road_v5_corner_se", "road_v5_corner_sw", "road_v5_corner_nw" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -94,11 +94,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "road_v1_corner_se", "road_v1_corner_ne", "road_v1_corner_nw", "road_v1_corner_sw" ] },
-      { "weight": 1, "sprite": [ "road_v2_corner_se", "road_v2_corner_ne", "road_v2_corner_nw", "road_v2_corner_sw" ] },
-      { "weight": 1, "sprite": [ "road_v3_corner_se", "road_v3_corner_ne", "road_v3_corner_nw", "road_v3_corner_sw" ] },
-      { "weight": 1, "sprite": [ "road_v4_corner_se", "road_v4_corner_ne", "road_v4_corner_nw", "road_v4_corner_sw" ] },
-      { "weight": 1, "sprite": [ "road_v5_corner_se", "road_v5_corner_ne", "road_v5_corner_nw", "road_v5_corner_sw" ] }
+      { "weight": 1, "sprite": [ "road_v1_corner_se", "road_v1_corner_sw", "road_v1_corner_nw", "road_v1_corner_ne" ] },
+      { "weight": 1, "sprite": [ "road_v2_corner_se", "road_v2_corner_sw", "road_v2_corner_nw", "road_v2_corner_ne" ] },
+      { "weight": 1, "sprite": [ "road_v3_corner_se", "road_v3_corner_sw", "road_v3_corner_nw", "road_v3_corner_ne" ] },
+      { "weight": 1, "sprite": [ "road_v4_corner_se", "road_v4_corner_sw", "road_v4_corner_nw", "road_v4_corner_ne" ] },
+      { "weight": 1, "sprite": [ "road_v5_corner_se", "road_v5_corner_sw", "road_v5_corner_nw", "road_v5_corner_ne" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
@@ -223,11 +223,11 @@
     ],
     "rotates": true,
     "fg": [
-      { "weight": 1, "sprite": [ "road_v1_t_connection_e", "road_v1_t_connection_n", "road_v1_t_connection_w", "road_v1_t_connection_s" ] },
-      { "weight": 1, "sprite": [ "road_v2_t_connection_e", "road_v2_t_connection_n", "road_v2_t_connection_w", "road_v2_t_connection_s" ] },
-      { "weight": 1, "sprite": [ "road_v3_t_connection_e", "road_v3_t_connection_n", "road_v3_t_connection_w", "road_v3_t_connection_s" ] },
-      { "weight": 1, "sprite": [ "road_v4_t_connection_e", "road_v4_t_connection_n", "road_v4_t_connection_w", "road_v4_t_connection_s" ] },
-      { "weight": 1, "sprite": [ "road_v5_t_connection_e", "road_v5_t_connection_n", "road_v5_t_connection_w", "road_v5_t_connection_s" ] }
+      { "weight": 1, "sprite": [ "road_v1_t_connection_e", "road_v1_t_connection_s", "road_v1_t_connection_w", "road_v1_t_connection_n" ] },
+      { "weight": 1, "sprite": [ "road_v2_t_connection_e", "road_v2_t_connection_s", "road_v2_t_connection_w", "road_v2_t_connection_n" ] },
+      { "weight": 1, "sprite": [ "road_v3_t_connection_e", "road_v3_t_connection_s", "road_v3_t_connection_w", "road_v3_t_connection_n" ] },
+      { "weight": 1, "sprite": [ "road_v4_t_connection_e", "road_v4_t_connection_s", "road_v4_t_connection_w", "road_v4_t_connection_n" ] },
+      { "weight": 1, "sprite": [ "road_v5_t_connection_e", "road_v5_t_connection_s", "road_v5_t_connection_w", "road_v5_t_connection_n" ] }
     ],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },

--- a/gfx/PenAndPaper/pngs_overmap_48x48/irregular/speedway/speedway_track.json
+++ b/gfx/PenAndPaper/pngs_overmap_48x48/irregular/speedway/speedway_track.json
@@ -2,7 +2,7 @@
   {
     "id": "speedway_1_0",
     "rotates": true,
-    "fg": ["speedway_track_var_01", "speedway_track_var_24", "speedway_track_var_34", "speedway_track_var_11"],
+    "fg": ["speedway_track_var_01", "speedway_track_var_11", "speedway_track_var_34", "speedway_track_var_24"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -34,7 +34,7 @@
   {
     "id": "speedway_2_0",
     "rotates": true,
-    "fg": ["speedway_track_var_02", "speedway_track_var_18", "speedway_track_var_33", "speedway_track_var_17"],
+    "fg": ["speedway_track_var_02", "speedway_track_var_17", "speedway_track_var_33", "speedway_track_var_18"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -130,7 +130,7 @@
   {
     "id": "speedway_5_0",
     "rotates":true,
-    "fg": ["speedway_track_var_03", "speedway_track_var_12", "speedway_track_var_32", "speedway_track_var_23"],
+    "fg": ["speedway_track_var_03", "speedway_track_var_23", "speedway_track_var_32", "speedway_track_var_12"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -162,7 +162,7 @@
   {
     "id": "speedway_6_0",
     "rotates":true,
-    "fg": ["speedway_track_var_04", "speedway_track_var_06", "speedway_track_var_31", "speedway_track_var_29"],
+    "fg": ["speedway_track_var_04", "speedway_track_var_29", "speedway_track_var_31", "speedway_track_var_06"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -195,7 +195,7 @@
   {
     "id": "speedway_0_1",
     "rotates": true,
-    "fg": ["speedway_track_var_06", "speedway_track_var_31", "speedway_track_var_29", "speedway_track_var_04"],
+    "fg": ["speedway_track_var_06", "speedway_track_var_04", "speedway_track_var_29", "speedway_track_var_31"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -227,7 +227,7 @@
   {
     "id": "speedway_1_1",
     "rotates": true,
-    "fg": ["speedway_track_var_07", "speedway_track_var_25", "speedway_track_var_28", "speedway_track_var_10"],
+    "fg": ["speedway_track_var_07", "speedway_track_var_10", "speedway_track_var_28", "speedway_track_var_25"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -259,7 +259,7 @@
   {
     "id": "speedway_6_1",
     "rotates": true,
-    "fg": ["speedway_track_var_10", "speedway_track_var_07", "speedway_track_var_25", "speedway_track_var_28"],
+    "fg": ["speedway_track_var_10", "speedway_track_var_28", "speedway_track_var_25", "speedway_track_var_07"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -291,7 +291,7 @@
   {
     "id": "speedway_7_1",
     "rotates": true,
-    "fg": ["speedway_track_var_11", "speedway_track_var_01", "speedway_track_var_24", "speedway_track_var_34"],
+    "fg": ["speedway_track_var_11", "speedway_track_var_34", "speedway_track_var_24", "speedway_track_var_01"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -325,7 +325,7 @@
   {
     "id": "speedway_0_2",
     "rotates": true,
-    "fg": ["speedway_track_var_12", "speedway_track_var_32", "speedway_track_var_23", "speedway_track_var_03"],
+    "fg": ["speedway_track_var_12", "speedway_track_var_03", "speedway_track_var_23", "speedway_track_var_32"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -357,7 +357,7 @@
   {
     "id": "speedway_7_2",
     "rotates": true,
-    "fg": ["speedway_track_var_17", "speedway_track_var_02", "speedway_track_var_18", "speedway_track_var_33"],
+    "fg": ["speedway_track_var_17", "speedway_track_var_33", "speedway_track_var_18", "speedway_track_var_02"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -389,7 +389,7 @@
   {
     "id": "speedway_0_3",
     "rotates": true,
-    "fg": ["speedway_track_var_18", "speedway_track_var_33", "speedway_track_var_17", "speedway_track_var_02"],
+    "fg": ["speedway_track_var_18", "speedway_track_var_02", "speedway_track_var_17", "speedway_track_var_33"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -421,7 +421,7 @@
   {
     "id": "speedway_7_3",
     "rotates": true,
-    "fg": ["speedway_track_var_23", "speedway_track_var_03", "speedway_track_var_12", "speedway_track_var_32"],
+    "fg": ["speedway_track_var_23", "speedway_track_var_32", "speedway_track_var_12", "speedway_track_var_03"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -454,7 +454,7 @@
   {
     "id": "speedway_0_4",
     "rotates": true,
-    "fg": ["speedway_track_var_24", "speedway_track_var_34", "speedway_track_var_11", "speedway_track_var_01"],
+    "fg": ["speedway_track_var_24", "speedway_track_var_01", "speedway_track_var_11", "speedway_track_var_34"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -486,7 +486,7 @@
   {
     "id": "speedway_1_4",
     "rotates": true,
-    "fg": ["speedway_track_var_25", "speedway_track_var_28", "speedway_track_var_10", "speedway_track_var_07"],
+    "fg": ["speedway_track_var_25", "speedway_track_var_07", "speedway_track_var_10", "speedway_track_var_28"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -518,7 +518,7 @@
   {
     "id": "speedway_6_4",
     "rotates": true,
-    "fg": ["speedway_track_var_28", "speedway_track_var_10", "speedway_track_var_07", "speedway_track_var_25"],
+    "fg": ["speedway_track_var_28", "speedway_track_var_25", "speedway_track_var_07", "speedway_track_var_10"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -550,7 +550,7 @@
   {
     "id": "speedway_7_4",
     "rotates": true,
-    "fg": ["speedway_track_var_29", "speedway_track_var_04", "speedway_track_var_06", "speedway_track_var_31"],
+    "fg": ["speedway_track_var_29", "speedway_track_var_31", "speedway_track_var_06", "speedway_track_var_04"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -583,7 +583,7 @@
   {
     "id": "speedway_1_5",
     "rotates": true,
-    "fg": ["speedway_track_var_31", "speedway_track_var_29", "speedway_track_var_04", "speedway_track_var_06"],
+    "fg": ["speedway_track_var_31", "speedway_track_var_06", "speedway_track_var_04", "speedway_track_var_29"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -615,7 +615,7 @@
   {
     "id": "speedway_2_5",
     "rotates": true,
-    "fg": ["speedway_track_var_32", "speedway_track_var_23", "speedway_track_var_03", "speedway_track_var_12"],
+    "fg": ["speedway_track_var_32", "speedway_track_var_12", "speedway_track_var_03", "speedway_track_var_23"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -711,7 +711,7 @@
   {
     "id": "speedway_5_5",
     "rotates": true,
-    "fg": ["speedway_track_var_33", "speedway_track_var_17", "speedway_track_var_02", "speedway_track_var_18"],
+    "fg": ["speedway_track_var_33", "speedway_track_var_18", "speedway_track_var_02", "speedway_track_var_17"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },
@@ -743,7 +743,7 @@
   {
     "id": "speedway_6_5",
     "rotates": true,
-    "fg": ["speedway_track_var_34", "speedway_track_var_11", "speedway_track_var_01", "speedway_track_var_24"],
+    "fg": ["speedway_track_var_34", "speedway_track_var_24", "speedway_track_var_01", "speedway_track_var_11"],
     "bg": [
       { "weight": 1, "sprite": "bg_00" },
       { "weight": 1, "sprite": "bg_01" },


### PR DESCRIPTION
#### Summary
Part 2 of ? series of PRs to update tile rotations on the overmap that need fixing due to tile rotations being fixed in https://github.com/CleverRaven/Cataclysm-DDA/pull/86335

#### Content of the change
Every tile definition that uses rotations to display a multitile special on the overmap had either its json definition changed back to the correct rotation order or the tiles renamed to match the correct rotation order. 

For this tileset all that was needed was swapping index 1 and 3 for every array with four rotation entries

#### Testing
Composed locally and took these screenshots
<details>
<summary>Images</summary>
<img width="1535" height="1200" alt="image" src="https://github.com/user-attachments/assets/de42c141-8e32-41c4-88d5-df652502346b" />
<img width="1535" height="1200" alt="image" src="https://github.com/user-attachments/assets/db6a763f-307c-4808-bb33-67a7eed7808a" />
<img width="1535" height="1200" alt="image" src="https://github.com/user-attachments/assets/119b1303-8617-4cf1-be39-87b691d4778d" />
<img width="1535" height="1200" alt="image" src="https://github.com/user-attachments/assets/a9245f48-9227-4a39-be12-a07c38dbc3e0" />



</details>

#### Additional information
