### PR TITLE
[MSX] Attach the butterfly wings sprite to `MUTATION_COSMETIC_BUTTERFLY_WINGS`

### DIFF
--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/xedra_evolved/character/mutations/MUTATION_COSMETIC_BUTTERFLY_WINGS.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/xedra_evolved/character/mutations/MUTATION_COSMETIC_BUTTERFLY_WINGS.json
@@ -1,0 +1,10 @@
+{
+  "id": "overlay_mutation_MUTATION_COSMETIC_BUTTERFLY_WINGS",
+  "fg": [
+    "2846_overlay_mutation_WINGS_BUTTERFLY_0"
+  ],
+  "rotates": false,
+  "bg": [
+    
+  ]
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
[MSX] Attach the butterfly wings sprite to `MUTATION_COSMETIC_BUTTERFLY_WINGS`

#### Content of the change

I need the butterfly wings sprite for the Wings of Gossamer spell in https://github.com/CleverRaven/Cataclysm-DDA/pull/85174, so this is preparing for that.

<!-- Explain what does this pull request contain. -->

#### Testing

Works: 
<img width="258" height="228" alt="Untitled" src="https://github.com/user-attachments/assets/e2f32e7b-55f1-41d2-a787-aac45387c3cc" />



<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
