### PR TITLE
[NeoDays] Rotation Fixes

### DIFF
--- a/gfx/NeoDays/pngs_tiles_10x10/furniture/indoors/f_pillow_fort.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/furniture/indoors/f_pillow_fort.json
@@ -4,49 +4,11 @@
   "rotates": true,
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_pillow_fort_1"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "f_pillow_fort_2",
-        "f_pillow_fort_3",
-        "f_pillow_fort_4",
-        "f_pillow_fort_5"
-      ]
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "f_pillow_fort_6",
-        "f_pillow_fort_0",
-        "f_pillow_fort_6",
-        "f_pillow_fort_0"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "f_pillow_fort_7",
-        "f_pillow_fort_0",
-        "f_pillow_fort_8",
-        "f_pillow_fort_0"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "f_pillow_fort_9",
-        "f_pillow_fort_10",
-        "f_pillow_fort_11",
-        "f_pillow_fort_12"
-      ]
-    },
-    {
-      "id": "unconnected",
-      "fg": "f_pillow_fort_0"
-    }
+    { "id": "center", "fg": "f_pillow_fort_1" },
+    { "id": "corner", "fg": [ "f_pillow_fort_2", "f_pillow_fort_5", "f_pillow_fort_4", "f_pillow_fort_3" ] },
+    { "id": "edge", "fg": [ "f_pillow_fort_6", "f_pillow_fort_0", "f_pillow_fort_6", "f_pillow_fort_0" ] },
+    { "id": "end_piece", "fg": [ "f_pillow_fort_7", "f_pillow_fort_0", "f_pillow_fort_8", "f_pillow_fort_0" ] },
+    { "id": "t_connection", "fg": [ "f_pillow_fort_9", "f_pillow_fort_12", "f_pillow_fort_11", "f_pillow_fort_10" ] },
+    { "id": "unconnected", "fg": "f_pillow_fort_0" }
   ]
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/furniture/utility/sink/f_sink.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/furniture/utility/sink/f_sink.json
@@ -4,50 +4,14 @@
   "rotates": false,
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_sink_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "f_sink_cornerNW",
-        "f_sink_cornerSW",
-        "f_sink_cornerSE",
-        "f_sink_cornerNE"
-      ]
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "f_sink_NS",
-        "f_sink_EW"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "f_sink_endN",
-        "f_sink_endE",
-        "f_sink_endS",
-        "f_sink_endW"
-      ]
-    },
+    { "id": "center", "fg": "f_sink_center" },
+    { "id": "corner", "fg": [ "f_sink_cornerNW", "f_sink_cornerNE", "f_sink_cornerSE", "f_sink_cornerSW" ] },
+    { "id": "edge", "fg": [ "f_sink_NS", "f_sink_EW" ] },
+    { "id": "end_piece", "fg": [ "f_sink_endN", "f_sink_endW", "f_sink_endS", "f_sink_endE" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "f_sink_t_connectionN",
-        "f_sink_t_connectionE",
-        "f_sink_t_connectionS",
-        "f_sink_t_connectionW"
-      ]
+      "fg": [ "f_sink_t_connectionN", "f_sink_t_connectionW", "f_sink_t_connectionS", "f_sink_t_connectionE" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_sink_unconnected",
-        "f_sink_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_sink_unconnected", "f_sink_unconnected" ] }
   ]
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/terrain/t_fence.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/terrain/t_fence.json
@@ -7,50 +7,12 @@
   "fg": "t_fence_0",
   "rotates": true,
   "multitile": true,
-  "additional_tiles":[
-    {
-      "id": "center",
-      "fg": "t_fence_1"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_fence_2",
-        "t_fence_3",
-        "t_fence_4",
-        "t_fence_0"
-      ]
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "t_fence_5",
-        "t_fence_6",
-        "t_fence_5",
-        "t_fence_6"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "t_fence_5",
-        "t_fence_6",
-        "t_fence_7",
-        "t_fence_0"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "t_fence_6",
-        "t_fence_3",
-        "t_fence_1",
-        "t_fence_4"
-      ]
-    },
-    {
-      "id": "unconnected",
-      "fg": "t_fence_0"
-    }
+  "additional_tiles": [
+    { "id": "center", "fg": "t_fence_1" },
+    { "id": "corner", "fg": [ "t_fence_2", "t_fence_0", "t_fence_4", "t_fence_3" ] },
+    { "id": "edge", "fg": [ "t_fence_5", "t_fence_6", "t_fence_5", "t_fence_6" ] },
+    { "id": "end_piece", "fg": [ "t_fence_5", "t_fence_0", "t_fence_7", "t_fence_6" ] },
+    { "id": "t_connection", "fg": [ "t_fence_6", "t_fence_4", "t_fence_1", "t_fence_3" ] },
+    { "id": "unconnected", "fg": "t_fence_0" }
   ]
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/terrain/t_palisade.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/terrain/t_palisade.json
@@ -4,29 +4,11 @@
   "rotates": true,
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": ["t_palisade_8"]
-    },
-    {
-      "id": "corner",
-      "fg": ["t_palisade_7", "t_palisade_1", "t_palisade_2", "t_palisade_6"]
-    },
-    {
-      "id": "edge",
-      "fg": ["t_palisade_3", "t_palisade_4", "t_palisade_3", "t_palisade_4"]
-    },
-    {
-      "id": "end_piece",
-      "fg": ["t_palisade_3", "t_palisade_1", "t_palisade_5", "t_palisade_0"]
-    },
-    {
-      "id": "t_connection",
-      "fg": ["t_palisade_8", "t_palisade_7", "t_palisade_4", "t_palisade_6"]
-    },
-    {
-      "id": "unconnected",
-      "fg": ["t_palisade_5"]
-    }
+    { "id": "center", "fg": [ "t_palisade_8" ] },
+    { "id": "corner", "fg": [ "t_palisade_7", "t_palisade_6", "t_palisade_2", "t_palisade_1" ] },
+    { "id": "edge", "fg": [ "t_palisade_3", "t_palisade_4", "t_palisade_3", "t_palisade_4" ] },
+    { "id": "end_piece", "fg": [ "t_palisade_3", "t_palisade_0", "t_palisade_5", "t_palisade_1" ] },
+    { "id": "t_connection", "fg": [ "t_palisade_8", "t_palisade_6", "t_palisade_4", "t_palisade_7" ] },
+    { "id": "unconnected", "fg": [ "t_palisade_5" ] }
   ]
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/terrain/t_railroad_track.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/terrain/t_railroad_track.json
@@ -11,33 +11,14 @@
   "rotates": true,
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_railroad_track_0"
-    },
+    { "id": "center", "fg": "t_railroad_track_0" },
     {
       "id": "corner",
-      "fg": [
-        "t_railroad_track_1",
-        "t_railroad_track_2",
-        "t_railroad_track_3",
-        "t_railroad_track_4"
-      ]
+      "fg": [ "t_railroad_track_1", "t_railroad_track_4", "t_railroad_track_3", "t_railroad_track_2" ]
     },
-    {
-      "id": "edge",
-      "fg": "t_railroad_track_5"
-    },
-    {
-      "id": "end_piece",
-      "fg": "t_railroad_track_5"
-    },
-    {
-      "id": "t_connection",
-      "fg": "t_railroad_track_6"
-    },
-    {
-      "id": "unconnected",
-      "fg": "t_railroad_track_5"
-  }]
+    { "id": "edge", "fg": "t_railroad_track_5" },
+    { "id": "end_piece", "fg": "t_railroad_track_5" },
+    { "id": "t_connection", "fg": "t_railroad_track_6" },
+    { "id": "unconnected", "fg": "t_railroad_track_5" }
+  ]
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_chitin.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_chitin.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_chitin",
-  "fg": [ "vp_ram_chitin", "vp_ram_chitin_left", "vp_ram_chitin_down", "vp_ram_chitin_right" ],
+  "fg": "vp_ram_chitin",
   "rotates": true
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_hardsteel.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_hardsteel.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_hardsteel",
-  "fg": [ "vp_ram_hardsteel", "vp_ram_hardsteel_left", "vp_ram_hardsteel_down", "vp_ram_hardsteel_right" ],
+  "fg": "vp_ram_hardsteel",
   "rotates": true
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_military.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_military.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_military",
-  "fg": [ "vp_ram_military", "vp_ram_military_left", "vp_ram_military_down", "vp_ram_military_right" ],
+  "fg": "vp_ram_military",
   "rotates": true
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_spiked.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_spiked.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_spiked",
-  "fg": [ "vp_ram_spiked", "vp_ram_spiked_left", "vp_ram_spiked_down", "vp_ram_spiked_right" ],
+  "fg": "vp_ram_spiked",
   "rotates": true
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_steel.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_steel.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_steel",
-  "fg": [ "vp_ram_steel", "vp_ram_steel_left", "vp_ram_steel_down", "vp_ram_steel_right" ],
+  "fg": "vp_ram_steel",
   "rotates": true
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_superalloy.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_superalloy.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_alloy",
-  "fg": [ "vp_ram_alloy", "vp_ram_alloy_left", "vp_ram_alloy_down", "vp_ram_alloy_right" ],
+  "fg": "vp_ram_alloy",
   "rotates": true
 }

--- a/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_wood.json
+++ b/gfx/NeoDays/pngs_tiles_10x10/vehicle/rams/vp_ram_wood.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_wood",
-  "fg": [ "vp_ram_wood", "vp_ram_wood_left", "vp_ram_wood_down", "vp_ram_wood_right" ],
+  "fg": "vp_ram_wood",
   "rotates": true
 }


### PR DESCRIPTION
#### Summary
Part of the tile rotation update PRs. Updates tile definitions to account for the fixes in https://github.com/CleverRaven/Cataclysm-DDA/pull/86335 and https://github.com/CleverRaven/Cataclysm-DDA/pull/86574

#### Content of the change
The dependent PR changed the tile drawing code to rotate tiles in the correct direction (clockwise instead of counter clockwise) and it will select tiles in an order opposite than it used to.
Every tile definition that defines all four rotations had to have indexes 1 and 3 swapped so the engine will select the correct tile to draw. 


#### Testing
Composed locally checked around for any obviously broken tiles. Attached is a save with a lot of testing material placed down in-game and on the overmap.
[Debug.tar.gz](https://github.com/user-attachments/files/26925717/Debug.tar.gz)


#### Additional information
Depends on https://github.com/CleverRaven/Cataclysm-DDA/pull/86574 being merged.