### PR TITLE
[RetroDays] Rotation Fixes

### DIFF
--- a/gfx/Retrodays/pngs_tiles_10x10/furniture/f_pillow_fort_0.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/furniture/f_pillow_fort_0.json
@@ -1,1 +1,35 @@
-{"id": "f_pillow_fort", "fg": ["670_f_pillow_fort_0"], "rotates": true, "multitile": true, "additional_tiles": [{"id": "center", "fg": ["671_f_pillow_fort_1"], "bg": []}, {"id": "corner", "fg": ["672_f_pillow_fort_2", "673_f_pillow_fort_3", "674_f_pillow_fort_4", "675_f_pillow_fort_5"], "bg": []}, {"id": "edge", "fg": ["676_f_pillow_fort_6", "670_f_pillow_fort_0", "676_f_pillow_fort_6", "670_f_pillow_fort_0"], "bg": []}, {"id": "end_piece", "fg": ["677_f_pillow_fort_7", "670_f_pillow_fort_0", "678_f_pillow_fort_8", "670_f_pillow_fort_0"], "bg": []}, {"id": "t_connection", "fg": ["679_f_pillow_fort_9", "680_f_pillow_fort_10", "681_f_pillow_fort_11", "682_f_pillow_fort_12"], "bg": []}, {"id": "unconnected", "fg": ["670_f_pillow_fort_0"], "bg": []}], "bg": []}
+{
+  "id": "f_pillow_fort",
+  "fg": [
+    "670_f_pillow_fort_0"
+  ],
+  "rotates": true,
+  "multitile": true,
+  "additional_tiles": [
+    { "id": "center", "fg": [ "671_f_pillow_fort_1" ], "bg": [  ] },
+    {
+      "id": "corner",
+      "fg": [ "672_f_pillow_fort_2", "675_f_pillow_fort_5", "674_f_pillow_fort_4", "673_f_pillow_fort_3" ],
+      "bg": [  ]
+    },
+    {
+      "id": "edge",
+      "fg": [ "676_f_pillow_fort_6", "670_f_pillow_fort_0", "676_f_pillow_fort_6", "670_f_pillow_fort_0" ],
+      "bg": [  ]
+    },
+    {
+      "id": "end_piece",
+      "fg": [ "677_f_pillow_fort_7", "670_f_pillow_fort_0", "678_f_pillow_fort_8", "670_f_pillow_fort_0" ],
+      "bg": [  ]
+    },
+    {
+      "id": "t_connection",
+      "fg": [ "679_f_pillow_fort_9", "682_f_pillow_fort_12", "681_f_pillow_fort_11", "680_f_pillow_fort_10" ],
+      "bg": [  ]
+    },
+    { "id": "unconnected", "fg": [ "670_f_pillow_fort_0" ], "bg": [  ] }
+  ],
+  "bg": [
+    
+  ]
+}

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/ants/ants.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/ants/ants.json
@@ -1,57 +1,26 @@
 {
-    "id": "ants",
-    "fg": "ants_unconnected",
-    "multitile": true,
-    "bg": "ants_bg",
-    "additional_tiles": [
-      {
-        "id": "center",
-        "bg": "ants_bg",
-        "fg": "ants_center"
-      },
-      {
-        "id": "corner",
-        "bg": "ants_bg",
-        "fg": [
-          "ants_corner_nw",
-          "ants_corner_sw",
-          "ants_corner_se",
-          "ants_corner_ne"
-        ]
-      },
-      {
-        "id": "t_connection",
-        "bg": "ants_bg",
-        "fg": [
-          "ants_t_connection_n",
-          "ants_t_connection_w",
-          "ants_t_connection_s",
-          "ants_t_connection_e"
-        ]
-      },
-      {
-        "id": "edge",
-        "bg": "ants_bg",
-        "fg": [
-          "ants_edge_ns",
-          "ants_edge_ew"
-        ]
-      },
-      {
-        "id": "end_piece",
-        "bg": "ants_bg",
-        "fg": [
-          "ants_end_piece_n",
-          "ants_end_piece_w",
-          "ants_end_piece_s",
-          "ants_end_piece_e"
-        ]
-      },
-      {
-        "id": "unconnected",
-        "bg": "ants_bg",
-        "fg": "ants_unconnected"
-      }
-    ]
-  }
-  
+  "id": "ants",
+  "fg": "ants_unconnected",
+  "multitile": true,
+  "bg": "ants_bg",
+  "additional_tiles": [
+    { "id": "center", "bg": "ants_bg", "fg": "ants_center" },
+    {
+      "id": "corner",
+      "bg": "ants_bg",
+      "fg": [ "ants_corner_nw", "ants_corner_ne", "ants_corner_se", "ants_corner_sw" ]
+    },
+    {
+      "id": "t_connection",
+      "bg": "ants_bg",
+      "fg": [ "ants_t_connection_n", "ants_t_connection_e", "ants_t_connection_s", "ants_t_connection_w" ]
+    },
+    { "id": "edge", "bg": "ants_bg", "fg": [ "ants_edge_ns", "ants_edge_ew" ] },
+    {
+      "id": "end_piece",
+      "bg": "ants_bg",
+      "fg": [ "ants_end_piece_n", "ants_end_piece_e", "ants_end_piece_s", "ants_end_piece_w" ]
+    },
+    { "id": "unconnected", "bg": "ants_bg", "fg": "ants_unconnected" }
+  ]
+}

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/rural_road.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/dirt_road/rural_road.json
@@ -10,16 +10,16 @@
     { "id": "center", "fg": "dirt_road_center" },
     {
       "id": "corner",
-      "fg": [ "dirt_road_corner_nw", "dirt_road_corner_sw", "dirt_road_corner_se", "dirt_road_corner_ne" ]
+      "fg": [ "dirt_road_corner_nw", "dirt_road_corner_ne", "dirt_road_corner_se", "dirt_road_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [ "dirt_road_t_connection_n", "dirt_road_t_connection_w", "dirt_road_t_connection_s", "dirt_road_t_connection_e" ]
+      "fg": [ "dirt_road_t_connection_n", "dirt_road_t_connection_e", "dirt_road_t_connection_s", "dirt_road_t_connection_w" ]
     },
     { "id": "edge", "fg": [ "dirt_road_edge_ns", "dirt_road_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [ "dirt_road_end_piece_n", "dirt_road_end_piece_w", "dirt_road_end_piece_s", "dirt_road_end_piece_e" ]
+      "fg": [ "dirt_road_end_piece_n", "dirt_road_end_piece_e", "dirt_road_end_piece_s", "dirt_road_end_piece_w" ]
     },
     { "id": "unconnected", "fg": [ "dirt_road_unconnected", "dirt_road_unconnected" ] }
   ]

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/forest_trail/forest_trail.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/forest_trail/forest_trail.json
@@ -1,57 +1,31 @@
 {
-    "id": "forest_trail",
-    "fg": "forest_trail_unconnected",
-    "multitile": true,
-    "bg": "forest_trail_bg",
-    "additional_tiles": [
-      {
-        "id": "center",
-        "bg": "forest_trail_bg",
-        "fg": "forest_trail_center"
-      },
-      {
-        "id": "corner",
-        "bg": "forest_trail_bg",
-        "fg": [
-          "forest_trail_corner_nw",
-          "forest_trail_corner_sw",
-          "forest_trail_corner_se",
-          "forest_trail_corner_ne"
-        ]
-      },
-      {
-        "id": "t_connection",
-        "bg": "forest_trail_bg",
-        "fg": [
-          "forest_trail_t_connection_n",
-          "forest_trail_t_connection_w",
-          "forest_trail_t_connection_s",
-          "forest_trail_t_connection_e"
-        ]
-      },
-      {
-        "id": "edge",
-        "bg": "forest_trail_bg",
-        "fg": [
-          "forest_trail_edge_ns",
-          "forest_trail_edge_ew"
-        ]
-      },
-      {
-        "id": "end_piece",
-        "bg": "forest_trail_bg",
-        "fg": [
-          "forest_trail_end_piece_n",
-          "forest_trail_end_piece_w",
-          "forest_trail_end_piece_s",
-          "forest_trail_end_piece_e"
-        ]
-      },
-      {
-        "id": "unconnected",
-        "bg": "forest_trail_bg",
-        "fg": "forest_trail_unconnected"
-      }
-    ]
-  }
-  
+  "id": "forest_trail",
+  "fg": "forest_trail_unconnected",
+  "multitile": true,
+  "bg": "forest_trail_bg",
+  "additional_tiles": [
+    { "id": "center", "bg": "forest_trail_bg", "fg": "forest_trail_center" },
+    {
+      "id": "corner",
+      "bg": "forest_trail_bg",
+      "fg": [ "forest_trail_corner_nw", "forest_trail_corner_ne", "forest_trail_corner_se", "forest_trail_corner_sw" ]
+    },
+    {
+      "id": "t_connection",
+      "bg": "forest_trail_bg",
+      "fg": [
+        "forest_trail_t_connection_n",
+        "forest_trail_t_connection_e",
+        "forest_trail_t_connection_s",
+        "forest_trail_t_connection_w"
+      ]
+    },
+    { "id": "edge", "bg": "forest_trail_bg", "fg": [ "forest_trail_edge_ns", "forest_trail_edge_ew" ] },
+    {
+      "id": "end_piece",
+      "bg": "forest_trail_bg",
+      "fg": [ "forest_trail_end_piece_n", "forest_trail_end_piece_e", "forest_trail_end_piece_s", "forest_trail_end_piece_w" ]
+    },
+    { "id": "unconnected", "bg": "forest_trail_bg", "fg": "forest_trail_unconnected" }
+  ]
+}

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/road/road.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/road/road.json
@@ -3,50 +3,14 @@
   "fg": "road_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "road_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "road_corner_nw",
-        "road_corner_sw",
-        "road_corner_se",
-        "road_corner_ne"
-      ]
-    },
+    { "id": "center", "fg": "road_center" },
+    { "id": "corner", "fg": [ "road_corner_nw", "road_corner_ne", "road_corner_se", "road_corner_sw" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "road_t_connection_n",
-        "road_t_connection_w",
-        "road_t_connection_s",
-        "road_t_connection_e"
-      ]
+      "fg": [ "road_t_connection_n", "road_t_connection_e", "road_t_connection_s", "road_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "road_edge_ns",
-        "road_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "road_end_piece_n",
-        "road_end_piece_w",
-        "road_end_piece_s",
-        "road_end_piece_e"
-      ]
-    },
-    {
-      "id": "unconnected",
-      "fg": [
-        "road_unconnected",
-        "road_unconnected"
-      ]
-    }
+    { "id": "edge", "fg": [ "road_edge_ns", "road_edge_ew" ] },
+    { "id": "end_piece", "fg": [ "road_end_piece_n", "road_end_piece_e", "road_end_piece_s", "road_end_piece_w" ] },
+    { "id": "unconnected", "fg": [ "road_unconnected", "road_unconnected" ] }
   ]
 }

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/sewer/sewer.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/sewer/sewer.json
@@ -1,57 +1,26 @@
 {
-    "id": "sewer",
-    "fg": "sewer_unconnected",
-    "multitile": true,
-    "bg": "sewer_bg",
-    "additional_tiles": [
-      {
-        "id": "center",
-        "bg": "sewer_bg",
-        "fg": "sewer_center"
-      },
-      {
-        "id": "corner",
-        "bg": "sewer_bg",
-        "fg": [
-          "sewer_corner_nw",
-          "sewer_corner_sw",
-          "sewer_corner_se",
-          "sewer_corner_ne"
-        ]
-      },
-      {
-        "id": "t_connection",
-        "bg": "sewer_bg",
-        "fg": [
-          "sewer_t_connection_n",
-          "sewer_t_connection_w",
-          "sewer_t_connection_s",
-          "sewer_t_connection_e"
-        ]
-      },
-      {
-        "id": "edge",
-        "bg": "sewer_bg",
-        "fg": [
-          "sewer_edge_ns",
-          "sewer_edge_ew"
-        ]
-      },
-      {
-        "id": "end_piece",
-        "bg": "sewer_bg",
-        "fg": [
-          "sewer_end_piece_n",
-          "sewer_end_piece_w",
-          "sewer_end_piece_s",
-          "sewer_end_piece_e"
-        ]
-      },
-      {
-        "id": "unconnected",
-        "bg": "sewer_bg",
-        "fg": "sewer_unconnected"
-      }
-    ]
-  }
-  
+  "id": "sewer",
+  "fg": "sewer_unconnected",
+  "multitile": true,
+  "bg": "sewer_bg",
+  "additional_tiles": [
+    { "id": "center", "bg": "sewer_bg", "fg": "sewer_center" },
+    {
+      "id": "corner",
+      "bg": "sewer_bg",
+      "fg": [ "sewer_corner_nw", "sewer_corner_ne", "sewer_corner_se", "sewer_corner_sw" ]
+    },
+    {
+      "id": "t_connection",
+      "bg": "sewer_bg",
+      "fg": [ "sewer_t_connection_n", "sewer_t_connection_e", "sewer_t_connection_s", "sewer_t_connection_w" ]
+    },
+    { "id": "edge", "bg": "sewer_bg", "fg": [ "sewer_edge_ns", "sewer_edge_ew" ] },
+    {
+      "id": "end_piece",
+      "bg": "sewer_bg",
+      "fg": [ "sewer_end_piece_n", "sewer_end_piece_e", "sewer_end_piece_s", "sewer_end_piece_w" ]
+    },
+    { "id": "unconnected", "bg": "sewer_bg", "fg": "sewer_unconnected" }
+  ]
+}

--- a/gfx/Retrodays/pngs_tiles_10x10/overmap/subway/subway.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/overmap/subway/subway.json
@@ -1,74 +1,26 @@
 {
-    "id": "subway",
-    "fg": "sewer_unconnected",
-    "multitile": true,
-    "bg": "subway_unconnected",
-    "additional_tiles": [
-        {
-            "id": "center",
-            "fg": "sewer_center",
-            "bg": "subway_center"
-        },
-        {
-            "id": "corner",
-            "fg": [
-                "sewer_corner_nw",
-                "sewer_corner_sw",
-                "sewer_corner_se",
-                "sewer_corner_ne"
-            ],
-            "bg": [
-                "subway_corner_nw",
-                "subway_corner_sw",
-                "subway_corner_se",
-                "subway_corner_ne"
-            ]
-        },
-        {
-            "id": "t_connection",
-            "fg": [
-                "sewer_t_connection_n",
-                "sewer_t_connection_w",
-                "sewer_t_connection_s",
-                "sewer_t_connection_e"
-            ],
-            "bg": [
-                "subway_t_connection_n",
-                "subway_t_connection_w",
-                "subway_t_connection_s",
-                "subway_t_connection_e"
-            ]
-        },
-        {
-            "id": "edge",
-            "fg": [
-                "sewer_edge_ns",
-                "sewer_edge_ew"
-            ],
-            "bg": [
-                "subway_edge_ns",
-                "subway_edge_ew"
-            ]
-        },
-        {
-            "id": "end_piece",
-            "fg": [
-                "sewer_end_piece_n",
-                "sewer_end_piece_w",
-                "sewer_end_piece_s",
-                "sewer_end_piece_e"
-            ],
-            "bg": [
-                "subway_end_piece_n",
-                "subway_end_piece_w",
-                "subway_end_piece_s",
-                "subway_end_piece_e"
-            ]
-        },
-        {
-            "id": "unconnected",
-            "fg": "sewer_unconnected",
-            "bg": "subway_unconnected"
-        }
-    ]
+  "id": "subway",
+  "fg": "sewer_unconnected",
+  "multitile": true,
+  "bg": "subway_unconnected",
+  "additional_tiles": [
+    { "id": "center", "fg": "sewer_center", "bg": "subway_center" },
+    {
+      "id": "corner",
+      "fg": [ "sewer_corner_nw", "sewer_corner_ne", "sewer_corner_se", "sewer_corner_sw" ],
+      "bg": [ "subway_corner_nw", "subway_corner_se", "subway_corner_se", "subway_corner_sw" ]
+    },
+    {
+      "id": "t_connection",
+      "fg": [ "sewer_t_connection_n", "sewer_t_connection_e", "sewer_t_connection_s", "sewer_t_connection_w" ],
+      "bg": [ "subway_t_connection_n", "subway_t_connection_e", "subway_t_connection_s", "subway_t_connection_w" ]
+    },
+    { "id": "edge", "fg": [ "sewer_edge_ns", "sewer_edge_ew" ], "bg": [ "subway_edge_ns", "subway_edge_ew" ] },
+    {
+      "id": "end_piece",
+      "fg": [ "sewer_end_piece_n", "sewer_end_piece_e", "sewer_end_piece_s", "sewer_end_piece_w" ],
+      "bg": [ "subway_end_piece_n", "subway_end_piece_e", "subway_end_piece_s", "subway_end_piece_w" ]
+    },
+    { "id": "unconnected", "fg": "sewer_unconnected", "bg": "subway_unconnected" }
+  ]
 }

--- a/gfx/Retrodays/pngs_tiles_10x10/terrain/t_fence_h_t_fence_v_t_fence_0.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/terrain/t_fence_h_t_fence_v_t_fence_0.json
@@ -1,39 +1,35 @@
 {
-  "id": ["t_fence_h", "t_fence_v", "t_fence"],
-  "fg": ["238_t_fence_h_0"],
+  "id": [
+    "t_fence_h",
+    "t_fence_v",
+    "t_fence"
+  ],
+  "fg": [
+    "238_t_fence_h_0"
+  ],
   "rotates": true,
   "multitile": true,
-  "additional_tiles":[
-    {
-      "id": "center",
-      "fg": ["239_t_fence_h_1"],
-      "bg": []
-    },
+  "additional_tiles": [
+    { "id": "center", "fg": [ "239_t_fence_h_1" ], "bg": [  ] },
     {
       "id": "corner",
-      "fg": ["240_t_fence_h_2", "241_t_fence_h_3", "242_t_fence_h_4", "238_t_fence_h_0"],
-      "bg": []
+      "fg": [ "240_t_fence_h_2", "238_t_fence_h_0", "242_t_fence_h_4", "241_t_fence_h_3" ],
+      "bg": [  ]
     },
-    {
-      "id": "edge",
-      "fg": ["243_t_fence_h_5", "244_t_fence_h_6", "243_t_fence_h_5", "244_t_fence_h_6"],
-      "bg": []
-    },
+    { "id": "edge", "fg": [ "243_t_fence_h_5", "244_t_fence_h_6", "243_t_fence_h_5", "244_t_fence_h_6" ], "bg": [  ] },
     {
       "id": "end_piece",
-      "fg": ["243_t_fence_h_5", "244_t_fence_h_6", "245_t_fence_h_7", "238_t_fence_h_0"],
-      "bg": []
+      "fg": [ "243_t_fence_h_5", "238_t_fence_h_0", "245_t_fence_h_7", "244_t_fence_h_6" ],
+      "bg": [  ]
     },
     {
       "id": "t_connection",
-      "fg": ["244_t_fence_h_6", "241_t_fence_h_3", "239_t_fence_h_1", "242_t_fence_h_4"],
-      "bg": []
+      "fg": [ "244_t_fence_h_6", "242_t_fence_h_4", "239_t_fence_h_1", "241_t_fence_h_3" ],
+      "bg": [  ]
     },
-    {
-      "id": "unconnected",
-      "fg": ["238_t_fence_h_0"],
-      "bg": []
-    }
+    { "id": "unconnected", "fg": [ "238_t_fence_h_0" ], "bg": [  ] }
   ],
-  "bg": []
+  "bg": [
+    
+  ]
 }

--- a/gfx/Retrodays/pngs_tiles_10x10/terrain/t_palisade_0.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/terrain/t_palisade_0.json
@@ -1,39 +1,19 @@
 {
   "id": "t_palisade",
-  "fg": ["t_palisade_0"],
+  "fg": [
+    "t_palisade_0"
+  ],
   "rotates": true,
   "multitile": true,
-  "additional_tiles":[
-    {
-      "id": "center",
-      "fg": ["t_palisade_8"],
-      "bg": []
-    },
-    {
-      "id": "corner",
-      "fg": ["t_palisade_7", "t_palisade_1", "t_palisade_2", "t_palisade_6"],
-      "bg": []
-    },
-    {
-      "id": "edge",
-      "fg": ["t_palisade_3", "t_palisade_4", "t_palisade_3", "t_palisade_4"],
-      "bg": []
-    },
-    {
-      "id": "end_piece",
-      "fg": ["t_palisade_3", "t_palisade_1", "t_palisade_5", "t_palisade_0"],
-      "bg": []
-    },
-    {
-      "id": "t_connection",
-      "fg": ["t_palisade_8", "t_palisade_7", "t_palisade_4", "t_palisade_6"],
-      "bg": []
-    },
-    {
-      "id": "unconnected",
-      "fg": ["t_palisade_5"],
-      "bg": []
-    }
+  "additional_tiles": [
+    { "id": "center", "fg": [ "t_palisade_8" ], "bg": [  ] },
+    { "id": "corner", "fg": [ "t_palisade_7", "t_palisade_6", "t_palisade_2", "t_palisade_1" ], "bg": [  ] },
+    { "id": "edge", "fg": [ "t_palisade_3", "t_palisade_4", "t_palisade_3", "t_palisade_4" ], "bg": [  ] },
+    { "id": "end_piece", "fg": [ "t_palisade_3", "t_palisade_0", "t_palisade_5", "t_palisade_1" ], "bg": [  ] },
+    { "id": "t_connection", "fg": [ "t_palisade_8", "t_palisade_6", "t_palisade_4", "t_palisade_7" ], "bg": [  ] },
+    { "id": "unconnected", "fg": [ "t_palisade_5" ], "bg": [  ] }
   ],
-  "bg": []
+  "bg": [
+    
+  ]
 }

--- a/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_chitin.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_chitin.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_chitin",
-  "fg": [ "vp_ram_chitin", "vp_ram_chitin_left", "vp_ram_chitin_down", "vp_ram_chitin_right" ],
+  "fg": "vp_ram_chitin",
   "rotates": true
 }

--- a/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_hardsteel.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_hardsteel.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_hardsteel",
-  "fg": [ "vp_ram_hardsteel", "vp_ram_hardsteel_left", "vp_ram_hardsteel_down", "vp_ram_hardsteel_right" ],
+  "fg": "vp_ram_hardsteel",
   "rotates": true
 }

--- a/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_military.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_military.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_military",
-  "fg": [ "vp_ram_military", "vp_ram_military_left", "vp_ram_military_down", "vp_ram_military_right" ],
+  "fg": "vp_ram_military",
   "rotates": true
 }

--- a/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_spiked.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_spiked.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_spiked",
-  "fg": [ "vp_ram_spiked", "vp_ram_spiked_left", "vp_ram_spiked_down", "vp_ram_spiked_right" ],
+  "fg": "vp_ram_spiked",
   "rotates": true
 }

--- a/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_steel.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_steel.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_steel",
-  "fg": [ "vp_ram_steel", "vp_ram_steel_left", "vp_ram_steel_down", "vp_ram_steel_right" ],
+  "fg": "vp_ram_steel",
   "rotates": true
 }

--- a/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_superalloy.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_superalloy.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_alloy",
-  "fg": [ "vp_ram_alloy", "vp_ram_alloy_left", "vp_ram_alloy_down", "vp_ram_alloy_right" ],
+  "fg": "vp_ram_alloy",
   "rotates": true
 }

--- a/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_wood.json
+++ b/gfx/Retrodays/pngs_tiles_10x10/vehicle_part/rams/vp_ram_wood.json
@@ -1,5 +1,5 @@
 {
   "id": "vp_ram_wood",
-  "fg": [ "vp_ram_wood", "vp_ram_wood_left", "vp_ram_wood_down", "vp_ram_wood_right" ],
+  "fg": "vp_ram_wood",
   "rotates": true
 }


### PR DESCRIPTION
#### Summary
Part of the tile rotation update PRs. Updates tile definitions to account for the fixes in https://github.com/CleverRaven/Cataclysm-DDA/pull/86335 and https://github.com/CleverRaven/Cataclysm-DDA/pull/86574

#### Content of the change
The dependent PR changed the tile drawing code to rotate tiles in the correct direction (clockwise instead of counter clockwise) and it will select tiles in an order opposite than it used to.
Every tile definition that defines all four rotations had to have indexes 1 and 3 swapped so the engine will select the correct tile to draw. 


#### Testing
Composed locally checked around for any obviously broken tiles. Attached is a save with a lot of testing material placed down in-game and on the overmap.
[Debug.tar.gz](https://github.com/user-attachments/files/26925717/Debug.tar.gz)


#### Additional information
Depends on https://github.com/CleverRaven/Cataclysm-DDA/pull/86574 being merged.