### PR TITLE
[MSX] Rotation Fixes

### DIFF
--- a/gfx/MShockXotto+/pngs_overmap_32x32/Campgrounds/Campgrounds.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/Campgrounds/Campgrounds.json
@@ -1,26 +1,26 @@
 [
-{
-  "id": "campground_1b",
-  "fg": [ "campground_1b_N", "campground_1b_W", "campground_1b_S", "campground_1b_E" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "campground_1a",
-  "fg": [ "campground_1a_N", "campground_1a_W", "campground_1a_S", "campground_1a_E" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "campground_2b",
-  "fg": [ "campground_2b_N", "campground_2b_W", "campground_2b_S", "campground_2b_E" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "campground_2a",
-  "fg": [ "campground_2a_N", "campground_2a_W", "campground_2a_S", "campground_2a_E" ],
-  "rotates": true,
-  "bg": [ ]
-}
+  {
+    "id": "campground_1b",
+    "fg": [ "campground_1b_N", "campground_1b_E", "campground_1b_S", "campground_1b_W" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "campground_1a",
+    "fg": [ "campground_1a_N", "campground_1a_E", "campground_1a_S", "campground_1a_W" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "campground_2b",
+    "fg": [ "campground_2b_N", "campground_2b_E", "campground_2b_S", "campground_2b_W" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "campground_2a",
+    "fg": [ "campground_2a_N", "campground_2a_E", "campground_2a_S", "campground_2a_W" ],
+    "rotates": true,
+    "bg": [  ]
+  }
 ]

--- a/gfx/MShockXotto+/pngs_overmap_32x32/Forest Trails/forest_trail.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/Forest Trails/forest_trail.json
@@ -3,50 +3,25 @@
   "fg": "forest_trail_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "forest_trail_center"
-    },
+    { "id": "center", "fg": "forest_trail_center" },
     {
       "id": "corner",
-      "fg": [
-        "forest_trail_corner_nw",
-        "forest_trail_corner_sw",
-        "forest_trail_corner_se",
-        "forest_trail_corner_ne"
-      ]
+      "fg": [ "forest_trail_corner_nw", "forest_trail_corner_ne", "forest_trail_corner_se", "forest_trail_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "forest_trail_t_connection_n",
-        "forest_trail_t_connection_w",
+        "forest_trail_t_connection_e",
         "forest_trail_t_connection_s",
-        "forest_trail_t_connection_e"
+        "forest_trail_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "forest_trail_edge_ns",
-        "forest_trail_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "forest_trail_edge_ns", "forest_trail_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "forest_trail_end_piece_n",
-        "forest_trail_end_piece_w",
-        "forest_trail_end_piece_s",
-        "forest_trail_end_piece_e"
-      ]
+      "fg": [ "forest_trail_end_piece_n", "forest_trail_end_piece_e", "forest_trail_end_piece_s", "forest_trail_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "forest_trail_unconnected",
-        "forest_trail_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "forest_trail_unconnected", "forest_trail_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_overmap_32x32/Houses/house_duplex.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/Houses/house_duplex.json
@@ -13,7 +13,7 @@
       "house_duplex8",
       "house_duplex9"
     ],
-    "fg": [ "house_duplex_north", "house_duplex_west", "house_duplex_south", "house_duplex_east" ],
+    "fg": [ "house_duplex_north", "house_duplex_east", "house_duplex_south", "house_duplex_west" ],
     "bg": [  ],
     "rotates": true
   },
@@ -31,7 +31,7 @@
       "house_duplex8_roof",
       "house_duplex9_roof"
     ],
-    "fg": [ "house_duplex_roof_north", "house_duplex_roof_west", "house_duplex_roof_south", "house_duplex_roof_east" ],
+    "fg": [ "house_duplex_roof_north", "house_duplex_roof_east", "house_duplex_roof_south", "house_duplex_roof_west" ],
     "bg": [  ],
     "rotates": true
   }

--- a/gfx/MShockXotto+/pngs_overmap_32x32/Houses/house_garage.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/Houses/house_garage.json
@@ -10,7 +10,7 @@
       "house_garage7",
       "house_garage8"
     ],
-    "fg": [ "house_garage_N", "house_garage_W", "house_garage_S", "house_garage_E" ],
+    "fg": [ "house_garage_N", "house_garage_E", "house_garage_S", "house_garage_W" ],
     "bg": [  ],
     "rotates": true
   },
@@ -25,7 +25,7 @@
       "house_garage7_roof",
       "house_garage8_roof"
     ],
-    "fg": [ "house_garage_roof_N", "house_garage_roof_W", "house_garage_roof_S", "house_garage_roof_E" ],
+    "fg": [ "house_garage_roof_N", "house_garage_roof_E", "house_garage_roof_S", "house_garage_roof_W" ],
     "bg": [  ],
     "rotates": true
   }

--- a/gfx/MShockXotto+/pngs_overmap_32x32/Houses/single_house.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/Houses/single_house.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "generic_city_house", "generic_city_house_no_sidewalk" ],
-    "fg": [ "single_houseN", "single_houseW", "single_houseS", "single_houseE" ],
+    "fg": [ "single_houseN", "single_houseE", "single_houseS", "single_houseW" ],
     "bg": [  ],
     "rotates": true
   },
@@ -73,7 +73,7 @@
       "urban_18_10",
       "2farm_11"
     ],
-    "fg": [ "single_house_roofN", "single_house_roofW", "single_house_roofS", "single_house_roofE" ],
+    "fg": [ "single_house_roofN", "single_house_roofE", "single_house_roofS", "single_house_roofW" ],
     "bg": [  ],
     "rotates": true
   }

--- a/gfx/MShockXotto+/pngs_overmap_32x32/Icecream/icecream.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/Icecream/icecream.json
@@ -1,14 +1,8 @@
-[{
-  "id": "icecream_shop",
-  "fg": [
-    "icecream_shop_N",
-    "icecream_shop_W",
-    "icecream_shop_S",
-    "icecream_shop_E"
-  ],
-  "rotates": true,
-  "bg": [
-    
-  ]
-}
+[
+  {
+    "id": "icecream_shop",
+    "fg": [ "icecream_shop_N", "icecream_shop_E", "icecream_shop_S", "icecream_shop_W" ],
+    "rotates": true,
+    "bg": [  ]
+  }
 ]

--- a/gfx/MShockXotto+/pngs_overmap_32x32/Prison/prison.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/Prison/prison.json
@@ -1,56 +1,56 @@
 [
-{
-  "id": "prison_1_1",
-  "fg": [ "prison_1_1_N", "prison_1_1_W", "prison_1_1_S", "prison_1_1_E" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "prison_1_2",
-  "fg": [ "prison_1_2_N", "prison_1_2_W", "prison_1_2_S", "prison_1_2_E" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "prison_1_3",
-  "fg": [ "prison_1_3_N", "prison_1_3_W", "prison_1_3_S", "prison_1_3_E" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "prison_1_4",
-  "fg": [ "prison_1_4_N", "prison_1_4_W", "prison_1_4_S", "prison_1_4_E" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "prison_1_5",
-  "fg": [ "prison_1_5_N", "prison_1_5_W", "prison_1_5_S", "prison_1_5_E" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "prison_1_6",
-  "fg": [ "prison_1_6_N", "prison_1_6_W", "prison_1_6_S", "prison_1_6_E" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "prison_1_7",
-  "fg": [ "prison_1_7_N", "prison_1_7_W", "prison_1_7_S", "prison_1_7_E" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "prison_1_8",
-  "fg": [ "prison_1_8_N", "prison_1_8_W", "prison_1_8_S", "prison_1_8_E" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "prison_1_9",
-  "fg": [ "prison_1_9_N", "prison_1_9_W", "prison_1_9_S", "prison_1_9_E" ],
-  "rotates": true,
-  "bg": [ ]
-}
+  {
+    "id": "prison_1_1",
+    "fg": [ "prison_1_1_N", "prison_1_1_E", "prison_1_1_S", "prison_1_1_W" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "prison_1_2",
+    "fg": [ "prison_1_2_N", "prison_1_2_E", "prison_1_2_S", "prison_1_2_W" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "prison_1_3",
+    "fg": [ "prison_1_3_N", "prison_1_3_E", "prison_1_3_S", "prison_1_3_W" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "prison_1_4",
+    "fg": [ "prison_1_4_N", "prison_1_4_E", "prison_1_4_S", "prison_1_4_W" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "prison_1_5",
+    "fg": [ "prison_1_5_N", "prison_1_5_E", "prison_1_5_S", "prison_1_5_W" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "prison_1_6",
+    "fg": [ "prison_1_6_N", "prison_1_6_E", "prison_1_6_S", "prison_1_6_W" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "prison_1_7",
+    "fg": [ "prison_1_7_N", "prison_1_7_E", "prison_1_7_S", "prison_1_7_W" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "prison_1_8",
+    "fg": [ "prison_1_8_N", "prison_1_8_E", "prison_1_8_S", "prison_1_8_W" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "prison_1_9",
+    "fg": [ "prison_1_9_N", "prison_1_9_E", "prison_1_9_S", "prison_1_9_W" ],
+    "rotates": true,
+    "bg": [  ]
+  }
 ]

--- a/gfx/MShockXotto+/pngs_overmap_32x32/PublicPond/PublicPond.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/PublicPond/PublicPond.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "PublicPond_1a" ],
-    "fg": [ "PublicPond_1a_north", "PublicPond_1a_west", "PublicPond_1a_south", "PublicPond_1a_east" ],
+    "fg": [ "PublicPond_1a_north", "PublicPond_1a_east", "PublicPond_1a_south", "PublicPond_1a_west" ],
     "bg": [  ],
     "rotates": true
   },
   {
     "id": [ "PublicPond_1b" ],
-    "fg": [ "PublicPond_1b_north", "PublicPond_1b_west", "PublicPond_1b_south", "PublicPond_1b_east" ],
+    "fg": [ "PublicPond_1b_north", "PublicPond_1b_east", "PublicPond_1b_south", "PublicPond_1b_west" ],
     "bg": [  ],
     "rotates": true
   }

--- a/gfx/MShockXotto+/pngs_overmap_32x32/Roads/road.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/Roads/road.json
@@ -5,13 +5,13 @@
     "multitile": true,
     "additional_tiles": [
       { "id": "center", "fg": "road_center" },
-      { "id": "corner", "fg": [ "road_corner_nw", "road_corner_sw", "road_corner_se", "road_corner_ne" ] },
+      { "id": "corner", "fg": [ "road_corner_nw", "road_corner_ne", "road_corner_se", "road_corner_sw" ] },
       {
         "id": "t_connection",
-        "fg": [ "road_t_connection_n", "road_t_connection_w", "road_t_connection_s", "road_t_connection_e" ]
+        "fg": [ "road_t_connection_n", "road_t_connection_e", "road_t_connection_s", "road_t_connection_w" ]
       },
       { "id": "edge", "fg": [ "road_edge_ns", "road_edge_ew" ] },
-      { "id": "end_piece", "fg": [ "road_end_piece_n", "road_end_piece_w", "road_end_piece_s", "road_end_piece_e" ] },
+      { "id": "end_piece", "fg": [ "road_end_piece_n", "road_end_piece_e", "road_end_piece_s", "road_end_piece_w" ] },
       { "id": "unconnected", "fg": [ "road_unconnected", "road_unconnected" ] }
     ]
   }

--- a/gfx/MShockXotto+/pngs_overmap_32x32/cabin_lapin/cabin_lapin.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/cabin_lapin/cabin_lapin.json
@@ -1,14 +1,8 @@
-[{
-  "id": "cabin_lapin",
-  "fg": [
-    "cabin_lapin_north",
-    "cabin_lapin_west",
-    "cabin_lapin_south",
-    "cabin_lapin_east"
-  ],
-  "rotates": true,
-  "bg": [
-    
-  ]
-}
+[
+  {
+    "id": "cabin_lapin",
+    "fg": [ "cabin_lapin_north", "cabin_lapin_east", "cabin_lapin_south", "cabin_lapin_west" ],
+    "rotates": true,
+    "bg": [  ]
+  }
 ]

--- a/gfx/MShockXotto+/pngs_overmap_32x32/cemetery_small/cemetery_small.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/cemetery_small/cemetery_small.json
@@ -1,14 +1,8 @@
-[{
-  "id": "cemetery_small",
-  "fg": [
-    "cemetery_small_N",
-    "cemetery_small_W",
-    "cemetery_small_S",
-    "cemetery_small_E"
-  ],
-  "rotates": true,
-  "bg": [
-    
-  ]
-}
+[
+  {
+    "id": "cemetery_small",
+    "fg": [ "cemetery_small_N", "cemetery_small_E", "cemetery_small_S", "cemetery_small_W" ],
+    "rotates": true,
+    "bg": [  ]
+  }
 ]

--- a/gfx/MShockXotto+/pngs_overmap_32x32/dirt_road_forest/rural_road.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/dirt_road_forest/rural_road.json
@@ -1,52 +1,25 @@
 {
-  "id": [ "rural_road", "rural_road_forest" ],
+  "id": [
+    "rural_road",
+    "rural_road_forest"
+  ],
   "fg": "rural_road_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "rural_road_center"
-    },
+    { "id": "center", "fg": "rural_road_center" },
     {
       "id": "corner",
-      "fg": [
-        "rural_road_corner_nw",
-        "rural_road_corner_sw",
-        "rural_road_corner_se",
-        "rural_road_corner_ne"
-      ]
+      "fg": [ "rural_road_corner_nw", "rural_road_corner_ne", "rural_road_corner_se", "rural_road_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "rural_road_t_connection_n",
-        "rural_road_t_connection_w",
-        "rural_road_t_connection_s",
-        "rural_road_t_connection_e"
-      ]
+      "fg": [ "rural_road_t_connection_n", "rural_road_t_connection_e", "rural_road_t_connection_s", "rural_road_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "rural_road_edge_ns",
-        "rural_road_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "rural_road_edge_ns", "rural_road_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "rural_road_end_piece_s",
-        "rural_road_end_piece_e",
-        "rural_road_end_piece_n",
-        "rural_road_end_piece_w"
-      ]
+      "fg": [ "rural_road_end_piece_n", "rural_road_end_piece_e", "rural_road_end_piece_s", "rural_road_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "rural_road_unconnected",
-        "rural_road_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "rural_road_unconnected", "rural_road_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_overmap_32x32/pavilion/pavilion.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/pavilion/pavilion.json
@@ -1,7 +1,7 @@
 [
   {
-    "id": ["pavilion", "pavilion_1"],
-    "fg": [ "pavilion_north","pavilion_west","pavilion_south","pavilion_east" ],
+    "id": [ "pavilion", "pavilion_1" ],
+    "fg": [ "pavilion_north", "pavilion_east", "pavilion_south", "pavilion_west" ],
     "rotates": true,
     "bg": [  ]
   }

--- a/gfx/MShockXotto+/pngs_overmap_32x32/pool/pool.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/pool/pool.json
@@ -1,13 +1,13 @@
 [
   {
-    "id": ["pool_1","pool_2","pool_3","pool_4","pool_5","pool_6"],
+    "id": [ "pool_1", "pool_2", "pool_3", "pool_4", "pool_5", "pool_6" ],
     "fg": [ "pool_5" ],
     "rotates": true,
     "bg": [  ]
   },
   {
     "id": "pool",
-    "fg": [ "pool_north","pool_west","pool_south","pool_east" ],
+    "fg": [ "pool_north", "pool_east", "pool_south", "pool_west" ],
     "rotates": true,
     "bg": [  ]
   }

--- a/gfx/MShockXotto+/pngs_overmap_32x32/s_baseballfield/s_baseballfield.json
+++ b/gfx/MShockXotto+/pngs_overmap_32x32/s_baseballfield/s_baseballfield.json
@@ -1,26 +1,26 @@
 [
-{
-  "id": "s_baseballfield_a1",
-  "fg": [ "s_baseballfield_a1", "s_baseballfield_a2", "s_baseballfield_b2", "s_baseballfield_b1" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "s_baseballfield_a2",
-  "fg": [ "s_baseballfield_a2", "s_baseballfield_b2", "s_baseballfield_b1", "s_baseballfield_a1" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "s_baseballfield_b1",
-  "fg": [ "s_baseballfield_b1", "s_baseballfield_a1", "s_baseballfield_a2", "s_baseballfield_b2" ],
-  "rotates": true,
-  "bg": [ ]
-},
-{
-  "id": "s_baseballfield_b2",
-  "fg": [ "s_baseballfield_b2", "s_baseballfield_b1", "s_baseballfield_a1", "s_baseballfield_a2" ],
-  "rotates": true,
-  "bg": [ ]
-}
+  {
+    "id": "s_baseballfield_a1",
+    "fg": [ "s_baseballfield_a1" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "s_baseballfield_a2",
+    "fg": [ "s_baseballfield_a2" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "s_baseballfield_b1",
+    "fg": [ "s_baseballfield_b1" ],
+    "rotates": true,
+    "bg": [  ]
+  },
+  {
+    "id": "s_baseballfield_b2",
+    "fg": [ "s_baseballfield_b2" ],
+    "rotates": true,
+    "bg": [  ]
+  }
 ]

--- a/gfx/MShockXotto+/pngs_tall_32x48/furniture/big_portable_freezer/big_portable_freezer.json
+++ b/gfx/MShockXotto+/pngs_tall_32x48/furniture/big_portable_freezer/big_portable_freezer.json
@@ -1,6 +1,14 @@
 {
-  "id": [ "f_big_portable_freezer", "vp_ap_big_portable_freezer" ],
+  "id": [
+    "f_big_portable_freezer",
+    "vp_ap_big_portable_freezer"
+  ],
   "rotates": true,
-  "fg": ["big_portable_freezer_S", "big_portable_freezer_W", "big_portable_freezer_N", "big_portable_freezer_E"],
+  "fg": [
+    "big_portable_freezer_S",
+    "big_portable_freezer_E",
+    "big_portable_freezer_N",
+    "big_portable_freezer_W"
+  ],
   "bg": ""
-} 
+}

--- a/gfx/MShockXotto+/pngs_tall_32x48/furniture/f_fridge/f_fridge.json
+++ b/gfx/MShockXotto+/pngs_tall_32x48/furniture/f_fridge/f_fridge.json
@@ -1,6 +1,14 @@
 {
-  "id": [ "f_fridge", "vp_ap_fridge" ],
+  "id": [
+    "f_fridge",
+    "vp_ap_fridge"
+  ],
   "rotates": true,
-  "fg": ["f_fridge", "f_fridge_W", "f_fridge_N", "f_fridge_E"],
+  "fg": [
+    "f_fridge",
+    "f_fridge_E",
+    "f_fridge_N",
+    "f_fridge_W"
+  ],
   "bg": ""
 }

--- a/gfx/MShockXotto+/pngs_tall_32x48/furniture/heavy_duty_freezer/heavy_duty_freezer.json
+++ b/gfx/MShockXotto+/pngs_tall_32x48/furniture/heavy_duty_freezer/heavy_duty_freezer.json
@@ -1,6 +1,14 @@
 {
-  "id": [ "f_heavy_duty_freezer", "vp_ap_heavy_duty_freezer" ],
+  "id": [
+    "f_heavy_duty_freezer",
+    "vp_ap_heavy_duty_freezer"
+  ],
   "rotates": true,
-  "fg": ["heavy_duty_freezer_S", "heavy_duty_freezer_W", "heavy_duty_freezer_N", "heavy_duty_freezer_E"],
+  "fg": [
+    "heavy_duty_freezer_S",
+    "heavy_duty_freezer_E",
+    "heavy_duty_freezer_N",
+    "heavy_duty_freezer_W"
+  ],
   "bg": ""
 }

--- a/gfx/MShockXotto+/pngs_tall_32x48/terrain/t_grass_alien/t_grass_alien.json
+++ b/gfx/MShockXotto+/pngs_tall_32x48/terrain/t_grass_alien/t_grass_alien.json
@@ -8,23 +8,18 @@
       { "id": "center", "fg": "t_grass_alien_edge_ew", "bg": "t_grass_tall" },
       {
         "id": "corner",
-        "fg": [ "t_grass_alien_end_piece_w", "t_grass_alien_end_piece_w", "t_grass_alien_end_piece_e", "t_grass_alien_end_piece_e" ],
+        "fg": [ "t_grass_alien_end_piece_w", "t_grass_alien_end_piece_e", "t_grass_alien_end_piece_e", "t_grass_alien_end_piece_w" ],
         "bg": "t_grass_tall"
       },
       {
         "id": "t_connection",
-        "fg": [ "t_grass_alien_edge_ew", "t_grass_alien_end_piece_w", "t_grass_alien_edge_ew", "t_grass_alien_end_piece_e" ],
+        "fg": [ "t_grass_alien_edge_ew", "t_grass_alien_end_piece_e", "t_grass_alien_edge_ew", "t_grass_alien_end_piece_w" ],
         "bg": "t_grass_tall"
       },
       { "id": "edge", "fg": [ "t_grass_alien_unconnected", "t_grass_alien_edge_ew" ], "bg": "t_grass_tall" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_grass_alien_unconnected",
-          "t_grass_alien_end_piece_w",
-          "t_grass_alien_unconnected",
-          "t_grass_alien_end_piece_e"
-        ],
+        "fg": [ "t_grass_alien_unconnected", "t_grass_alien_end_piece_e", "t_grass_alien_unconnected", "t_grass_alien_end_piece_w" ],
         "bg": "t_grass_tall"
       },
       {
@@ -43,23 +38,18 @@
       { "id": "center", "fg": "t_grass_alien_edge_ew", "bg": "t_grass_autumn_tall" },
       {
         "id": "corner",
-        "fg": [ "t_grass_alien_end_piece_w", "t_grass_alien_end_piece_w", "t_grass_alien_end_piece_e", "t_grass_alien_end_piece_e" ],
+        "fg": [ "t_grass_alien_end_piece_w", "t_grass_alien_end_piece_e", "t_grass_alien_end_piece_e", "t_grass_alien_end_piece_w" ],
         "bg": "t_grass_autumn_tall"
       },
       {
         "id": "t_connection",
-        "fg": [ "t_grass_alien_edge_ew", "t_grass_alien_end_piece_w", "t_grass_alien_edge_ew", "t_grass_alien_end_piece_e" ],
+        "fg": [ "t_grass_alien_edge_ew", "t_grass_alien_end_piece_e", "t_grass_alien_edge_ew", "t_grass_alien_end_piece_w" ],
         "bg": "t_grass_autumn_tall"
       },
       { "id": "edge", "fg": [ "t_grass_alien_unconnected", "t_grass_alien_edge_ew" ], "bg": "t_grass_autumn_tall" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_grass_alien_unconnected",
-          "t_grass_alien_end_piece_w",
-          "t_grass_alien_unconnected",
-          "t_grass_alien_end_piece_e"
-        ],
+        "fg": [ "t_grass_alien_unconnected", "t_grass_alien_end_piece_e", "t_grass_alien_unconnected", "t_grass_alien_end_piece_w" ],
         "bg": "t_grass_autumn_tall"
       },
       {
@@ -78,23 +68,18 @@
       { "id": "center", "fg": "t_grass_alien_unconnected", "bg": "t_grass_summer_tall" },
       {
         "id": "corner",
-        "fg": [ "t_grass_alien_end_piece_w", "t_grass_alien_end_piece_w", "t_grass_alien_end_piece_e", "t_grass_alien_end_piece_e" ],
+        "fg": [ "t_grass_alien_end_piece_w", "t_grass_alien_end_piece_e", "t_grass_alien_end_piece_e", "t_grass_alien_end_piece_w" ],
         "bg": "t_grass_summer_tall"
       },
       {
         "id": "t_connection",
-        "fg": [ "t_grass_alien_edge_ew", "t_grass_alien_end_piece_w", "t_grass_alien_edge_ew", "t_grass_alien_end_piece_e" ],
+        "fg": [ "t_grass_alien_edge_ew", "t_grass_alien_end_piece_e", "t_grass_alien_edge_ew", "t_grass_alien_end_piece_w" ],
         "bg": "t_grass_summer_tall"
       },
       { "id": "edge", "fg": [ "t_grass_alien_unconnected", "t_grass_alien_edge_ew" ], "bg": "t_grass_summer_tall" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_grass_alien_unconnected",
-          "t_grass_alien_end_piece_w",
-          "t_grass_alien_unconnected",
-          "t_grass_alien_end_piece_e"
-        ],
+        "fg": [ "t_grass_alien_unconnected", "t_grass_alien_end_piece_e", "t_grass_alien_unconnected", "t_grass_alien_end_piece_w" ],
         "bg": "t_grass_summer_tall"
       },
       {
@@ -113,23 +98,18 @@
       { "id": "center", "fg": "t_grass_alien_unconnected", "bg": "t_grass_winter_tall" },
       {
         "id": "corner",
-        "fg": [ "t_grass_alien_end_piece_w", "t_grass_alien_end_piece_w", "t_grass_alien_end_piece_e", "t_grass_alien_end_piece_e" ],
+        "fg": [ "t_grass_alien_end_piece_w", "t_grass_alien_end_piece_e", "t_grass_alien_end_piece_e", "t_grass_alien_end_piece_w" ],
         "bg": "t_grass_winter_tall"
       },
       {
         "id": "t_connection",
-        "fg": [ "t_grass_alien_edge_ew", "t_grass_alien_end_piece_w", "t_grass_alien_edge_ew", "t_grass_alien_end_piece_e" ],
+        "fg": [ "t_grass_alien_edge_ew", "t_grass_alien_end_piece_e", "t_grass_alien_edge_ew", "t_grass_alien_end_piece_w" ],
         "bg": "t_grass_winter_tall"
       },
       { "id": "edge", "fg": [ "t_grass_alien_unconnected", "t_grass_alien_edge_ew" ], "bg": "t_grass_winter_tall" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_grass_alien_unconnected",
-          "t_grass_alien_end_piece_w",
-          "t_grass_alien_unconnected",
-          "t_grass_alien_end_piece_e"
-        ],
+        "fg": [ "t_grass_alien_unconnected", "t_grass_alien_end_piece_e", "t_grass_alien_unconnected", "t_grass_alien_end_piece_w" ],
         "bg": "t_grass_winter_tall"
       },
       {

--- a/gfx/MShockXotto+/pngs_tall_32x48/terrain/t_privacy_fence/t_privacy_fence.json
+++ b/gfx/MShockXotto+/pngs_tall_32x48/terrain/t_privacy_fence/t_privacy_fence.json
@@ -8,7 +8,7 @@
       { "id": "center", "fg": "t_privacy_fence_unconnected", "bg": "t_grass_tall" },
       {
         "id": "corner",
-        "fg": [ "t_privacy_fence_corner_nw", "t_privacy_fence_corner_sw", "t_privacy_fence_corner_se", "t_privacy_fence_corner_ne" ],
+        "fg": [ "t_privacy_fence_corner_nw", "t_privacy_fence_corner_ne", "t_privacy_fence_corner_se", "t_privacy_fence_corner_sw" ],
         "bg": "t_grass_tall"
       },
       {
@@ -21,9 +21,9 @@
         "id": "end_piece",
         "fg": [
           "t_privacy_fence_end_piece_n",
-          "t_privacy_fence_end_piece_w",
+          "t_privacy_fence_end_piece_e",
           "t_privacy_fence_end_piece_s",
-          "t_privacy_fence_end_piece_e"
+          "t_privacy_fence_end_piece_w"
         ],
         "bg": "t_grass_tall"
       },
@@ -43,7 +43,7 @@
       { "id": "center", "fg": "t_privacy_fence_unconnected", "bg": "t_grass_autumn_tall" },
       {
         "id": "corner",
-        "fg": [ "t_privacy_fence_corner_nw", "t_privacy_fence_corner_sw", "t_privacy_fence_corner_se", "t_privacy_fence_corner_ne" ],
+        "fg": [ "t_privacy_fence_corner_nw", "t_privacy_fence_corner_ne", "t_privacy_fence_corner_se", "t_privacy_fence_corner_sw" ],
         "bg": "t_grass_autumn_tall"
       },
       {
@@ -56,9 +56,9 @@
         "id": "end_piece",
         "fg": [
           "t_privacy_fence_end_piece_n",
-          "t_privacy_fence_end_piece_w",
+          "t_privacy_fence_end_piece_e",
           "t_privacy_fence_end_piece_s",
-          "t_privacy_fence_end_piece_e"
+          "t_privacy_fence_end_piece_w"
         ],
         "bg": "t_grass_autumn_tall"
       },
@@ -78,7 +78,7 @@
       { "id": "center", "fg": "t_privacy_fence_unconnected", "bg": "t_grass_summer_tall" },
       {
         "id": "corner",
-        "fg": [ "t_privacy_fence_corner_nw", "t_privacy_fence_corner_sw", "t_privacy_fence_corner_se", "t_privacy_fence_corner_ne" ],
+        "fg": [ "t_privacy_fence_corner_nw", "t_privacy_fence_corner_ne", "t_privacy_fence_corner_se", "t_privacy_fence_corner_sw" ],
         "bg": "t_grass_summer_tall"
       },
       {
@@ -91,9 +91,9 @@
         "id": "end_piece",
         "fg": [
           "t_privacy_fence_end_piece_n",
-          "t_privacy_fence_end_piece_w",
+          "t_privacy_fence_end_piece_e",
           "t_privacy_fence_end_piece_s",
-          "t_privacy_fence_end_piece_e"
+          "t_privacy_fence_end_piece_w"
         ],
         "bg": "t_grass_summer_tall"
       },
@@ -113,7 +113,7 @@
       { "id": "center", "fg": "t_privacy_fence_unconnected", "bg": "t_grass_winter_tall" },
       {
         "id": "corner",
-        "fg": [ "t_privacy_fence_corner_nw", "t_privacy_fence_corner_sw", "t_privacy_fence_corner_se", "t_privacy_fence_corner_ne" ],
+        "fg": [ "t_privacy_fence_corner_nw", "t_privacy_fence_corner_ne", "t_privacy_fence_corner_se", "t_privacy_fence_corner_sw" ],
         "bg": "t_grass_winter_tall"
       },
       {
@@ -126,9 +126,9 @@
         "id": "end_piece",
         "fg": [
           "t_privacy_fence_end_piece_n",
-          "t_privacy_fence_end_piece_w",
+          "t_privacy_fence_end_piece_e",
           "t_privacy_fence_end_piece_s",
-          "t_privacy_fence_end_piece_e"
+          "t_privacy_fence_end_piece_w"
         ],
         "bg": "t_grass_winter_tall"
       },

--- a/gfx/MShockXotto+/pngs_tall_32x48/vehicle/boards/cloth/vp_clothboard_ne_edge.json
+++ b/gfx/MShockXotto+/pngs_tall_32x48/vehicle/boards/cloth/vp_clothboard_ne_edge.json
@@ -1,47 +1,27 @@
 [
   {
     "id": [ "vp_clothboard_ne_edge" ],
-    "fg": [
-      "vp_clothboard_ne_edge",
-      "vp_clothboard_ne_edge_rotW",
-      "vp_clothboard_ne_edge_rotS",
-      "vp_clothboard_ne_edge_rotE"
-    ],
+    "fg": [ "vp_clothboard_ne_edge", "vp_clothboard_ne_edge_rotE", "vp_clothboard_ne_edge_rotS", "vp_clothboard_ne_edge_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
-        "fg": [
-      "vp_clothboard_ne_edge",
-      "vp_clothboard_ne_edge_rotW",
-      "vp_clothboard_ne_edge_rotS",
-      "vp_clothboard_ne_edge_rotE"
-    ]
+        "fg": [ "vp_clothboard_ne_edge", "vp_clothboard_ne_edge_rotE", "vp_clothboard_ne_edge_rotS", "vp_clothboard_ne_edge_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_clothboard_nw_edge" ],
-    "fg": [
-      "vp_clothboard_nw_edge",
-      "vp_clothboard_nw_edge_rotW",
-      "vp_clothboard_nw_edge_rotS",
-      "vp_clothboard_nw_edge_rotE"
-    ],
+    "fg": [ "vp_clothboard_nw_edge", "vp_clothboard_nw_edge_rotE", "vp_clothboard_nw_edge_rotS", "vp_clothboard_nw_edge_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
-        "fg": [
-      "vp_clothboard_nw_edge",
-      "vp_clothboard_nw_edge_rotW",
-      "vp_clothboard_nw_edge_rotS",
-      "vp_clothboard_nw_edge_rotE"
-    ]
+        "fg": [ "vp_clothboard_nw_edge", "vp_clothboard_nw_edge_rotE", "vp_clothboard_nw_edge_rotS", "vp_clothboard_nw_edge_rotW" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tall_32x48/vehicle/doors/vp_door_sides.json
+++ b/gfx/MShockXotto+/pngs_tall_32x48/vehicle/doors/vp_door_sides.json
@@ -1,39 +1,47 @@
 [
   {
-    "id": [ "vp_door_right", "vp_door_vertical_right", "vp_door_sliding", "vp_door_se", "vp_door_rear_right","vp_door_ne", "vp_door_front_right" ],
-    "fg": [ "vp_door_R", "vp_door_R_rotW", "vp_door_R_rotS", "vp_door_R_rotE" ],
+    "id": [
+      "vp_door_right",
+      "vp_door_vertical_right",
+      "vp_door_sliding",
+      "vp_door_se",
+      "vp_door_rear_right",
+      "vp_door_ne",
+      "vp_door_front_right"
+    ],
+    "fg": [ "vp_door_R", "vp_door_R_rotE", "vp_door_R_rotS", "vp_door_R_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_right_open_rotN", "vp_door_right_open_rotW", "vp_door_right_open_rotS", "vp_door_right_open_rotE" ],
+        "fg": [ "vp_door_right_open_rotN", "vp_door_right_open_rotE", "vp_door_right_open_rotS", "vp_door_right_open_rotW" ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_door_R", "vp_door_R_rotW", "vp_door_R_rotS", "vp_door_R_rotE" ]
+        "bg": [ "vp_door_R", "vp_door_R_rotE", "vp_door_R_rotS", "vp_door_R_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_door_left", "vp_door_vertical_left", "vp_door_nw", "vp_door_front_left", "vp_door_sw", "vp_door_rear_left" ],
-    "fg": [ "vp_door_L", "vp_door_L_rotW", "vp_door_L_rotS", "vp_door_L_rotE" ],
+    "fg": [ "vp_door_L", "vp_door_L_rotE", "vp_door_L_rotS", "vp_door_L_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_left_open_rotN", "vp_door_left_open_rotW", "vp_door_left_open_rotS", "vp_door_left_open_rotE" ],
+        "fg": [ "vp_door_left_open_rotN", "vp_door_left_open_rotE", "vp_door_left_open_rotS", "vp_door_left_open_rotW" ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_door_L", "vp_door_L_rotW", "vp_door_L_rotS", "vp_door_L_rotE" ]
+        "bg": [ "vp_door_L", "vp_door_L_rotE", "vp_door_L_rotS", "vp_door_L_rotW" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tall_32x48/vehicle/doors/vp_door_trunk.json
+++ b/gfx/MShockXotto+/pngs_tall_32x48/vehicle/doors/vp_door_trunk.json
@@ -2,9 +2,9 @@
   "id": "vp_door_trunk",
   "fg": [
     "vp_door_trunk",
-    "vp_door_trunk_rotW",
+    "vp_door_trunk_rotE",
     "vp_door_trunk_rotS",
-    "vp_door_trunk_rotE"
+    "vp_door_trunk_rotW"
   ],
   "bg": [
     
@@ -14,13 +14,13 @@
   "additional_tiles": [
     {
       "id": "open",
-      "fg": [ "vp_door_trunk_open", "vp_door_trunk_open_rotW", "vp_door_trunk_open_rotS", "vp_door_trunk_open_rotE" ],
+      "fg": [ "vp_door_trunk_open", "vp_door_trunk_open_rotE", "vp_door_trunk_open_rotS", "vp_door_trunk_open_rotW" ],
       "bg": [  ]
     },
     {
       "id": "broken",
       "fg": [ "3987_vp_cargo_space_2" ],
-      "bg": [ "vp_door_trunk", "vp_door_trunk_rotW", "vp_door_trunk_rotS", "vp_door_trunk_rotE" ]
+      "bg": [ "vp_door_trunk", "vp_door_trunk_rotE", "vp_door_trunk_rotS", "vp_door_trunk_rotW" ]
     }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tall_32x48/vehicle/freezers/vp_big_portable_freezer/vp_big_portable_freezer.json
+++ b/gfx/MShockXotto+/pngs_tall_32x48/vehicle/freezers/vp_big_portable_freezer/vp_big_portable_freezer.json
@@ -1,15 +1,15 @@
-[  
+[
   {
     "id": [ "vp_big_portable_freezer" ],
     "rotates": true,
-    "fg": [ "vp_big_portable_freezer_S", "vp_big_portable_freezer_E", "vp_big_portable_freezer_W", "vp_big_portable_freezer_N" ],
+    "fg": [ "vp_big_portable_freezer_N", "vp_big_portable_freezer_E", "vp_big_portable_freezer_S", "vp_big_portable_freezer_W" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_big_portable_freezer_S", "vp_big_portable_freezer_E", "vp_big_portable_freezer_W", "vp_big_portable_freezer_N" ]
+        "bg": [ "vp_big_portable_freezer_N", "vp_big_portable_freezer_E", "vp_big_portable_freezer_S", "vp_big_portable_freezer_W" ]
       }
     ]
   }
-] 
+]

--- a/gfx/MShockXotto+/pngs_tall_32x48/vehicle/motorcycle/motorcycle_handle.json
+++ b/gfx/MShockXotto+/pngs_tall_32x48/vehicle/motorcycle/motorcycle_handle.json
@@ -1,13 +1,13 @@
 [
   {
     "id": "vp_frame_handle",
-    "fg": [ "handle_motor_rotN", "handle_motor_rotW", "handle_motor_rotS", "handle_motor_rotE" ],
+    "fg": [ "handle_motor_rotN", "handle_motor_rotE", "handle_motor_rotS", "handle_motor_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
-        "bg": [ "handle_motor_rotN", "handle_motor_rotW", "handle_motor_rotS", "handle_motor_rotE" ]
+        "bg": [ "handle_motor_rotN", "handle_motor_rotE", "handle_motor_rotS", "handle_motor_rotW" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/appliances/vp_ap_apartment_freezer/vp_ap_apartment_freezer.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/appliances/vp_ap_apartment_freezer/vp_ap_apartment_freezer.json
@@ -3,8 +3,8 @@
   "rotates": true,
   "fg": [
     "vp_ap_apartment_freezer_S",
-    "vp_ap_apartment_freezer_W",
+    "vp_ap_apartment_freezer_E",
     "vp_ap_apartment_freezer_N",
-    "vp_ap_apartment_freezer_E"
+    "vp_ap_apartment_freezer_W"
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/field/fd_acid/fd_acid.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/field/fd_acid/fd_acid.json
@@ -23,35 +23,35 @@
       "fg": [
         {
           "weight": 8,
-          "sprite": [ "fd_acid_0_corner_nw", "fd_acid_0_corner_sw", "fd_acid_0_corner_se", "fd_acid_0_corner_ne" ]
+          "sprite": [ "fd_acid_0_corner_nw", "fd_acid_0_corner_ne", "fd_acid_0_corner_se", "fd_acid_0_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_1_corner_nw", "fd_acid_1_corner_sw", "fd_acid_1_corner_se", "fd_acid_1_corner_ne" ]
+          "sprite": [ "fd_acid_1_corner_nw", "fd_acid_1_corner_ne", "fd_acid_1_corner_se", "fd_acid_1_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_2_corner_nw", "fd_acid_2_corner_sw", "fd_acid_2_corner_se", "fd_acid_2_corner_ne" ]
+          "sprite": [ "fd_acid_2_corner_nw", "fd_acid_2_corner_ne", "fd_acid_2_corner_se", "fd_acid_2_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_3_corner_nw", "fd_acid_3_corner_sw", "fd_acid_3_corner_se", "fd_acid_3_corner_ne" ]
+          "sprite": [ "fd_acid_3_corner_nw", "fd_acid_3_corner_ne", "fd_acid_3_corner_se", "fd_acid_3_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_4_corner_nw", "fd_acid_4_corner_sw", "fd_acid_4_corner_se", "fd_acid_4_corner_ne" ]
+          "sprite": [ "fd_acid_4_corner_nw", "fd_acid_4_corner_ne", "fd_acid_4_corner_se", "fd_acid_4_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_5_corner_nw", "fd_acid_5_corner_sw", "fd_acid_5_corner_se", "fd_acid_5_corner_ne" ]
+          "sprite": [ "fd_acid_5_corner_nw", "fd_acid_5_corner_ne", "fd_acid_5_corner_se", "fd_acid_5_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_6_corner_nw", "fd_acid_6_corner_sw", "fd_acid_6_corner_se", "fd_acid_6_corner_ne" ]
+          "sprite": [ "fd_acid_6_corner_nw", "fd_acid_6_corner_ne", "fd_acid_6_corner_se", "fd_acid_6_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_7_corner_nw", "fd_acid_7_corner_sw", "fd_acid_7_corner_se", "fd_acid_7_corner_ne" ]
+          "sprite": [ "fd_acid_7_corner_nw", "fd_acid_7_corner_ne", "fd_acid_7_corner_se", "fd_acid_7_corner_sw" ]
         }
       ]
     },
@@ -61,35 +61,35 @@
       "fg": [
         {
           "weight": 8,
-          "sprite": [ "fd_acid_0_t_connection_n", "fd_acid_0_t_connection_w", "fd_acid_0_t_connection_s", "fd_acid_0_t_connection_e" ]
+          "sprite": [ "fd_acid_0_t_connection_n", "fd_acid_0_t_connection_e", "fd_acid_0_t_connection_s", "fd_acid_0_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_1_t_connection_n", "fd_acid_1_t_connection_w", "fd_acid_1_t_connection_s", "fd_acid_1_t_connection_e" ]
+          "sprite": [ "fd_acid_1_t_connection_n", "fd_acid_1_t_connection_e", "fd_acid_1_t_connection_s", "fd_acid_1_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_2_t_connection_n", "fd_acid_2_t_connection_w", "fd_acid_2_t_connection_s", "fd_acid_2_t_connection_e" ]
+          "sprite": [ "fd_acid_2_t_connection_n", "fd_acid_2_t_connection_e", "fd_acid_2_t_connection_s", "fd_acid_2_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_3_t_connection_n", "fd_acid_3_t_connection_w", "fd_acid_3_t_connection_s", "fd_acid_3_t_connection_e" ]
+          "sprite": [ "fd_acid_3_t_connection_n", "fd_acid_3_t_connection_e", "fd_acid_3_t_connection_s", "fd_acid_3_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_4_t_connection_n", "fd_acid_4_t_connection_w", "fd_acid_4_t_connection_s", "fd_acid_4_t_connection_e" ]
+          "sprite": [ "fd_acid_4_t_connection_n", "fd_acid_4_t_connection_e", "fd_acid_4_t_connection_s", "fd_acid_4_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_5_t_connection_n", "fd_acid_5_t_connection_w", "fd_acid_5_t_connection_s", "fd_acid_5_t_connection_e" ]
+          "sprite": [ "fd_acid_5_t_connection_n", "fd_acid_5_t_connection_e", "fd_acid_5_t_connection_s", "fd_acid_5_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_6_t_connection_n", "fd_acid_6_t_connection_w", "fd_acid_6_t_connection_s", "fd_acid_6_t_connection_e" ]
+          "sprite": [ "fd_acid_6_t_connection_n", "fd_acid_6_t_connection_e", "fd_acid_6_t_connection_s", "fd_acid_6_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_7_t_connection_n", "fd_acid_7_t_connection_w", "fd_acid_7_t_connection_s", "fd_acid_7_t_connection_e" ]
+          "sprite": [ "fd_acid_7_t_connection_n", "fd_acid_7_t_connection_e", "fd_acid_7_t_connection_s", "fd_acid_7_t_connection_w" ]
         }
       ]
     },
@@ -113,35 +113,35 @@
       "fg": [
         {
           "weight": 8,
-          "sprite": [ "fd_acid_0_end_piece_n", "fd_acid_0_end_piece_w", "fd_acid_0_end_piece_s", "fd_acid_0_end_piece_e" ]
+          "sprite": [ "fd_acid_0_end_piece_n", "fd_acid_0_end_piece_e", "fd_acid_0_end_piece_s", "fd_acid_0_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_1_end_piece_n", "fd_acid_1_end_piece_w", "fd_acid_1_end_piece_s", "fd_acid_1_end_piece_e" ]
+          "sprite": [ "fd_acid_1_end_piece_n", "fd_acid_1_end_piece_e", "fd_acid_1_end_piece_s", "fd_acid_1_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_2_end_piece_n", "fd_acid_2_end_piece_w", "fd_acid_2_end_piece_s", "fd_acid_2_end_piece_e" ]
+          "sprite": [ "fd_acid_2_end_piece_n", "fd_acid_2_end_piece_e", "fd_acid_2_end_piece_s", "fd_acid_2_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_3_end_piece_n", "fd_acid_3_end_piece_w", "fd_acid_3_end_piece_s", "fd_acid_3_end_piece_e" ]
+          "sprite": [ "fd_acid_3_end_piece_n", "fd_acid_3_end_piece_e", "fd_acid_3_end_piece_s", "fd_acid_3_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_4_end_piece_n", "fd_acid_4_end_piece_w", "fd_acid_4_end_piece_s", "fd_acid_4_end_piece_e" ]
+          "sprite": [ "fd_acid_4_end_piece_n", "fd_acid_4_end_piece_e", "fd_acid_4_end_piece_s", "fd_acid_4_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_5_end_piece_n", "fd_acid_5_end_piece_w", "fd_acid_5_end_piece_s", "fd_acid_5_end_piece_e" ]
+          "sprite": [ "fd_acid_5_end_piece_n", "fd_acid_5_end_piece_e", "fd_acid_5_end_piece_s", "fd_acid_5_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_6_end_piece_n", "fd_acid_6_end_piece_w", "fd_acid_6_end_piece_s", "fd_acid_6_end_piece_e" ]
+          "sprite": [ "fd_acid_6_end_piece_n", "fd_acid_6_end_piece_e", "fd_acid_6_end_piece_s", "fd_acid_6_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_7_end_piece_n", "fd_acid_7_end_piece_w", "fd_acid_7_end_piece_s", "fd_acid_7_end_piece_e" ]
+          "sprite": [ "fd_acid_7_end_piece_n", "fd_acid_7_end_piece_e", "fd_acid_7_end_piece_s", "fd_acid_7_end_piece_w" ]
         }
       ]
     },

--- a/gfx/MShockXotto+/pngs_tiles_32x32/field/fd_dust/fd_dust.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/field/fd_dust/fd_dust.json
@@ -3,50 +3,17 @@
   "fg": "fd_dust_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "fd_dust_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "fd_dust_corner_nw",
-        "fd_dust_corner_sw",
-        "fd_dust_corner_se",
-        "fd_dust_corner_ne"
-      ]
-    },
+    { "id": "center", "fg": "fd_dust_center" },
+    { "id": "corner", "fg": [ "fd_dust_corner_nw", "fd_dust_corner_ne", "fd_dust_corner_se", "fd_dust_corner_sw" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "fd_dust_t_connection_n",
-        "fd_dust_t_connection_w",
-        "fd_dust_t_connection_s",
-        "fd_dust_t_connection_e"
-      ]
+      "fg": [ "fd_dust_t_connection_n", "fd_dust_t_connection_e", "fd_dust_t_connection_s", "fd_dust_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "fd_dust_edge_ns",
-        "fd_dust_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "fd_dust_edge_ns", "fd_dust_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "fd_dust_end_piece_n",
-        "fd_dust_end_piece_w",
-        "fd_dust_end_piece_s",
-        "fd_dust_end_piece_e"
-      ]
+      "fg": [ "fd_dust_end_piece_n", "fd_dust_end_piece_e", "fd_dust_end_piece_s", "fd_dust_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "fd_dust_unconnected",
-        "fd_dust_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "fd_dust_unconnected", "fd_dust_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/field/fd_splinters/fd_splinters.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/field/fd_splinters/fd_splinters.json
@@ -3,50 +3,25 @@
   "fg": "fd_splinters_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "fd_splinters_center"
-    },
+    { "id": "center", "fg": "fd_splinters_center" },
     {
       "id": "corner",
-      "fg": [
-        "fd_splinters_corner_nw",
-        "fd_splinters_corner_sw",
-        "fd_splinters_corner_se",
-        "fd_splinters_corner_ne"
-      ]
+      "fg": [ "fd_splinters_corner_nw", "fd_splinters_corner_ne", "fd_splinters_corner_se", "fd_splinters_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "fd_splinters_t_connection_n",
-        "fd_splinters_t_connection_w",
+        "fd_splinters_t_connection_e",
         "fd_splinters_t_connection_s",
-        "fd_splinters_t_connection_e"
+        "fd_splinters_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "fd_splinters_edge_ns",
-        "fd_splinters_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "fd_splinters_edge_ns", "fd_splinters_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "fd_splinters_end_piece_n",
-        "fd_splinters_end_piece_w",
-        "fd_splinters_end_piece_s",
-        "fd_splinters_end_piece_e"
-      ]
+      "fg": [ "fd_splinters_end_piece_n", "fd_splinters_end_piece_e", "fd_splinters_end_piece_s", "fd_splinters_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "fd_splinters_unconnected",
-        "fd_splinters_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "fd_splinters_unconnected", "fd_splinters_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/Counter/f_counter.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/Counter/f_counter.json
@@ -6,16 +6,16 @@
     { "id": "center", "fg": "f_counter_center" },
     {
       "id": "corner",
-      "fg": [ "f_counter_corner_nw", "f_counter_corner_sw", "f_counter_corner_se", "f_counter_corner_ne" ]
+      "fg": [ "f_counter_corner_nw", "f_counter_corner_ne", "f_counter_corner_se", "f_counter_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [ "f_counter_t_connection_n", "f_counter_t_connection_w", "f_counter_t_connection_s", "f_counter_t_connection_e" ]
+      "fg": [ "f_counter_t_connection_n", "f_counter_t_connection_e", "f_counter_t_connection_s", "f_counter_t_connection_w" ]
     },
     { "id": "edge", "fg": [ "f_counter_edge_ns", "f_counter_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [ "f_counter_end_piece_n", "f_counter_end_piece_w", "f_counter_end_piece_s", "f_counter_end_piece_e" ]
+      "fg": [ "f_counter_end_piece_n", "f_counter_end_piece_e", "f_counter_end_piece_s", "f_counter_end_piece_w" ]
     },
     { "id": "unconnected", "fg": [ "f_counter_unconnected", "f_counter_unconnected" ] }
   ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/Cupboard/f_cupboard.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/Cupboard/f_cupboard.json
@@ -3,50 +3,20 @@
   "fg": "f_cupboard_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_cupboard_center"
-    },
+    { "id": "center", "fg": "f_cupboard_center" },
     {
       "id": "corner",
-      "fg": [
-        "f_cupboard_corner_nw",
-        "f_cupboard_corner_sw",
-        "f_cupboard_corner_se",
-        "f_cupboard_corner_ne"
-      ]
+      "fg": [ "f_cupboard_corner_nw", "f_cupboard_corner_ne", "f_cupboard_corner_se", "f_cupboard_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "f_cupboard_t_connection_n",
-        "f_cupboard_t_connection_w",
-        "f_cupboard_t_connection_s",
-        "f_cupboard_t_connection_e"
-      ]
+      "fg": [ "f_cupboard_t_connection_n", "f_cupboard_t_connection_e", "f_cupboard_t_connection_s", "f_cupboard_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_cupboard_edge_ns",
-        "f_cupboard_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_cupboard_edge_ns", "f_cupboard_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "f_cupboard_end_piece_n",
-        "f_cupboard_end_piece_w",
-        "f_cupboard_end_piece_s",
-        "f_cupboard_end_piece_e"
-      ]
+      "fg": [ "f_cupboard_end_piece_n", "f_cupboard_end_piece_e", "f_cupboard_end_piece_s", "f_cupboard_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_cupboard_unconnected",
-        "f_cupboard_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_cupboard_unconnected", "f_cupboard_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/chest_minifreezer/chest_minifreezer.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/chest_minifreezer/chest_minifreezer.json
@@ -1,6 +1,14 @@
 {
-  "id": [ "f_chest_minifreezer", "vp_ap_chest_minifreezer" ],
+  "id": [
+    "f_chest_minifreezer",
+    "vp_ap_chest_minifreezer"
+  ],
   "rotates": true,
-  "fg": ["chest_minifreezer_S", "chest_minifreezer_W", "chest_minifreezer_N", "chest_minifreezer_E"],
+  "fg": [
+    "chest_minifreezer_S",
+    "chest_minifreezer_E",
+    "chest_minifreezer_N",
+    "chest_minifreezer_W"
+  ],
   "bg": ""
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_absence/f_absence.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_absence/f_absence.json
@@ -3,50 +3,20 @@
   "fg": "f_absence_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_absence_center"
-    },
+    { "id": "center", "fg": "f_absence_center" },
     {
       "id": "corner",
-      "fg": [
-        "f_absence_corner_nw",
-        "f_absence_corner_sw",
-        "f_absence_corner_se",
-        "f_absence_corner_ne"
-      ]
+      "fg": [ "f_absence_corner_nw", "f_absence_corner_ne", "f_absence_corner_se", "f_absence_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "f_absence_t_connection_n",
-        "f_absence_t_connection_w",
-        "f_absence_t_connection_s",
-        "f_absence_t_connection_e"
-      ]
+      "fg": [ "f_absence_t_connection_n", "f_absence_t_connection_e", "f_absence_t_connection_s", "f_absence_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_absence_edge_ns",
-        "f_absence_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_absence_edge_ns", "f_absence_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "f_absence_end_piece_n",
-        "f_absence_end_piece_w",
-        "f_absence_end_piece_s",
-        "f_absence_end_piece_e"
-      ]
+      "fg": [ "f_absence_end_piece_n", "f_absence_end_piece_e", "f_absence_end_piece_s", "f_absence_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_absence_unconnected",
-        "f_absence_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_absence_unconnected", "f_absence_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_alien_table/f_alien_table.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_alien_table/f_alien_table.json
@@ -4,56 +4,28 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_alien_table_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "f_alien_table_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "f_alien_table_corner_nw",
-        "f_alien_table_corner_sw",
-        "f_alien_table_corner_se",
-        "f_alien_table_corner_ne"
-      ],
+      "fg": [ "f_alien_table_corner_nw", "f_alien_table_corner_ne", "f_alien_table_corner_se", "f_alien_table_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
       "fg": [
         "f_alien_table_t_connection_n",
-        "f_alien_table_t_connection_w",
+        "f_alien_table_t_connection_e",
         "f_alien_table_t_connection_s",
-        "f_alien_table_t_connection_e"
+        "f_alien_table_t_connection_w"
       ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_alien_table_edge_ns",
-        "f_alien_table_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "f_alien_table_edge_ns", "f_alien_table_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "f_alien_table_end_piece_n",
-        "f_alien_table_end_piece_w",
-        "f_alien_table_end_piece_s",
-        "f_alien_table_end_piece_e"
-      ],
+      "fg": [ "f_alien_table_end_piece_n", "f_alien_table_end_piece_e", "f_alien_table_end_piece_s", "f_alien_table_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_alien_table_unconnected",
-        "f_alien_table_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "f_alien_table_unconnected", "f_alien_table_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_bed_frame/bed_frame.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_bed_frame/bed_frame.json
@@ -4,56 +4,28 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_bed_frame_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "f_bed_frame_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "f_bed_frame_corner_nw",
-        "f_bed_frame_corner_sw",
-        "f_bed_frame_corner_se",
-        "f_bed_frame_corner_ne"
-      ],
+      "fg": [ "f_bed_frame_corner_nw", "f_bed_frame_corner_ne", "f_bed_frame_corner_se", "f_bed_frame_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
       "fg": [
         "f_bed_frame_t_connection_n",
-        "f_bed_frame_t_connection_w",
+        "f_bed_frame_t_connection_e",
         "f_bed_frame_t_connection_s",
-        "f_bed_frame_t_connection_e"
+        "f_bed_frame_t_connection_w"
       ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_bed_frame_edge_ns",
-        "f_bed_frame_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "f_bed_frame_edge_ns", "f_bed_frame_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "f_bed_frame_end_piece_n",
-        "f_bed_frame_end_piece_w",
-        "f_bed_frame_end_piece_s",
-        "f_bed_frame_end_piece_e"
-      ],
+      "fg": [ "f_bed_frame_end_piece_n", "f_bed_frame_end_piece_e", "f_bed_frame_end_piece_s", "f_bed_frame_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_bed_frame_unconnected",
-        "f_bed_frame_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "f_bed_frame_unconnected", "f_bed_frame_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_bench/f_bench.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_bench/f_bench.json
@@ -3,50 +3,17 @@
   "fg": "f_bench_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_bench_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "f_bench_corner_nw",
-        "f_bench_corner_sw",
-        "f_bench_corner_se",
-        "f_bench_corner_ne"
-      ]
-    },
+    { "id": "center", "fg": "f_bench_center" },
+    { "id": "corner", "fg": [ "f_bench_corner_nw", "f_bench_corner_ne", "f_bench_corner_se", "f_bench_corner_sw" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "f_bench_t_connection_n",
-        "f_bench_t_connection_w",
-        "f_bench_t_connection_s",
-        "f_bench_t_connection_e"
-      ]
+      "fg": [ "f_bench_t_connection_n", "f_bench_t_connection_e", "f_bench_t_connection_s", "f_bench_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_bench_edge_ns",
-        "f_bench_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_bench_edge_ns", "f_bench_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "f_bench_end_piece_n",
-        "f_bench_end_piece_w",
-        "f_bench_end_piece_s",
-        "f_bench_end_piece_e"
-      ]
+      "fg": [ "f_bench_end_piece_n", "f_bench_end_piece_e", "f_bench_end_piece_s", "f_bench_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_bench_unconnected",
-        "f_bench_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_bench_unconnected", "f_bench_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_bike_rack/f_bike_rack.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_bike_rack/f_bike_rack.json
@@ -7,7 +7,7 @@
       { "id": "edge", "fg": [ "f_bike_rack_edge_ns", "f_bike_rack_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [ "f_bike_rack_end_piece_n", "f_bike_rack_end_piece_w", "f_bike_rack_end_piece_s", "f_bike_rack_end_piece_e" ]
+        "fg": [ "f_bike_rack_end_piece_n", "f_bike_rack_end_piece_e", "f_bike_rack_end_piece_s", "f_bike_rack_end_piece_w" ]
       },
       { "id": "unconnected", "fg": [ "f_bike_rack_unconnected" ] }
     ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_canvas_wall/f_canvas_wall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_canvas_wall/f_canvas_wall.json
@@ -3,50 +3,20 @@
   "fg": "f_canvas_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_canvas_wall_unconnected"
-    },
+    { "id": "center", "fg": "f_canvas_wall_unconnected" },
     {
       "id": "corner",
-      "fg": [
-        "f_canvas_wall_corner_nw",
-        "f_canvas_wall_corner_sw",
-        "f_canvas_wall_corner_se",
-        "f_canvas_wall_corner_ne"
-      ]
+      "fg": [ "f_canvas_wall_corner_nw", "f_canvas_wall_corner_ne", "f_canvas_wall_corner_se", "f_canvas_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "f_canvas_wall_edge_ew",
-        "f_canvas_wall_edge_ns",
-        "f_canvas_wall_edge_ew",
-        "f_canvas_wall_edge_ns"
-      ]
+      "fg": [ "f_canvas_wall_edge_ew", "f_canvas_wall_edge_ns", "f_canvas_wall_edge_ew", "f_canvas_wall_edge_ns" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_canvas_wall_edge_ns",
-        "f_canvas_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_canvas_wall_edge_ns", "f_canvas_wall_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "f_canvas_wall_end_piece_n",
-        "f_canvas_wall_end_piece_w",
-        "f_canvas_wall_end_piece_s",
-        "f_canvas_wall_end_piece_e"
-      ]
+      "fg": [ "f_canvas_wall_end_piece_n", "f_canvas_wall_end_piece_e", "f_canvas_wall_end_piece_s", "f_canvas_wall_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_canvas_wall_unconnected",
-        "f_canvas_wall_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_canvas_wall_unconnected", "f_canvas_wall_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_curtain/f_curtain.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_curtain/f_curtain.json
@@ -4,56 +4,23 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_curtain_unconnected",
-      "bg": ""
-    },
+    { "id": "center", "fg": "f_curtain_unconnected", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "f_curtain_corner_nw",
-        "f_curtain_corner_sw",
-        "f_curtain_corner_se",
-        "f_curtain_corner_ne"
-      ],
+      "fg": [ "f_curtain_corner_nw", "f_curtain_corner_ne", "f_curtain_corner_se", "f_curtain_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
-      "fg": [
-        "f_curtain_t_connection_n",
-        "f_curtain_t_connection_w",
-        "f_curtain_t_connection_s",
-        "f_curtain_t_connection_e"
-      ],
+      "fg": [ "f_curtain_t_connection_n", "f_curtain_t_connection_e", "f_curtain_t_connection_s", "f_curtain_t_connection_w" ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_curtain_edge_ns",
-        "f_curtain_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "f_curtain_edge_ns", "f_curtain_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "f_curtain_end_piece_n",
-        "f_curtain_end_piece_w",
-        "f_curtain_end_piece_s",
-        "f_curtain_end_piece_e"
-      ],
+      "fg": [ "f_curtain_end_piece_n", "f_curtain_end_piece_e", "f_curtain_end_piece_s", "f_curtain_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_curtain_unconnected",
-        "f_curtain_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "f_curtain_unconnected", "f_curtain_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_desk/f_desk.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_desk/f_desk.json
@@ -3,50 +3,14 @@
   "fg": "f_desk_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_desk_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "f_desk_corner_nw",
-        "f_desk_corner_sw",
-        "f_desk_corner_se",
-        "f_desk_corner_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "f_desk_t_connection_n",
-        "f_desk_edge_ns",
-        "f_desk_edge_ew",
-        "f_desk_edge_ns"
-      ]
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "f_desk_edge_ns",
-        "f_desk_edge_ew"
-      ]
-    },
+    { "id": "center", "fg": "f_desk_center" },
+    { "id": "corner", "fg": [ "f_desk_corner_nw", "f_desk_corner_ne", "f_desk_corner_se", "f_desk_corner_sw" ] },
+    { "id": "t_connection", "fg": [ "f_desk_t_connection_n", "f_desk_edge_ns", "f_desk_edge_ew", "f_desk_edge_ns" ] },
+    { "id": "edge", "fg": [ "f_desk_edge_ns", "f_desk_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "f_desk_end_piece_n",
-        "f_desk_end_piece_w",
-        "f_desk_end_piece_s",
-        "f_desk_end_piece_e"
-      ]
+      "fg": [ "f_desk_end_piece_n", "f_desk_end_piece_e", "f_desk_end_piece_s", "f_desk_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_desk_unconnected",
-        "f_desk_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_desk_unconnected", "f_desk_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_filiing_cabinet/f_filing_cabinet.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_filiing_cabinet/f_filing_cabinet.json
@@ -1,6 +1,11 @@
 {
   "id": "f_filing_cabinet",
   "rotates": true,
-  "fg": ["f_filing_cabinet", "f_filing_cabinet_W", "f_filing_cabinet_N", "f_filing_cabinet_E"],
+  "fg": [
+    "f_filing_cabinet",
+    "f_filing_cabinet_E",
+    "f_filing_cabinet_N",
+    "f_filing_cabinet_W"
+  ],
   "bg": ""
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_gravel_mound_mid/f_gravel_mound_mid.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_gravel_mound_mid/f_gravel_mound_mid.json
@@ -3,50 +3,35 @@
   "fg": "f_gravel_mound_mid_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_gravel_mound_mid_center"
-    },
+    { "id": "center", "fg": "f_gravel_mound_mid_center" },
     {
       "id": "corner",
       "fg": [
         "f_gravel_mound_mid_corner_nw",
-        "f_gravel_mound_mid_corner_sw",
+        "f_gravel_mound_mid_corner_ne",
         "f_gravel_mound_mid_corner_se",
-        "f_gravel_mound_mid_corner_ne"
+        "f_gravel_mound_mid_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_gravel_mound_mid_t_connection_n",
-        "f_gravel_mound_mid_t_connection_w",
+        "f_gravel_mound_mid_t_connection_e",
         "f_gravel_mound_mid_t_connection_s",
-        "f_gravel_mound_mid_t_connection_e"
+        "f_gravel_mound_mid_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_gravel_mound_mid_edge_ns",
-        "f_gravel_mound_mid_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_gravel_mound_mid_edge_ns", "f_gravel_mound_mid_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_gravel_mound_mid_end_piece_n",
-        "f_gravel_mound_mid_end_piece_w",
+        "f_gravel_mound_mid_end_piece_e",
         "f_gravel_mound_mid_end_piece_s",
-        "f_gravel_mound_mid_end_piece_e"
+        "f_gravel_mound_mid_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_gravel_mound_mid_unconnected",
-        "f_gravel_mound_mid_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_gravel_mound_mid_unconnected", "f_gravel_mound_mid_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_gravel_mound_short/f_gravel_mound_short.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_gravel_mound_short/f_gravel_mound_short.json
@@ -3,50 +3,35 @@
   "fg": "f_gravel_mound_short_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_gravel_mound_short_center"
-    },
+    { "id": "center", "fg": "f_gravel_mound_short_center" },
     {
       "id": "corner",
       "fg": [
         "f_gravel_mound_short_corner_nw",
-        "f_gravel_mound_short_corner_sw",
+        "f_gravel_mound_short_corner_ne",
         "f_gravel_mound_short_corner_se",
-        "f_gravel_mound_short_corner_ne"
+        "f_gravel_mound_short_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_gravel_mound_short_t_connection_n",
-        "f_gravel_mound_short_t_connection_w",
+        "f_gravel_mound_short_t_connection_e",
         "f_gravel_mound_short_t_connection_s",
-        "f_gravel_mound_short_t_connection_e"
+        "f_gravel_mound_short_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_gravel_mound_short_edge_ns",
-        "f_gravel_mound_short_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_gravel_mound_short_edge_ns", "f_gravel_mound_short_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_gravel_mound_short_end_piece_n",
-        "f_gravel_mound_short_end_piece_w",
+        "f_gravel_mound_short_end_piece_e",
         "f_gravel_mound_short_end_piece_s",
-        "f_gravel_mound_short_end_piece_e"
+        "f_gravel_mound_short_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_gravel_mound_short_unconnected",
-        "f_gravel_mound_short_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_gravel_mound_short_unconnected", "f_gravel_mound_short_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_gravel_mound_tall/f_gravel_mound_tall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_gravel_mound_tall/f_gravel_mound_tall.json
@@ -3,50 +3,35 @@
   "fg": "f_gravel_mound_tall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_gravel_mound_tall_center"
-    },
+    { "id": "center", "fg": "f_gravel_mound_tall_center" },
     {
       "id": "corner",
       "fg": [
         "f_gravel_mound_tall_corner_nw",
-        "f_gravel_mound_tall_corner_sw",
+        "f_gravel_mound_tall_corner_ne",
         "f_gravel_mound_tall_corner_se",
-        "f_gravel_mound_tall_corner_ne"
+        "f_gravel_mound_tall_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_gravel_mound_tall_t_connection_n",
-        "f_gravel_mound_tall_t_connection_w",
+        "f_gravel_mound_tall_t_connection_e",
         "f_gravel_mound_tall_t_connection_s",
-        "f_gravel_mound_tall_t_connection_e"
+        "f_gravel_mound_tall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_gravel_mound_tall_edge_ns",
-        "f_gravel_mound_tall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_gravel_mound_tall_edge_ns", "f_gravel_mound_tall_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_gravel_mound_tall_end_piece_n",
-        "f_gravel_mound_tall_end_piece_w",
+        "f_gravel_mound_tall_end_piece_e",
         "f_gravel_mound_tall_end_piece_s",
-        "f_gravel_mound_tall_end_piece_e"
+        "f_gravel_mound_tall_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_gravel_mound_tall_unconnected",
-        "f_gravel_mound_tall_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_gravel_mound_tall_unconnected", "f_gravel_mound_tall_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_hedge_short/f_hedge_short.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_hedge_short/f_hedge_short.json
@@ -4,53 +4,19 @@
   "fg": "f_hedge_short",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_hedge_short"
-    },
+    { "id": "center", "bg": "", "fg": "f_hedge_short" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_hedge_short_nw",
-        "f_hedge_short_sw",
-        "f_hedge_short_se",
-        "f_hedge_short_ne"
-      ]
+      "fg": [ "f_hedge_short_nw", "f_hedge_short_ne", "f_hedge_short_se", "f_hedge_short_sw" ]
     },
-    {
-      "id": "t_connection",
-      "bg": "",
-      "fg": [
-        "f_hedge_short",
-        "f_hedge_short",
-        "f_hedge_short",
-        "f_hedge_short"
-      ]
-    },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_hedge_short_ns",
-        "f_hedge_short"
-      ]
-    },
+    { "id": "t_connection", "bg": "", "fg": [ "f_hedge_short", "f_hedge_short", "f_hedge_short", "f_hedge_short" ] },
+    { "id": "edge", "bg": "", "fg": [ "f_hedge_short_ns", "f_hedge_short" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_hedge_short_n",
-        "f_hedge_short_w",
-        "f_hedge_short_s",
-        "f_hedge_short_e"
-      ]
+      "fg": [ "f_hedge_short_n", "f_hedge_short_e", "f_hedge_short_s", "f_hedge_short_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_hedge_short",  "f_hedge_short" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_hedge_short", "f_hedge_short" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_hedge_tall/f_hedge_tall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_hedge_tall/f_hedge_tall.json
@@ -4,53 +4,11 @@
   "fg": "f_hedge_tall",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_hedge_tall"
-    },
-    {
-      "id": "corner",
-      "bg": "",
-      "fg": [
-        "f_hedge_tall_nw",
-        "f_hedge_tall_sw",
-        "f_hedge_tall_se",
-        "f_hedge_tall_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "bg": "",
-      "fg": [
-        "f_hedge_tall",
-        "f_hedge_tall",
-        "f_hedge_tall",
-        "f_hedge_tall"
-      ]
-    },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_hedge_tall_ns",
-        "f_hedge_tall"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "bg": "",
-      "fg": [
-        "f_hedge_tall_n",
-        "f_hedge_tall_w",
-        "f_hedge_tall_s",
-        "f_hedge_tall_e"
-      ]
-    },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_hedge_tall",  "f_hedge_tall" ]
-    }
+    { "id": "center", "bg": "", "fg": "f_hedge_tall" },
+    { "id": "corner", "bg": "", "fg": [ "f_hedge_tall_nw", "f_hedge_tall_ne", "f_hedge_tall_se", "f_hedge_tall_sw" ] },
+    { "id": "t_connection", "bg": "", "fg": [ "f_hedge_tall", "f_hedge_tall", "f_hedge_tall", "f_hedge_tall" ] },
+    { "id": "edge", "bg": "", "fg": [ "f_hedge_tall_ns", "f_hedge_tall" ] },
+    { "id": "end_piece", "bg": "", "fg": [ "f_hedge_tall_n", "f_hedge_tall_e", "f_hedge_tall_s", "f_hedge_tall_w" ] },
+    { "bg": "", "id": "unconnected", "fg": [ "f_hedge_tall", "f_hedge_tall" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_large_canvas_wall/f_large_canvas_wall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_large_canvas_wall/f_large_canvas_wall.json
@@ -3,17 +3,14 @@
   "fg": "f_large_canvas_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_large_canvas_wall_unconnected"
-    },
+    { "id": "center", "fg": "f_large_canvas_wall_unconnected" },
     {
       "id": "corner",
       "fg": [
         "f_large_canvas_wall_corner_nw",
-        "f_large_canvas_wall_corner_sw",
+        "f_large_canvas_wall_corner_ne",
         "f_large_canvas_wall_corner_se",
-        "f_large_canvas_wall_corner_ne"
+        "f_large_canvas_wall_corner_sw"
       ]
     },
     {
@@ -25,28 +22,16 @@
         "f_large_canvas_wall_edge_ns"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_large_canvas_wall_edge_ns",
-        "f_large_canvas_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_large_canvas_wall_edge_ns", "f_large_canvas_wall_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_large_canvas_wall_end_piece_n",
-        "f_large_canvas_wall_end_piece_w",
+        "f_large_canvas_wall_end_piece_e",
         "f_large_canvas_wall_end_piece_s",
-        "f_large_canvas_wall_end_piece_e"
+        "f_large_canvas_wall_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_large_canvas_wall_unconnected",
-        "f_large_canvas_wall_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_large_canvas_wall_unconnected", "f_large_canvas_wall_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_metal_bench/f_metal_bench.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_metal_bench/f_metal_bench.json
@@ -3,50 +3,25 @@
   "fg": "f_metal_bench_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_metal_bench_center"
-    },
+    { "id": "center", "fg": "f_metal_bench_center" },
     {
       "id": "corner",
-      "fg": [
-        "f_metal_bench_corner_nw",
-        "f_metal_bench_corner_sw",
-        "f_metal_bench_corner_se",
-        "f_metal_bench_corner_ne"
-      ]
+      "fg": [ "f_metal_bench_corner_nw", "f_metal_bench_corner_ne", "f_metal_bench_corner_se", "f_metal_bench_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_metal_bench_t_connection_n",
-        "f_metal_bench_t_connection_w",
+        "f_metal_bench_t_connection_e",
         "f_metal_bench_t_connection_s",
-        "f_metal_bench_t_connection_e"
+        "f_metal_bench_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_metal_bench_edge_ns",
-        "f_metal_bench_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_metal_bench_edge_ns", "f_metal_bench_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "f_metal_bench_end_piece_n",
-        "f_metal_bench_end_piece_w",
-        "f_metal_bench_end_piece_s",
-        "f_metal_bench_end_piece_e"
-      ]
+      "fg": [ "f_metal_bench_end_piece_n", "f_metal_bench_end_piece_e", "f_metal_bench_end_piece_s", "f_metal_bench_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_metal_bench_unconnected",
-        "f_metal_bench_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_metal_bench_unconnected", "f_metal_bench_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_metal_table/f_metal_table.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_metal_table/f_metal_table.json
@@ -3,50 +3,25 @@
   "fg": "f_metal_table_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_metal_table_center"
-    },
+    { "id": "center", "fg": "f_metal_table_center" },
     {
       "id": "corner",
-      "fg": [
-        "f_metal_table_corner_nw",
-        "f_metal_table_corner_sw",
-        "f_metal_table_corner_se",
-        "f_metal_table_corner_ne"
-      ]
+      "fg": [ "f_metal_table_corner_nw", "f_metal_table_corner_ne", "f_metal_table_corner_se", "f_metal_table_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_metal_table_t_connection_n",
-        "f_metal_table_t_connection_w",
+        "f_metal_table_t_connection_e",
         "f_metal_table_t_connection_s",
-        "f_metal_table_t_connection_e"
+        "f_metal_table_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_metal_table_edge_ns",
-        "f_metal_table_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_metal_table_edge_ns", "f_metal_table_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "f_metal_table_end_piece_n",
-        "f_metal_table_end_piece_w",
-        "f_metal_table_end_piece_s",
-        "f_metal_table_end_piece_e"
-      ]
+      "fg": [ "f_metal_table_end_piece_n", "f_metal_table_end_piece_e", "f_metal_table_end_piece_s", "f_metal_table_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_metal_table_unconnected",
-        "f_metal_table_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_metal_table_unconnected", "f_metal_table_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_sand_mound_mid/f_sand_mound_mid.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_sand_mound_mid/f_sand_mound_mid.json
@@ -3,50 +3,35 @@
   "fg": "f_sand_mound_mid_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_sand_mound_mid_center"
-    },
+    { "id": "center", "fg": "f_sand_mound_mid_center" },
     {
       "id": "corner",
       "fg": [
         "f_sand_mound_mid_corner_nw",
-        "f_sand_mound_mid_corner_sw",
+        "f_sand_mound_mid_corner_ne",
         "f_sand_mound_mid_corner_se",
-        "f_sand_mound_mid_corner_ne"
+        "f_sand_mound_mid_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_sand_mound_mid_t_connection_n",
-        "f_sand_mound_mid_t_connection_w",
+        "f_sand_mound_mid_t_connection_e",
         "f_sand_mound_mid_t_connection_s",
-        "f_sand_mound_mid_t_connection_e"
+        "f_sand_mound_mid_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_sand_mound_mid_edge_ns",
-        "f_sand_mound_mid_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_sand_mound_mid_edge_ns", "f_sand_mound_mid_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_sand_mound_mid_end_piece_n",
-        "f_sand_mound_mid_end_piece_w",
+        "f_sand_mound_mid_end_piece_e",
         "f_sand_mound_mid_end_piece_s",
-        "f_sand_mound_mid_end_piece_e"
+        "f_sand_mound_mid_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_sand_mound_mid_unconnected",
-        "f_sand_mound_mid_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_sand_mound_mid_unconnected", "f_sand_mound_mid_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_sand_mound_short/f_sand_mound_short.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_sand_mound_short/f_sand_mound_short.json
@@ -3,50 +3,35 @@
   "fg": "f_sand_mound_short_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_sand_mound_short_center"
-    },
+    { "id": "center", "fg": "f_sand_mound_short_center" },
     {
       "id": "corner",
       "fg": [
         "f_sand_mound_short_corner_nw",
-        "f_sand_mound_short_corner_sw",
+        "f_sand_mound_short_corner_ne",
         "f_sand_mound_short_corner_se",
-        "f_sand_mound_short_corner_ne"
+        "f_sand_mound_short_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_sand_mound_short_t_connection_n",
-        "f_sand_mound_short_t_connection_w",
+        "f_sand_mound_short_t_connection_e",
         "f_sand_mound_short_t_connection_s",
-        "f_sand_mound_short_t_connection_e"
+        "f_sand_mound_short_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_sand_mound_short_edge_ns",
-        "f_sand_mound_short_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_sand_mound_short_edge_ns", "f_sand_mound_short_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_sand_mound_short_end_piece_n",
-        "f_sand_mound_short_end_piece_w",
+        "f_sand_mound_short_end_piece_e",
         "f_sand_mound_short_end_piece_s",
-        "f_sand_mound_short_end_piece_e"
+        "f_sand_mound_short_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_sand_mound_short_unconnected",
-        "f_sand_mound_short_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_sand_mound_short_unconnected", "f_sand_mound_short_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_sand_mound_tall/f_sand_mound_tall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_sand_mound_tall/f_sand_mound_tall.json
@@ -3,50 +3,35 @@
   "fg": "f_sand_mound_tall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_sand_mound_tall_center"
-    },
+    { "id": "center", "fg": "f_sand_mound_tall_center" },
     {
       "id": "corner",
       "fg": [
         "f_sand_mound_tall_corner_nw",
-        "f_sand_mound_tall_corner_sw",
+        "f_sand_mound_tall_corner_ne",
         "f_sand_mound_tall_corner_se",
-        "f_sand_mound_tall_corner_ne"
+        "f_sand_mound_tall_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_sand_mound_tall_t_connection_n",
-        "f_sand_mound_tall_t_connection_w",
+        "f_sand_mound_tall_t_connection_e",
         "f_sand_mound_tall_t_connection_s",
-        "f_sand_mound_tall_t_connection_e"
+        "f_sand_mound_tall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_sand_mound_tall_edge_ns",
-        "f_sand_mound_tall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_sand_mound_tall_edge_ns", "f_sand_mound_tall_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_sand_mound_tall_end_piece_n",
-        "f_sand_mound_tall_end_piece_w",
+        "f_sand_mound_tall_end_piece_e",
         "f_sand_mound_tall_end_piece_s",
-        "f_sand_mound_tall_end_piece_e"
+        "f_sand_mound_tall_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_sand_mound_tall_unconnected",
-        "f_sand_mound_tall_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_sand_mound_tall_unconnected", "f_sand_mound_tall_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_scrap_metal_bridge/f_scrap_bridge.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_scrap_metal_bridge/f_scrap_bridge.json
@@ -3,50 +3,30 @@
   "fg": "f_scrap_bridge_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_scrap_bridge_center"
-    },
+    { "id": "center", "fg": "f_scrap_bridge_center" },
     {
       "id": "corner",
-      "fg": [
-        "f_scrap_bridge_corner_nw",
-        "f_scrap_bridge_corner_sw",
-        "f_scrap_bridge_corner_se",
-        "f_scrap_bridge_corner_ne"
-      ]
+      "fg": [ "f_scrap_bridge_corner_nw", "f_scrap_bridge_corner_ne", "f_scrap_bridge_corner_se", "f_scrap_bridge_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_scrap_bridge_t_connection_n",
-        "f_scrap_bridge_t_connection_w",
+        "f_scrap_bridge_t_connection_e",
         "f_scrap_bridge_t_connection_s",
-        "f_scrap_bridge_t_connection_e"
+        "f_scrap_bridge_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_scrap_bridge_edge_ns",
-        "f_scrap_bridge_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_scrap_bridge_edge_ns", "f_scrap_bridge_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_scrap_bridge_end_piece_n",
-        "f_scrap_bridge_end_piece_w",
+        "f_scrap_bridge_end_piece_e",
         "f_scrap_bridge_end_piece_s",
-        "f_scrap_bridge_end_piece_e"
+        "f_scrap_bridge_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_scrap_bridge_unconnected",
-        "f_scrap_bridge_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_scrap_bridge_unconnected", "f_scrap_bridge_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_skin_wall/f_skin_wall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_skin_wall/f_skin_wall.json
@@ -3,50 +3,20 @@
   "fg": "f_skin_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_skin_wall_unconnected"
-    },
+    { "id": "center", "fg": "f_skin_wall_unconnected" },
     {
       "id": "corner",
-      "fg": [
-        "f_skin_wall_corner_nw",
-        "f_skin_wall_corner_sw",
-        "f_skin_wall_corner_se",
-        "f_skin_wall_corner_ne"
-      ]
+      "fg": [ "f_skin_wall_corner_nw", "f_skin_wall_corner_ne", "f_skin_wall_corner_se", "f_skin_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "f_skin_wall_edge_ns",
-        "f_skin_wall_edge_ew",
-        "f_skin_wall_edge_ns",
-        "f_skin_wall_edge_ew"
-      ]
+      "fg": [ "f_skin_wall_edge_ns", "f_skin_wall_edge_ew", "f_skin_wall_edge_ns", "f_skin_wall_edge_ew" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_skin_wall_edge_ns",
-        "f_skin_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_skin_wall_edge_ns", "f_skin_wall_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "f_skin_wall_end_piece_n",
-        "f_skin_wall_end_piece_w",
-        "f_skin_wall_end_piece_s",
-        "f_skin_wall_end_piece_e"
-      ]
+      "fg": [ "f_skin_wall_end_piece_n", "f_skin_wall_end_piece_e", "f_skin_wall_end_piece_s", "f_skin_wall_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_skin_wall_unconnected",
-        "f_skin_wall_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_skin_wall_unconnected", "f_skin_wall_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_table/f_table.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_table/f_table.json
@@ -3,50 +3,17 @@
   "fg": "f_table_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_table_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "f_table_corner_nw",
-        "f_table_corner_sw",
-        "f_table_corner_se",
-        "f_table_corner_ne"
-      ]
-    },
+    { "id": "center", "fg": "f_table_center" },
+    { "id": "corner", "fg": [ "f_table_corner_nw", "f_table_corner_ne", "f_table_corner_se", "f_table_corner_sw" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "f_table_t_connection_n",
-        "f_table_t_connection_w",
-        "f_table_t_connection_s",
-        "f_table_t_connection_e"
-      ]
+      "fg": [ "f_table_t_connection_n", "f_table_t_connection_e", "f_table_t_connection_s", "f_table_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_table_edge_ns",
-        "f_table_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_table_edge_ns", "f_table_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "f_table_end_piece_n",
-        "f_table_end_piece_w",
-        "f_table_end_piece_s",
-        "f_table_end_piece_e"
-      ]
+      "fg": [ "f_table_end_piece_n", "f_table_end_piece_e", "f_table_end_piece_s", "f_table_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_table_unconnected",
-        "f_table_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_table_unconnected", "f_table_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_tatami/f_tatami.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_tatami/f_tatami.json
@@ -3,50 +3,20 @@
   "fg": "f_tatami_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_tatami_center"
-    },
+    { "id": "center", "fg": "f_tatami_center" },
     {
       "id": "corner",
-      "fg": [
-        "f_tatami_corner_nw",
-        "f_tatami_corner_sw",
-        "f_tatami_corner_se",
-        "f_tatami_corner_ne"
-      ]
+      "fg": [ "f_tatami_corner_nw", "f_tatami_corner_ne", "f_tatami_corner_se", "f_tatami_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "f_tatami_t_connection_n",
-        "f_tatami_t_connection_w",
-        "f_tatami_t_connection_s",
-        "f_tatami_t_connection_e"
-      ]
+      "fg": [ "f_tatami_t_connection_n", "f_tatami_t_connection_e", "f_tatami_t_connection_s", "f_tatami_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_tatami_edge_ns",
-        "f_tatami_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_tatami_edge_ns", "f_tatami_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "f_tatami_end_piece_n",
-        "f_tatami_end_piece_w",
-        "f_tatami_end_piece_s",
-        "f_tatami_end_piece_e"
-      ]
+      "fg": [ "f_tatami_end_piece_n", "f_tatami_end_piece_e", "f_tatami_end_piece_s", "f_tatami_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_tatami_unconnected",
-        "f_tatami_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_tatami_unconnected", "f_tatami_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_vitrified_cupboard/f_vitrified_cupboard.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_vitrified_cupboard/f_vitrified_cupboard.json
@@ -1,52 +1,40 @@
 {
-  "id": [ "f_vitrified_cupboard", "f_vitrified_counter" ],
+  "id": [
+    "f_vitrified_cupboard",
+    "f_vitrified_counter"
+  ],
   "fg": "f_vitrified_cupboard_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_vitrified_cupboard_center"
-    },
+    { "id": "center", "fg": "f_vitrified_cupboard_center" },
     {
       "id": "corner",
       "fg": [
         "f_vitrified_cupboard_corner_nw",
-        "f_vitrified_cupboard_corner_sw",
+        "f_vitrified_cupboard_corner_ne",
         "f_vitrified_cupboard_corner_se",
-        "f_vitrified_cupboard_corner_ne"
+        "f_vitrified_cupboard_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_vitrified_cupboard_t_connection_n",
-        "f_vitrified_cupboard_t_connection_w",
+        "f_vitrified_cupboard_t_connection_e",
         "f_vitrified_cupboard_t_connection_s",
-        "f_vitrified_cupboard_t_connection_e"
+        "f_vitrified_cupboard_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_vitrified_cupboard_edge_ns",
-        "f_vitrified_cupboard_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_vitrified_cupboard_edge_ns", "f_vitrified_cupboard_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_vitrified_cupboard_end_piece_n",
-        "f_vitrified_cupboard_end_piece_w",
+        "f_vitrified_cupboard_end_piece_e",
         "f_vitrified_cupboard_end_piece_s",
-        "f_vitrified_cupboard_end_piece_e"
+        "f_vitrified_cupboard_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_vitrified_cupboard_unconnected",
-        "f_vitrified_cupboard_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_vitrified_cupboard_unconnected", "f_vitrified_cupboard_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_vitrified_desk/f_vitrified_desk.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_vitrified_desk/f_vitrified_desk.json
@@ -3,50 +3,35 @@
   "fg": "f_vitrified_desk_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_vitrified_desk_center"
-    },
+    { "id": "center", "fg": "f_vitrified_desk_center" },
     {
       "id": "corner",
       "fg": [
         "f_vitrified_desk_corner_nw",
-        "f_vitrified_desk_corner_sw",
+        "f_vitrified_desk_corner_ne",
         "f_vitrified_desk_corner_se",
-        "f_vitrified_desk_corner_ne"
+        "f_vitrified_desk_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_vitrified_desk_t_connection_n",
+        "f_vitrified_desk_t_connection_e",
         "f_vitrified_desk_t_connection_s",
-        "f_vitrified_desk_t_connection_w",
-        "f_vitrified_desk_t_connection_e"
+        "f_vitrified_desk_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_vitrified_desk_edge_ns",
-        "f_vitrified_desk_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_vitrified_desk_edge_ns", "f_vitrified_desk_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_vitrified_desk_end_piece_n",
-        "f_vitrified_desk_end_piece_w",
+        "f_vitrified_desk_end_piece_e",
         "f_vitrified_desk_end_piece_s",
-        "f_vitrified_desk_end_piece_e"
+        "f_vitrified_desk_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_vitrified_desk_unconnected",
-        "f_vitrified_desk_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_vitrified_desk_unconnected", "f_vitrified_desk_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_vitrified_table/f_vitrified_table.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/f_vitrified_table/f_vitrified_table.json
@@ -3,50 +3,35 @@
   "fg": "f_vitrified_table_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_vitrified_table_center"
-    },
+    { "id": "center", "fg": "f_vitrified_table_center" },
     {
       "id": "corner",
       "fg": [
         "f_vitrified_table_corner_nw",
-        "f_vitrified_table_corner_sw",
+        "f_vitrified_table_corner_ne",
         "f_vitrified_table_corner_se",
-        "f_vitrified_table_corner_ne"
+        "f_vitrified_table_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_vitrified_table_t_connection_n",
-        "f_vitrified_table_t_connection_w",
+        "f_vitrified_table_t_connection_e",
         "f_vitrified_table_t_connection_s",
-        "f_vitrified_table_t_connection_e"
+        "f_vitrified_table_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_vitrified_table_edge_ns",
-        "f_vitrified_table_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_vitrified_table_edge_ns", "f_vitrified_table_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_vitrified_table_end_piece_n",
-        "f_vitrified_table_end_piece_w",
+        "f_vitrified_table_end_piece_e",
         "f_vitrified_table_end_piece_s",
-        "f_vitrified_table_end_piece_e"
+        "f_vitrified_table_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_vitrified_table_unconnected",
-        "f_vitrified_table_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_vitrified_table_unconnected", "f_vitrified_table_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/furniture/minifreezer/minifreezer.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/furniture/minifreezer/minifreezer.json
@@ -1,6 +1,14 @@
 {
-  "id": [ "f_minifreezer", "vp_ap_minifreezer" ],
+  "id": [
+    "f_minifreezer",
+    "vp_ap_minifreezer"
+  ],
   "rotates": true,
-  "fg": ["minifreezer_S", "minifreezer_W", "minifreezer_N", "minifreezer_E"],
+  "fg": [
+    "minifreezer_S",
+    "minifreezer_E",
+    "minifreezer_N",
+    "minifreezer_W"
+  ],
   "bg": ""
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/furniture/f_afs_sofa/f_afs_sofa.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/furniture/f_afs_sofa/f_afs_sofa.json
@@ -3,50 +3,20 @@
   "fg": "f_afs_sofa_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_afs_sofa_center"
-    },
+    { "id": "center", "fg": "f_afs_sofa_center" },
     {
       "id": "corner",
-      "fg": [
-        "f_afs_sofa_corner_nw",
-        "f_afs_sofa_corner_sw",
-        "f_afs_sofa_corner_se",
-        "f_afs_sofa_corner_ne"
-      ]
+      "fg": [ "f_afs_sofa_corner_nw", "f_afs_sofa_corner_ne", "f_afs_sofa_corner_se", "f_afs_sofa_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "f_afs_sofa_t_connection_n",
-        "f_afs_sofa_t_connection_w",
-        "f_afs_sofa_t_connection_s",
-        "f_afs_sofa_t_connection_e"
-      ]
+      "fg": [ "f_afs_sofa_t_connection_n", "f_afs_sofa_t_connection_e", "f_afs_sofa_t_connection_s", "f_afs_sofa_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_afs_sofa_edge_ns",
-        "f_afs_sofa_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_afs_sofa_edge_ns", "f_afs_sofa_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "f_afs_sofa_end_piece_n",
-        "f_afs_sofa_end_piece_w",
-        "f_afs_sofa_end_piece_s",
-        "f_afs_sofa_end_piece_e"
-      ]
+      "fg": [ "f_afs_sofa_end_piece_n", "f_afs_sofa_end_piece_e", "f_afs_sofa_end_piece_s", "f_afs_sofa_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_afs_sofa_unconnected",
-        "f_afs_sofa_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_afs_sofa_unconnected", "f_afs_sofa_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/furniture/f_habitat_storage_board/f_habitat_storage_board.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/furniture/f_habitat_storage_board/f_habitat_storage_board.json
@@ -3,50 +3,35 @@
   "fg": "f_habitat_storage_board_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_habitat_storage_board_center"
-    },
+    { "id": "center", "fg": "f_habitat_storage_board_center" },
     {
       "id": "corner",
       "fg": [
         "f_habitat_storage_board_corner_nw",
-        "f_habitat_storage_board_corner_sw",
+        "f_habitat_storage_board_corner_ne",
         "f_habitat_storage_board_corner_se",
-        "f_habitat_storage_board_corner_ne"
+        "f_habitat_storage_board_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_habitat_storage_board_t_connection_n",
-        "f_habitat_storage_board_t_connection_w",
+        "f_habitat_storage_board_t_connection_e",
         "f_habitat_storage_board_t_connection_s",
-        "f_habitat_storage_board_t_connection_e"
+        "f_habitat_storage_board_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_habitat_storage_board_edge_ns",
-        "f_habitat_storage_board_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_habitat_storage_board_edge_ns", "f_habitat_storage_board_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_habitat_storage_board_end_piece_n",
-        "f_habitat_storage_board_end_piece_w",
+        "f_habitat_storage_board_end_piece_e",
         "f_habitat_storage_board_end_piece_s",
-        "f_habitat_storage_board_end_piece_e"
+        "f_habitat_storage_board_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_habitat_storage_board_unconnected",
-        "f_habitat_storage_board_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_habitat_storage_board_unconnected", "f_habitat_storage_board_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/terrain/t_afs_gun_ship_hull_wall/t_afs_gun_ship_hull_wall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/terrain/t_afs_gun_ship_hull_wall/t_afs_gun_ship_hull_wall.json
@@ -3,50 +3,35 @@
   "fg": "t_afs_gun_ship_hull_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_afs_gun_ship_hull_wall_center"
-    },
+    { "id": "center", "fg": "t_afs_gun_ship_hull_wall_center" },
     {
       "id": "corner",
       "fg": [
         "t_afs_gun_ship_hull_wall_corner_nw",
-        "t_afs_gun_ship_hull_wall_corner_sw",
+        "t_afs_gun_ship_hull_wall_corner_ne",
         "t_afs_gun_ship_hull_wall_corner_se",
-        "t_afs_gun_ship_hull_wall_corner_ne"
+        "t_afs_gun_ship_hull_wall_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_afs_gun_ship_hull_wall_t_connection_n",
-        "t_afs_gun_ship_hull_wall_t_connection_w",
+        "t_afs_gun_ship_hull_wall_t_connection_e",
         "t_afs_gun_ship_hull_wall_t_connection_s",
-        "t_afs_gun_ship_hull_wall_t_connection_e"
+        "t_afs_gun_ship_hull_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_afs_gun_ship_hull_wall_edge_ns",
-        "t_afs_gun_ship_hull_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_afs_gun_ship_hull_wall_edge_ns", "t_afs_gun_ship_hull_wall_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_afs_gun_ship_hull_wall_end_piece_n",
-        "t_afs_gun_ship_hull_wall_end_piece_w",
+        "t_afs_gun_ship_hull_wall_end_piece_e",
         "t_afs_gun_ship_hull_wall_end_piece_s",
-        "t_afs_gun_ship_hull_wall_end_piece_e"
+        "t_afs_gun_ship_hull_wall_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_afs_gun_ship_hull_wall_unconnected",
-        "t_afs_gun_ship_hull_wall_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_afs_gun_ship_hull_wall_unconnected", "t_afs_gun_ship_hull_wall_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/terrain/t_afs_space_ship_wall/t_afs_space_ship_hull_wall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/terrain/t_afs_space_ship_wall/t_afs_space_ship_hull_wall.json
@@ -3,50 +3,38 @@
   "fg": "t_afs_space_ship_hull_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_afs_space_ship_hull_wall_center"
-    },
+    { "id": "center", "fg": "t_afs_space_ship_hull_wall_center" },
     {
       "id": "corner",
       "fg": [
         "t_afs_space_ship_hull_wall_corner_nw",
-        "t_afs_space_ship_hull_wall_corner_sw",
+        "t_afs_space_ship_hull_wall_corner_ne",
         "t_afs_space_ship_hull_wall_corner_se",
-        "t_afs_space_ship_hull_wall_corner_ne"
+        "t_afs_space_ship_hull_wall_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_afs_space_ship_hull_wall_t_connection_n",
-        "t_afs_space_ship_hull_wall_t_connection_w",
+        "t_afs_space_ship_hull_wall_t_connection_e",
         "t_afs_space_ship_hull_wall_t_connection_s",
-        "t_afs_space_ship_hull_wall_t_connection_e"
+        "t_afs_space_ship_hull_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_afs_space_ship_hull_wall_edge_ns",
-        "t_afs_space_ship_hull_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_afs_space_ship_hull_wall_edge_ns", "t_afs_space_ship_hull_wall_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_afs_space_ship_hull_wall_end_piece_n",
-        "t_afs_space_ship_hull_wall_end_piece_w",
+        "t_afs_space_ship_hull_wall_end_piece_e",
         "t_afs_space_ship_hull_wall_end_piece_s",
-        "t_afs_space_ship_hull_wall_end_piece_e"
+        "t_afs_space_ship_hull_wall_end_piece_w"
       ]
     },
     {
       "id": "unconnected",
-      "fg": [
-        "t_afs_space_ship_hull_wall_unconnected",
-        "t_afs_space_ship_hull_wall_unconnected"
-      ]
+      "fg": [ "t_afs_space_ship_hull_wall_unconnected", "t_afs_space_ship_hull_wall_unconnected" ]
     }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/terrain/t_foamcrete_wall_seal/t_foamcrete_wall_seal.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/terrain/t_foamcrete_wall_seal/t_foamcrete_wall_seal.json
@@ -3,50 +3,35 @@
   "fg": "t_foamcrete_wall_seal_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_foamcrete_wall_seal_center"
-    },
+    { "id": "center", "fg": "t_foamcrete_wall_seal_center" },
     {
       "id": "corner",
       "fg": [
         "t_foamcrete_wall_seal_corner_nw",
-        "t_foamcrete_wall_seal_corner_sw",
+        "t_foamcrete_wall_seal_corner_ne",
         "t_foamcrete_wall_seal_corner_se",
-        "t_foamcrete_wall_seal_corner_ne"
+        "t_foamcrete_wall_seal_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_foamcrete_wall_seal_t_connection_n",
-        "t_foamcrete_wall_seal_t_connection_w",
+        "t_foamcrete_wall_seal_t_connection_e",
         "t_foamcrete_wall_seal_t_connection_s",
-        "t_foamcrete_wall_seal_t_connection_e"
+        "t_foamcrete_wall_seal_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_foamcrete_wall_seal_edge_ns",
-        "t_foamcrete_wall_seal_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_foamcrete_wall_seal_edge_ns", "t_foamcrete_wall_seal_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_foamcrete_wall_seal_end_piece_n",
-        "t_foamcrete_wall_seal_end_piece_w",
+        "t_foamcrete_wall_seal_end_piece_e",
         "t_foamcrete_wall_seal_end_piece_s",
-        "t_foamcrete_wall_seal_end_piece_e"
+        "t_foamcrete_wall_seal_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_foamcrete_wall_seal_unconnected",
-        "t_foamcrete_wall_seal_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_foamcrete_wall_seal_unconnected", "t_foamcrete_wall_seal_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/terrain/t_ice/t_ice.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/terrain/t_ice/t_ice.json
@@ -3,50 +3,17 @@
   "fg": "t_ice_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_ice_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_ice_corner_nw",
-        "t_ice_corner_sw",
-        "t_ice_corner_se",
-        "t_ice_corner_ne"
-      ]
-    },
+    { "id": "center", "fg": "t_ice_center" },
+    { "id": "corner", "fg": [ "t_ice_corner_nw", "t_ice_corner_ne", "t_ice_corner_se", "t_ice_corner_sw" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "t_ice_t_connection_n",
-        "t_ice_t_connection_w",
-        "t_ice_t_connection_s",
-        "t_ice_t_connection_e"
-      ]
+      "fg": [ "t_ice_t_connection_n", "t_ice_t_connection_e", "t_ice_t_connection_s", "t_ice_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_ice_edge_ns",
-        "t_ice_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_ice_edge_ns", "t_ice_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_ice_end_piece_n",
-        "t_ice_end_piece_w",
-        "t_ice_end_piece_s",
-        "t_ice_end_piece_e"
-      ]
+      "fg": [ "t_ice_end_piece_n", "t_ice_end_piece_e", "t_ice_end_piece_s", "t_ice_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_ice_unconnected",
-        "t_ice_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_ice_unconnected", "t_ice_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/terrain/t_snow/t_snow.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/terrain/t_snow/t_snow.json
@@ -3,50 +3,17 @@
   "fg": "t_snow_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_snow_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_snow_corner_nw",
-        "t_snow_corner_sw",
-        "t_snow_corner_se",
-        "t_snow_corner_ne"
-      ]
-    },
+    { "id": "center", "fg": "t_snow_center" },
+    { "id": "corner", "fg": [ "t_snow_corner_nw", "t_snow_corner_ne", "t_snow_corner_se", "t_snow_corner_sw" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "t_snow_t_connection_n",
-        "t_snow_t_connection_w",
-        "t_snow_t_connection_s",
-        "t_snow_t_connection_e"
-      ]
+      "fg": [ "t_snow_t_connection_n", "t_snow_t_connection_e", "t_snow_t_connection_s", "t_snow_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_snow_edge_ns",
-        "t_snow_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_snow_edge_ns", "t_snow_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_snow_end_piece_n",
-        "t_snow_end_piece_w",
-        "t_snow_end_piece_s",
-        "t_snow_end_piece_e"
-      ]
+      "fg": [ "t_snow_end_piece_n", "t_snow_end_piece_e", "t_snow_end_piece_s", "t_snow_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_snow_unconnected",
-        "t_snow_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_snow_unconnected", "t_snow_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/terrain/t_wall_prefab_glass/t_wall_prefab_glass.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/Aftershock/terrain/t_wall_prefab_glass/t_wall_prefab_glass.json
@@ -3,50 +3,35 @@
   "fg": "t_wall_prefab_glass_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_prefab_glass_center"
-    },
+    { "id": "center", "fg": "t_wall_prefab_glass_center" },
     {
       "id": "corner",
       "fg": [
         "t_wall_prefab_glass_corner_nw",
-        "t_wall_prefab_glass_corner_sw",
+        "t_wall_prefab_glass_corner_ne",
         "t_wall_prefab_glass_corner_se",
-        "t_wall_prefab_glass_corner_ne"
+        "t_wall_prefab_glass_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_prefab_glass_t_connection_n",
-        "t_wall_prefab_glass_t_connection_w",
+        "t_wall_prefab_glass_t_connection_e",
         "t_wall_prefab_glass_t_connection_s",
-        "t_wall_prefab_glass_t_connection_e"
+        "t_wall_prefab_glass_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_prefab_glass_edge_ns",
-        "t_wall_prefab_glass_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_prefab_glass_edge_ns", "t_wall_prefab_glass_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wall_prefab_glass_end_piece_n",
-        "t_wall_prefab_glass_end_piece_w",
+        "t_wall_prefab_glass_end_piece_e",
         "t_wall_prefab_glass_end_piece_s",
-        "t_wall_prefab_glass_end_piece_e"
+        "t_wall_prefab_glass_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_prefab_glass_unconnected",
-        "t_wall_prefab_glass_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_prefab_glass_unconnected", "t_wall_prefab_glass_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/Magiclysm/field/fd_alkahest/fd_alkahest.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/Magiclysm/field/fd_alkahest/fd_alkahest.json
@@ -3,50 +3,25 @@
   "fg": "fd_alkahest_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "fd_alkahest_center"
-    },
+    { "id": "center", "fg": "fd_alkahest_center" },
     {
       "id": "corner",
-      "fg": [
-        "fd_alkahest_corner_nw",
-        "fd_alkahest_corner_sw",
-        "fd_alkahest_corner_se",
-        "fd_alkahest_corner_ne"
-      ]
+      "fg": [ "fd_alkahest_corner_nw", "fd_alkahest_corner_ne", "fd_alkahest_corner_se", "fd_alkahest_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "fd_alkahest_t_connection_n",
-        "fd_alkahest_t_connection_w",
+        "fd_alkahest_t_connection_e",
         "fd_alkahest_t_connection_s",
-        "fd_alkahest_t_connection_e"
+        "fd_alkahest_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "fd_alkahest_edge_ns",
-        "fd_alkahest_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "fd_alkahest_edge_ns", "fd_alkahest_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "fd_alkahest_end_piece_n",
-        "fd_alkahest_end_piece_w",
-        "fd_alkahest_end_piece_s",
-        "fd_alkahest_end_piece_e"
-      ]
+      "fg": [ "fd_alkahest_end_piece_n", "fd_alkahest_end_piece_e", "fd_alkahest_end_piece_s", "fd_alkahest_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "fd_alkahest_unconnected",
-        "fd_alkahest_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "fd_alkahest_unconnected", "fd_alkahest_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/Magiclysm/terrain/t_magiconc_floor/t_magiconc_floor/t_magiconc_floor.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/Magiclysm/terrain/t_magiconc_floor/t_magiconc_floor/t_magiconc_floor.json
@@ -3,50 +3,35 @@
   "fg": "t_magiconc_floor_center",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_magiconc_floor_center"
-    },
+    { "id": "center", "fg": "t_magiconc_floor_center" },
     {
       "id": "corner",
       "fg": [
         "t_magiconc_floor_corner_nw",
-        "t_magiconc_floor_corner_sw",
+        "t_magiconc_floor_corner_ne",
         "t_magiconc_floor_corner_se",
-        "t_magiconc_floor_corner_ne"
+        "t_magiconc_floor_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_magiconc_floor_t_connection_n",
-        "t_magiconc_floor_t_connection_w",
+        "t_magiconc_floor_t_connection_e",
         "t_magiconc_floor_t_connection_s",
-        "t_magiconc_floor_t_connection_e"
+        "t_magiconc_floor_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_magiconc_floor_edge_ns",
-        "t_magiconc_floor_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_magiconc_floor_edge_ns", "t_magiconc_floor_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_magiconc_floor_end_piece_n",
-        "t_magiconc_floor_end_piece_w",
+        "t_magiconc_floor_end_piece_e",
         "t_magiconc_floor_end_piece_s",
-        "t_magiconc_floor_end_piece_e"
+        "t_magiconc_floor_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_magiconc_floor_center",
-        "t_magiconc_floor_center"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_magiconc_floor_center", "t_magiconc_floor_center" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/Magiclysm/terrain/t_magiconc_floor/t_safe_shopper/t_safe_shopper.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/Magiclysm/terrain/t_magiconc_floor/t_safe_shopper/t_safe_shopper.json
@@ -3,50 +3,30 @@
   "fg": "t_magiconc_floor_center",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_magiconc_floor_center"
-    },
+    { "id": "center", "fg": "t_magiconc_floor_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_safe_shopper_corner_nw",
-        "t_safe_shopper_corner_sw",
-        "t_safe_shopper_corner_se",
-        "t_safe_shopper_corner_ne"
-      ]
+      "fg": [ "t_safe_shopper_corner_nw", "t_safe_shopper_corner_ne", "t_safe_shopper_corner_se", "t_safe_shopper_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_safe_shopper_t_connection_n",
-        "t_safe_shopper_t_connection_w",
+        "t_safe_shopper_t_connection_e",
         "t_safe_shopper_t_connection_s",
-        "t_safe_shopper_t_connection_e"
+        "t_safe_shopper_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_safe_shopper_edge_ns",
-        "t_safe_shopper_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_safe_shopper_edge_ns", "t_safe_shopper_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_safe_shopper_end_piece_n",
-        "t_safe_shopper_end_piece_w",
+        "t_safe_shopper_end_piece_e",
         "t_safe_shopper_end_piece_s",
-        "t_safe_shopper_end_piece_e"
+        "t_safe_shopper_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_magiconc_floor_center",
-        "t_magiconc_floor_center"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_magiconc_floor_center", "t_magiconc_floor_center" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/Magiclysm/terrain/t_magiconc_floor/t_vault_vent/t_vault_vent.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/Magiclysm/terrain/t_magiconc_floor/t_vault_vent/t_vault_vent.json
@@ -3,50 +3,25 @@
   "fg": "t_magiconc_floor_center",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_magiconc_floor_center"
-    },
+    { "id": "center", "fg": "t_magiconc_floor_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_vault_vent_corner_nw",
-        "t_vault_vent_corner_sw",
-        "t_vault_vent_corner_se",
-        "t_vault_vent_corner_ne"
-      ]
+      "fg": [ "t_vault_vent_corner_nw", "t_vault_vent_corner_ne", "t_vault_vent_corner_se", "t_vault_vent_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_vault_vent_t_connection_n",
-        "t_vault_vent_t_connection_w",
+        "t_vault_vent_t_connection_e",
         "t_vault_vent_t_connection_s",
-        "t_vault_vent_t_connection_e"
+        "t_vault_vent_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_vault_vent_edge_ns",
-        "t_vault_vent_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_vault_vent_edge_ns", "t_vault_vent_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_vault_vent_end_piece_n",
-        "t_vault_vent_end_piece_w",
-        "t_vault_vent_end_piece_s",
-        "t_vault_vent_end_piece_e"
-      ]
+      "fg": [ "t_vault_vent_end_piece_n", "t_vault_vent_end_piece_e", "t_vault_vent_end_piece_s", "t_vault_vent_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_magiconc_floor_center",
-        "t_magiconc_floor_center"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_magiconc_floor_center", "t_magiconc_floor_center" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/xedra_evolved/terrain/t_solid_fog/t_solid_fog.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/xedra_evolved/terrain/t_solid_fog/t_solid_fog.json
@@ -1,53 +1,29 @@
 [
- {
-  "id": "t_solid_fog",
-  "fg": "t_solid_fog_unconnected",
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_solid_fog_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_solid_fog_corner_nw",
-        "t_solid_fog_corner_sw",
-        "t_solid_fog_corner_se",
-        "t_solid_fog_corner_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "t_solid_fog_t_connection_n",
-        "t_solid_fog_t_connection_w",
-        "t_solid_fog_t_connection_s",
-        "t_solid_fog_t_connection_e"
-      ]
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "t_solid_fog_edge_ns",
-        "t_solid_fog_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "t_solid_fog_end_piece_n",
-        "t_solid_fog_end_piece_w",
-        "t_solid_fog_end_piece_s",
-        "t_solid_fog_end_piece_e"
-      ]
-    },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_solid_fog_unconnected"
-      ]
-    }
-  ]
-} 
+  {
+    "id": "t_solid_fog",
+    "fg": "t_solid_fog_unconnected",
+    "multitile": true,
+    "additional_tiles": [
+      { "id": "center", "fg": "t_solid_fog_center" },
+      {
+        "id": "corner",
+        "fg": [ "t_solid_fog_corner_nw", "t_solid_fog_corner_ne", "t_solid_fog_corner_se", "t_solid_fog_corner_sw" ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_solid_fog_t_connection_n",
+          "t_solid_fog_t_connection_e",
+          "t_solid_fog_t_connection_s",
+          "t_solid_fog_t_connection_w"
+        ]
+      },
+      { "id": "edge", "fg": [ "t_solid_fog_edge_ns", "t_solid_fog_edge_ew" ] },
+      {
+        "id": "end_piece",
+        "fg": [ "t_solid_fog_end_piece_n", "t_solid_fog_end_piece_e", "t_solid_fog_end_piece_s", "t_solid_fog_end_piece_w" ]
+      },
+      { "id": "unconnected", "fg": [ "t_solid_fog_unconnected" ] }
+    ]
+  }
 ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/resin_terrain/t_wall_resin/t_wall_resin.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/resin_terrain/t_wall_resin/t_wall_resin.json
@@ -6,23 +6,23 @@
     { "id": "center", "fg": "t_wall_resin_center", "bg": "t_floor_resin" },
     {
       "id": "corner",
-      "fg": [ "t_wall_resin_corner_nw", "t_wall_resin_corner_sw", "t_wall_resin_corner_se", "t_wall_resin_corner_ne" ],
+      "fg": [ "t_wall_resin_corner_nw", "t_wall_resin_corner_ne", "t_wall_resin_corner_se", "t_wall_resin_corner_sw" ],
       "bg": "t_floor_resin"
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_resin_t_connection_n",
-        "t_wall_resin_t_connection_w",
+        "t_wall_resin_t_connection_e",
         "t_wall_resin_t_connection_s",
-        "t_wall_resin_t_connection_e"
+        "t_wall_resin_t_connection_w"
       ],
       "bg": "t_floor_resin"
     },
     { "id": "edge", "fg": [ "t_wall_resin_edge_ns", "t_wall_resin_edge_ew" ], "bg": "t_floor_resin" },
     {
       "id": "end_piece",
-      "fg": [ "t_wall_resin_end_piece_n", "t_wall_resin_end_piece_w", "t_wall_resin_end_piece_s", "t_wall_resin_end_piece_e" ],
+      "fg": [ "t_wall_resin_end_piece_n", "t_wall_resin_end_piece_e", "t_wall_resin_end_piece_s", "t_wall_resin_end_piece_w" ],
       "bg": "t_floor_resin"
     },
     { "id": "unconnected", "fg": [ "t_wall_resin_unconnected", "t_wall_resin_unconnected" ], "bg": "t_floor_resin" }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_alien_meadow_grass/t_alien_meadow_grass.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_alien_meadow_grass/t_alien_meadow_grass.json
@@ -19,9 +19,9 @@
         "bg": [ "t_grass" ],
         "fg": [
           "t_alien_meadow_grass_corner_nw",
-          "t_alien_meadow_grass_corner_sw",
+          "t_alien_meadow_grass_corner_ne",
           "t_alien_meadow_grass_corner_se",
-          "t_alien_meadow_grass_corner_ne"
+          "t_alien_meadow_grass_corner_sw"
         ]
       },
       {
@@ -29,9 +29,9 @@
         "bg": [ "t_grass" ],
         "fg": [
           "t_alien_meadow_grass_t_connection_n",
-          "t_alien_meadow_grass_t_connection_w",
+          "t_alien_meadow_grass_t_connection_e",
           "t_alien_meadow_grass_t_connection_s",
-          "t_alien_meadow_grass_t_connection_e"
+          "t_alien_meadow_grass_t_connection_w"
         ]
       },
       { "id": "edge", "bg": [ "t_grass" ], "fg": [ "t_alien_meadow_grass_edge_ns", "t_alien_meadow_grass_edge_ew" ] },
@@ -40,9 +40,9 @@
         "bg": [ "t_grass" ],
         "fg": [
           "t_alien_meadow_grass_end_piece_n",
-          "t_alien_meadow_grass_end_piece_w",
+          "t_alien_meadow_grass_end_piece_e",
           "t_alien_meadow_grass_end_piece_s",
-          "t_alien_meadow_grass_end_piece_e"
+          "t_alien_meadow_grass_end_piece_w"
         ]
       },
       { "bg": [ "t_grass" ], "id": "unconnected", "fg": [ "t_alien_meadow_grass_unconnected" ] }
@@ -68,9 +68,9 @@
         "bg": [ "t_grass_summer" ],
         "fg": [
           "t_alien_meadow_grass_corner_nw",
-          "t_alien_meadow_grass_corner_sw",
+          "t_alien_meadow_grass_corner_ne",
           "t_alien_meadow_grass_corner_se",
-          "t_alien_meadow_grass_corner_ne"
+          "t_alien_meadow_grass_corner_sw"
         ]
       },
       {
@@ -78,9 +78,9 @@
         "bg": [ "t_grass_summer" ],
         "fg": [
           "t_alien_meadow_grass_t_connection_n",
-          "t_alien_meadow_grass_t_connection_w",
+          "t_alien_meadow_grass_t_connection_e",
           "t_alien_meadow_grass_t_connection_s",
-          "t_alien_meadow_grass_t_connection_e"
+          "t_alien_meadow_grass_t_connection_w"
         ]
       },
       {
@@ -93,9 +93,9 @@
         "bg": [ "t_grass_summer" ],
         "fg": [
           "t_alien_meadow_grass_end_piece_n",
-          "t_alien_meadow_grass_end_piece_w",
+          "t_alien_meadow_grass_end_piece_e",
           "t_alien_meadow_grass_end_piece_s",
-          "t_alien_meadow_grass_end_piece_e"
+          "t_alien_meadow_grass_end_piece_w"
         ]
       },
       { "bg": [ "t_grass_summer" ], "id": "unconnected", "fg": [ "t_alien_meadow_grass_unconnected" ] }
@@ -121,9 +121,9 @@
         "bg": [ "t_grass_autumn" ],
         "fg": [
           "t_alien_meadow_grass_corner_nw",
-          "t_alien_meadow_grass_corner_sw",
+          "t_alien_meadow_grass_corner_ne",
           "t_alien_meadow_grass_corner_se",
-          "t_alien_meadow_grass_corner_ne"
+          "t_alien_meadow_grass_corner_sw"
         ]
       },
       {
@@ -131,9 +131,9 @@
         "bg": [ "t_grass_autumn" ],
         "fg": [
           "t_alien_meadow_grass_t_connection_n",
-          "t_alien_meadow_grass_t_connection_w",
+          "t_alien_meadow_grass_t_connection_e",
           "t_alien_meadow_grass_t_connection_s",
-          "t_alien_meadow_grass_t_connection_e"
+          "t_alien_meadow_grass_t_connection_w"
         ]
       },
       {
@@ -146,9 +146,9 @@
         "bg": [ "t_grass_autumn" ],
         "fg": [
           "t_alien_meadow_grass_end_piece_n",
-          "t_alien_meadow_grass_end_piece_w",
+          "t_alien_meadow_grass_end_piece_e",
           "t_alien_meadow_grass_end_piece_s",
-          "t_alien_meadow_grass_end_piece_e"
+          "t_alien_meadow_grass_end_piece_w"
         ]
       },
       { "bg": [ "t_grass_autumn" ], "id": "unconnected", "fg": [ "t_alien_meadow_grass_unconnected" ] }
@@ -174,9 +174,9 @@
         "bg": [ "t_grass_winter" ],
         "fg": [
           "t_alien_meadow_grass_corner_nw",
-          "t_alien_meadow_grass_corner_sw",
+          "t_alien_meadow_grass_corner_ne",
           "t_alien_meadow_grass_corner_se",
-          "t_alien_meadow_grass_corner_ne"
+          "t_alien_meadow_grass_corner_sw"
         ]
       },
       {
@@ -184,9 +184,9 @@
         "bg": [ "t_grass_winter" ],
         "fg": [
           "t_alien_meadow_grass_t_connection_n",
-          "t_alien_meadow_grass_t_connection_w",
+          "t_alien_meadow_grass_t_connection_e",
           "t_alien_meadow_grass_t_connection_s",
-          "t_alien_meadow_grass_t_connection_e"
+          "t_alien_meadow_grass_t_connection_w"
         ]
       },
       {
@@ -199,9 +199,9 @@
         "bg": [ "t_grass_winter" ],
         "fg": [
           "t_alien_meadow_grass_end_piece_n",
-          "t_alien_meadow_grass_end_piece_w",
+          "t_alien_meadow_grass_end_piece_e",
           "t_alien_meadow_grass_end_piece_s",
-          "t_alien_meadow_grass_end_piece_e"
+          "t_alien_meadow_grass_end_piece_w"
         ]
       },
       { "bg": [ "t_grass_winter" ], "id": "unconnected", "fg": [ "t_alien_meadow_grass_unconnected" ] }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_alien_meadow_grass_long/t_alien_meadow_grass_long.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_alien_meadow_grass_long/t_alien_meadow_grass_long.json
@@ -11,9 +11,9 @@
         "bg": [ "t_dirt_center" ],
         "fg": [
           "t_alien_meadow_grass_long_corner_nw",
-          "t_alien_meadow_grass_long_corner_sw",
+          "t_alien_meadow_grass_long_corner_ne",
           "t_alien_meadow_grass_long_corner_se",
-          "t_alien_meadow_grass_long_corner_ne"
+          "t_alien_meadow_grass_long_corner_sw"
         ]
       },
       {
@@ -21,9 +21,9 @@
         "bg": [ "t_dirt_center" ],
         "fg": [
           "t_alien_meadow_grass_long_t_connection_n",
-          "t_alien_meadow_grass_long_t_connection_w",
+          "t_alien_meadow_grass_long_t_connection_e",
           "t_alien_meadow_grass_long_t_connection_s",
-          "t_alien_meadow_grass_long_t_connection_e"
+          "t_alien_meadow_grass_long_t_connection_w"
         ]
       },
       {
@@ -36,9 +36,9 @@
         "bg": [ "t_dirt_center" ],
         "fg": [
           "t_alien_meadow_grass_long_end_piece_n",
-          "t_alien_meadow_grass_long_end_piece_w",
+          "t_alien_meadow_grass_long_end_piece_e",
           "t_alien_meadow_grass_long_end_piece_s",
-          "t_alien_meadow_grass_long_end_piece_e"
+          "t_alien_meadow_grass_long_end_piece_w"
         ]
       },
       { "bg": [ "t_dirt_center" ], "id": "unconnected", "fg": [ "t_alien_meadow_grass_long_unconnected" ] }
@@ -56,9 +56,9 @@
         "bg": [ "t_dirt_summer_center" ],
         "fg": [
           "t_alien_meadow_grass_long_corner_nw",
-          "t_alien_meadow_grass_long_corner_sw",
+          "t_alien_meadow_grass_long_corner_ne",
           "t_alien_meadow_grass_long_corner_se",
-          "t_alien_meadow_grass_long_corner_ne"
+          "t_alien_meadow_grass_long_corner_sw"
         ]
       },
       {
@@ -66,9 +66,9 @@
         "bg": [ "t_dirt_summer_center" ],
         "fg": [
           "t_alien_meadow_grass_long_t_connection_n",
-          "t_alien_meadow_grass_long_t_connection_w",
+          "t_alien_meadow_grass_long_t_connection_e",
           "t_alien_meadow_grass_long_t_connection_s",
-          "t_alien_meadow_grass_long_t_connection_e"
+          "t_alien_meadow_grass_long_t_connection_w"
         ]
       },
       {
@@ -81,9 +81,9 @@
         "bg": [ "t_dirt_summer_center" ],
         "fg": [
           "t_alien_meadow_grass_long_end_piece_n",
-          "t_alien_meadow_grass_long_end_piece_w",
+          "t_alien_meadow_grass_long_end_piece_e",
           "t_alien_meadow_grass_long_end_piece_s",
-          "t_alien_meadow_grass_long_end_piece_e"
+          "t_alien_meadow_grass_long_end_piece_w"
         ]
       },
       { "bg": [ "t_dirt_summer_center" ], "id": "unconnected", "fg": [ "t_alien_meadow_grass_long_unconnected" ] }
@@ -101,9 +101,9 @@
         "bg": [ "t_dirt_autumn_center" ],
         "fg": [
           "t_alien_meadow_grass_long_corner_nw",
-          "t_alien_meadow_grass_long_corner_sw",
+          "t_alien_meadow_grass_long_corner_ne",
           "t_alien_meadow_grass_long_corner_se",
-          "t_alien_meadow_grass_long_corner_ne"
+          "t_alien_meadow_grass_long_corner_sw"
         ]
       },
       {
@@ -111,9 +111,9 @@
         "bg": [ "t_dirt_autumn_center" ],
         "fg": [
           "t_alien_meadow_grass_long_t_connection_n",
-          "t_alien_meadow_grass_long_t_connection_w",
+          "t_alien_meadow_grass_long_t_connection_e",
           "t_alien_meadow_grass_long_t_connection_s",
-          "t_alien_meadow_grass_long_t_connection_e"
+          "t_alien_meadow_grass_long_t_connection_w"
         ]
       },
       {
@@ -126,9 +126,9 @@
         "bg": [ "t_dirt_autumn_center" ],
         "fg": [
           "t_alien_meadow_grass_long_end_piece_n",
-          "t_alien_meadow_grass_long_end_piece_w",
+          "t_alien_meadow_grass_long_end_piece_e",
           "t_alien_meadow_grass_long_end_piece_s",
-          "t_alien_meadow_grass_long_end_piece_e"
+          "t_alien_meadow_grass_long_end_piece_w"
         ]
       },
       { "bg": [ "t_dirt_autumn_center" ], "id": "unconnected", "fg": [ "t_alien_meadow_grass_long_unconnected" ] }
@@ -146,9 +146,9 @@
         "bg": [ "t_dirt_winter_center" ],
         "fg": [
           "t_alien_meadow_grass_long_corner_nw",
-          "t_alien_meadow_grass_long_corner_sw",
+          "t_alien_meadow_grass_long_corner_ne",
           "t_alien_meadow_grass_long_corner_se",
-          "t_alien_meadow_grass_long_corner_ne"
+          "t_alien_meadow_grass_long_corner_sw"
         ]
       },
       {
@@ -156,9 +156,9 @@
         "bg": [ "t_dirt_winter_center" ],
         "fg": [
           "t_alien_meadow_grass_long_t_connection_n",
-          "t_alien_meadow_grass_long_t_connection_w",
+          "t_alien_meadow_grass_long_t_connection_e",
           "t_alien_meadow_grass_long_t_connection_s",
-          "t_alien_meadow_grass_long_t_connection_e"
+          "t_alien_meadow_grass_long_t_connection_w"
         ]
       },
       {
@@ -171,9 +171,9 @@
         "bg": [ "t_dirt_winter_center" ],
         "fg": [
           "t_alien_meadow_grass_long_end_piece_n",
-          "t_alien_meadow_grass_long_end_piece_w",
+          "t_alien_meadow_grass_long_end_piece_e",
           "t_alien_meadow_grass_long_end_piece_s",
-          "t_alien_meadow_grass_long_end_piece_e"
+          "t_alien_meadow_grass_long_end_piece_w"
         ]
       },
       { "bg": [ "t_dirt_winter_center" ], "id": "unconnected", "fg": [ "t_alien_meadow_grass_long_unconnected" ] }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_alien_meadow_grass_tall/t_alien_meadow_grass_tall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_alien_meadow_grass_tall/t_alien_meadow_grass_tall.json
@@ -11,9 +11,9 @@
         "bg": [ "t_dirt_center" ],
         "fg": [
           "t_alien_meadow_grass_tall_corner_nw",
-          "t_alien_meadow_grass_tall_corner_sw",
+          "t_alien_meadow_grass_tall_corner_ne",
           "t_alien_meadow_grass_tall_corner_se",
-          "t_alien_meadow_grass_tall_corner_ne"
+          "t_alien_meadow_grass_tall_corner_sw"
         ]
       },
       {
@@ -21,9 +21,9 @@
         "bg": [ "t_dirt_center" ],
         "fg": [
           "t_alien_meadow_grass_tall_t_connection_n",
-          "t_alien_meadow_grass_tall_t_connection_w",
+          "t_alien_meadow_grass_tall_t_connection_e",
           "t_alien_meadow_grass_tall_t_connection_s",
-          "t_alien_meadow_grass_tall_t_connection_e"
+          "t_alien_meadow_grass_tall_t_connection_w"
         ]
       },
       {
@@ -36,9 +36,9 @@
         "bg": [ "t_dirt_center" ],
         "fg": [
           "t_alien_meadow_grass_tall_end_piece_n",
-          "t_alien_meadow_grass_tall_end_piece_w",
+          "t_alien_meadow_grass_tall_end_piece_e",
           "t_alien_meadow_grass_tall_end_piece_s",
-          "t_alien_meadow_grass_tall_end_piece_e"
+          "t_alien_meadow_grass_tall_end_piece_w"
         ]
       },
       { "bg": [ "t_dirt_center" ], "id": "unconnected", "fg": [ "t_alien_meadow_grass_tall_unconnected" ] }
@@ -56,9 +56,9 @@
         "bg": [ "t_dirt_summer_center" ],
         "fg": [
           "t_alien_meadow_grass_tall_corner_nw",
-          "t_alien_meadow_grass_tall_corner_sw",
+          "t_alien_meadow_grass_tall_corner_ne",
           "t_alien_meadow_grass_tall_corner_se",
-          "t_alien_meadow_grass_tall_corner_ne"
+          "t_alien_meadow_grass_tall_corner_sw"
         ]
       },
       {
@@ -66,9 +66,9 @@
         "bg": [ "t_dirt_summer_center" ],
         "fg": [
           "t_alien_meadow_grass_tall_t_connection_n",
-          "t_alien_meadow_grass_tall_t_connection_w",
+          "t_alien_meadow_grass_tall_t_connection_e",
           "t_alien_meadow_grass_tall_t_connection_s",
-          "t_alien_meadow_grass_tall_t_connection_e"
+          "t_alien_meadow_grass_tall_t_connection_w"
         ]
       },
       {
@@ -81,9 +81,9 @@
         "bg": [ "t_dirt_summer_center" ],
         "fg": [
           "t_alien_meadow_grass_tall_end_piece_n",
-          "t_alien_meadow_grass_tall_end_piece_w",
+          "t_alien_meadow_grass_tall_end_piece_e",
           "t_alien_meadow_grass_tall_end_piece_s",
-          "t_alien_meadow_grass_tall_end_piece_e"
+          "t_alien_meadow_grass_tall_end_piece_w"
         ]
       },
       { "bg": [ "t_dirt_summer_center" ], "id": "unconnected", "fg": [ "t_alien_meadow_grass_tall_unconnected" ] }
@@ -101,9 +101,9 @@
         "bg": [ "t_dirt_autumn_center" ],
         "fg": [
           "t_alien_meadow_grass_tall_corner_nw",
-          "t_alien_meadow_grass_tall_corner_sw",
+          "t_alien_meadow_grass_tall_corner_ne",
           "t_alien_meadow_grass_tall_corner_se",
-          "t_alien_meadow_grass_tall_corner_ne"
+          "t_alien_meadow_grass_tall_corner_sw"
         ]
       },
       {
@@ -111,9 +111,9 @@
         "bg": [ "t_dirt_autumn_center" ],
         "fg": [
           "t_alien_meadow_grass_tall_t_connection_n",
-          "t_alien_meadow_grass_tall_t_connection_w",
+          "t_alien_meadow_grass_tall_t_connection_e",
           "t_alien_meadow_grass_tall_t_connection_s",
-          "t_alien_meadow_grass_tall_t_connection_e"
+          "t_alien_meadow_grass_tall_t_connection_w"
         ]
       },
       {
@@ -126,9 +126,9 @@
         "bg": [ "t_dirt_autumn_center" ],
         "fg": [
           "t_alien_meadow_grass_tall_end_piece_n",
-          "t_alien_meadow_grass_tall_end_piece_w",
+          "t_alien_meadow_grass_tall_end_piece_e",
           "t_alien_meadow_grass_tall_end_piece_s",
-          "t_alien_meadow_grass_tall_end_piece_e"
+          "t_alien_meadow_grass_tall_end_piece_w"
         ]
       },
       { "bg": [ "t_dirt_autumn_center" ], "id": "unconnected", "fg": [ "t_alien_meadow_grass_tall_unconnected" ] }
@@ -146,9 +146,9 @@
         "bg": [ "t_dirt_winter_center" ],
         "fg": [
           "t_alien_meadow_grass_tall_corner_nw",
-          "t_alien_meadow_grass_tall_corner_sw",
+          "t_alien_meadow_grass_tall_corner_ne",
           "t_alien_meadow_grass_tall_corner_se",
-          "t_alien_meadow_grass_tall_corner_ne"
+          "t_alien_meadow_grass_tall_corner_sw"
         ]
       },
       {
@@ -156,9 +156,9 @@
         "bg": [ "t_dirt_winter_center" ],
         "fg": [
           "t_alien_meadow_grass_tall_t_connection_n",
-          "t_alien_meadow_grass_tall_t_connection_w",
+          "t_alien_meadow_grass_tall_t_connection_e",
           "t_alien_meadow_grass_tall_t_connection_s",
-          "t_alien_meadow_grass_tall_t_connection_e"
+          "t_alien_meadow_grass_tall_t_connection_w"
         ]
       },
       {
@@ -171,9 +171,9 @@
         "bg": [ "t_dirt_winter_center" ],
         "fg": [
           "t_alien_meadow_grass_tall_end_piece_n",
-          "t_alien_meadow_grass_tall_end_piece_w",
+          "t_alien_meadow_grass_tall_end_piece_e",
           "t_alien_meadow_grass_tall_end_piece_s",
-          "t_alien_meadow_grass_tall_end_piece_e"
+          "t_alien_meadow_grass_tall_end_piece_w"
         ]
       },
       { "bg": [ "t_dirt_winter_center" ], "id": "unconnected", "fg": [ "t_alien_meadow_grass_tall_unconnected" ] }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_alien_meadow_pond_goo/t_alien_meadow_pond_goo.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_alien_meadow_pond_goo/t_alien_meadow_pond_goo.json
@@ -11,9 +11,9 @@
         "bg": [ "t_dirt_center" ],
         "fg": [
           "t_alien_meadow_pond_goo_corner_nw",
-          "t_alien_meadow_pond_goo_corner_sw",
+          "t_alien_meadow_pond_goo_corner_ne",
           "t_alien_meadow_pond_goo_corner_se",
-          "t_alien_meadow_pond_goo_corner_ne"
+          "t_alien_meadow_pond_goo_corner_sw"
         ]
       },
       {
@@ -21,9 +21,9 @@
         "bg": [ "t_dirt_center" ],
         "fg": [
           "t_alien_meadow_pond_goo_t_connection_n",
-          "t_alien_meadow_pond_goo_t_connection_w",
+          "t_alien_meadow_pond_goo_t_connection_e",
           "t_alien_meadow_pond_goo_t_connection_s",
-          "t_alien_meadow_pond_goo_t_connection_e"
+          "t_alien_meadow_pond_goo_t_connection_w"
         ]
       },
       {
@@ -36,9 +36,9 @@
         "bg": [ "t_dirt_center" ],
         "fg": [
           "t_alien_meadow_pond_goo_end_piece_n",
-          "t_alien_meadow_pond_goo_end_piece_w",
+          "t_alien_meadow_pond_goo_end_piece_e",
           "t_alien_meadow_pond_goo_end_piece_s",
-          "t_alien_meadow_pond_goo_end_piece_e"
+          "t_alien_meadow_pond_goo_end_piece_w"
         ]
       },
       { "bg": [ "t_dirt_center" ], "id": "unconnected", "fg": [ "t_alien_meadow_pond_goo_unconnected" ] }
@@ -56,9 +56,9 @@
         "bg": [ "t_dirt_summer_center" ],
         "fg": [
           "t_alien_meadow_pond_goo_corner_nw",
-          "t_alien_meadow_pond_goo_corner_sw",
+          "t_alien_meadow_pond_goo_corner_ne",
           "t_alien_meadow_pond_goo_corner_se",
-          "t_alien_meadow_pond_goo_corner_ne"
+          "t_alien_meadow_pond_goo_corner_sw"
         ]
       },
       {
@@ -66,9 +66,9 @@
         "bg": [ "t_dirt_summer_center" ],
         "fg": [
           "t_alien_meadow_pond_goo_t_connection_n",
-          "t_alien_meadow_pond_goo_t_connection_w",
+          "t_alien_meadow_pond_goo_t_connection_e",
           "t_alien_meadow_pond_goo_t_connection_s",
-          "t_alien_meadow_pond_goo_t_connection_e"
+          "t_alien_meadow_pond_goo_t_connection_w"
         ]
       },
       {
@@ -81,9 +81,9 @@
         "bg": [ "t_dirt_summer_center" ],
         "fg": [
           "t_alien_meadow_pond_goo_end_piece_n",
-          "t_alien_meadow_pond_goo_end_piece_w",
+          "t_alien_meadow_pond_goo_end_piece_e",
           "t_alien_meadow_pond_goo_end_piece_s",
-          "t_alien_meadow_pond_goo_end_piece_e"
+          "t_alien_meadow_pond_goo_end_piece_w"
         ]
       },
       { "bg": [ "t_dirt_summer_center" ], "id": "unconnected", "fg": [ "t_alien_meadow_pond_goo_unconnected" ] }
@@ -101,9 +101,9 @@
         "bg": [ "t_dirt_autumn_center" ],
         "fg": [
           "t_alien_meadow_pond_goo_corner_nw",
-          "t_alien_meadow_pond_goo_corner_sw",
+          "t_alien_meadow_pond_goo_corner_ne",
           "t_alien_meadow_pond_goo_corner_se",
-          "t_alien_meadow_pond_goo_corner_ne"
+          "t_alien_meadow_pond_goo_corner_sw"
         ]
       },
       {
@@ -111,9 +111,9 @@
         "bg": [ "t_dirt_autumn_center" ],
         "fg": [
           "t_alien_meadow_pond_goo_t_connection_n",
-          "t_alien_meadow_pond_goo_t_connection_w",
+          "t_alien_meadow_pond_goo_t_connection_e",
           "t_alien_meadow_pond_goo_t_connection_s",
-          "t_alien_meadow_pond_goo_t_connection_e"
+          "t_alien_meadow_pond_goo_t_connection_w"
         ]
       },
       {
@@ -126,9 +126,9 @@
         "bg": [ "t_dirt_autumn_center" ],
         "fg": [
           "t_alien_meadow_pond_goo_end_piece_n",
-          "t_alien_meadow_pond_goo_end_piece_w",
+          "t_alien_meadow_pond_goo_end_piece_e",
           "t_alien_meadow_pond_goo_end_piece_s",
-          "t_alien_meadow_pond_goo_end_piece_e"
+          "t_alien_meadow_pond_goo_end_piece_w"
         ]
       },
       { "bg": [ "t_dirt_autumn_center" ], "id": "unconnected", "fg": [ "t_alien_meadow_pond_goo_unconnected" ] }
@@ -146,9 +146,9 @@
         "bg": [ "t_dirt_winter_center" ],
         "fg": [
           "t_alien_meadow_pond_goo_corner_nw",
-          "t_alien_meadow_pond_goo_corner_sw",
+          "t_alien_meadow_pond_goo_corner_ne",
           "t_alien_meadow_pond_goo_corner_se",
-          "t_alien_meadow_pond_goo_corner_ne"
+          "t_alien_meadow_pond_goo_corner_sw"
         ]
       },
       {
@@ -156,9 +156,9 @@
         "bg": [ "t_dirt_winter_center" ],
         "fg": [
           "t_alien_meadow_pond_goo_t_connection_n",
-          "t_alien_meadow_pond_goo_t_connection_w",
+          "t_alien_meadow_pond_goo_t_connection_e",
           "t_alien_meadow_pond_goo_t_connection_s",
-          "t_alien_meadow_pond_goo_t_connection_e"
+          "t_alien_meadow_pond_goo_t_connection_w"
         ]
       },
       {
@@ -171,9 +171,9 @@
         "bg": [ "t_dirt_winter_center" ],
         "fg": [
           "t_alien_meadow_pond_goo_end_piece_n",
-          "t_alien_meadow_pond_goo_end_piece_w",
+          "t_alien_meadow_pond_goo_end_piece_e",
           "t_alien_meadow_pond_goo_end_piece_s",
-          "t_alien_meadow_pond_goo_end_piece_e"
+          "t_alien_meadow_pond_goo_end_piece_w"
         ]
       },
       { "bg": [ "t_dirt_winter_center" ], "id": "unconnected", "fg": [ "t_alien_meadow_pond_goo_unconnected" ] }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_brick_wall/t_brick_wall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_brick_wall/t_brick_wall.json
@@ -10,21 +10,21 @@
     { "id": "center", "fg": "t_brick_wall_center" },
     {
       "id": "corner",
-      "fg": [ "t_brick_wall_corner_nw", "t_brick_wall_corner_sw", "t_brick_wall_corner_se", "t_brick_wall_corner_ne" ]
+      "fg": [ "t_brick_wall_corner_nw", "t_brick_wall_corner_ne", "t_brick_wall_corner_se", "t_brick_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_brick_wall_t_connection_n",
-        "t_brick_wall_t_connection_w",
+        "t_brick_wall_t_connection_e",
         "t_brick_wall_t_connection_s",
-        "t_brick_wall_t_connection_e"
+        "t_brick_wall_t_connection_w"
       ]
     },
     { "id": "edge", "fg": [ "t_brick_wall_edge_ns", "t_brick_wall_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [ "t_brick_wall_end_piece_n", "t_brick_wall_end_piece_w", "t_brick_wall_end_piece_s", "t_brick_wall_end_piece_e" ]
+      "fg": [ "t_brick_wall_end_piece_n", "t_brick_wall_end_piece_e", "t_brick_wall_end_piece_s", "t_brick_wall_end_piece_w" ]
     },
     { "id": "unconnected", "fg": [ "t_brick_wall_unconnected", "t_brick_wall_unconnected" ] }
   ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_concrete_railing/t_concrete_railing.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_concrete_railing/t_concrete_railing.json
@@ -4,18 +4,14 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_railing_unconnected",
-      "bg": "t_concrete"
-    },
+    { "id": "center", "fg": "t_concrete_railing_unconnected", "bg": "t_concrete" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_railing_corner_nw",
-        "t_concrete_railing_corner_sw",
+        "t_concrete_railing_corner_ne",
         "t_concrete_railing_corner_se",
-        "t_concrete_railing_corner_ne"
+        "t_concrete_railing_corner_sw"
       ],
       "bg": "t_concrete"
     },
@@ -29,14 +25,7 @@
       ],
       "bg": "t_concrete"
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_railing_edge_ns",
-        "t_concrete_railing_unconnected"
-      ],
-      "bg": "t_concrete"
-    },
+    { "id": "edge", "fg": [ "t_concrete_railing_edge_ns", "t_concrete_railing_unconnected" ], "bg": "t_concrete" },
     {
       "id": "end_piece",
       "fg": [
@@ -49,10 +38,7 @@
     },
     {
       "id": "unconnected",
-      "fg": [
-        "t_concrete_railing_unconnected",
-        "t_concrete_railing_unconnected"
-      ],
+      "fg": [ "t_concrete_railing_unconnected", "t_concrete_railing_unconnected" ],
       "bg": "t_concrete"
     }
   ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_concrete_wall/t_concrete_wall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_concrete_wall/t_concrete_wall.json
@@ -12,15 +12,15 @@
       "fg": [
         {
           "weight": 1,
-          "sprite": [ "t_concrete_wall_corner_nw", "t_concrete_wall_corner_sw", "t_concrete_wall_corner_se", "t_concrete_wall_corner_ne" ]
+          "sprite": [ "t_concrete_wall_corner_nw", "t_concrete_wall_corner_ne", "t_concrete_wall_corner_se", "t_concrete_wall_corner_sw" ]
         },
         {
           "weight": 1,
           "sprite": [
             "t_concrete_wall2_corner_nw",
-            "t_concrete_wall2_corner_sw",
+            "t_concrete_wall2_corner_ne",
             "t_concrete_wall2_corner_se",
-            "t_concrete_wall2_corner_ne"
+            "t_concrete_wall2_corner_sw"
           ]
         }
       ]
@@ -32,18 +32,18 @@
           "weight": 1,
           "sprite": [
             "t_concrete_wall_t_connection_n",
-            "t_concrete_wall_t_connection_w",
+            "t_concrete_wall_t_connection_e",
             "t_concrete_wall_t_connection_s",
-            "t_concrete_wall_t_connection_e"
+            "t_concrete_wall_t_connection_w"
           ]
         },
         {
           "weight": 1,
           "sprite": [
             "t_concrete_wall2_t_connection_n",
-            "t_concrete_wall2_t_connection_w",
+            "t_concrete_wall2_t_connection_e",
             "t_concrete_wall2_t_connection_s",
-            "t_concrete_wall2_t_connection_e"
+            "t_concrete_wall2_t_connection_w"
           ]
         }
       ]
@@ -62,18 +62,18 @@
           "weight": 1,
           "sprite": [
             "t_concrete_wall_end_piece_n",
-            "t_concrete_wall_end_piece_w",
+            "t_concrete_wall_end_piece_e",
             "t_concrete_wall_end_piece_s",
-            "t_concrete_wall_end_piece_e"
+            "t_concrete_wall_end_piece_w"
           ]
         },
         {
           "weight": 1,
           "sprite": [
             "t_concrete_wall2_end_piece_n",
-            "t_concrete_wall2_end_piece_w",
+            "t_concrete_wall2_end_piece_e",
             "t_concrete_wall2_end_piece_s",
-            "t_concrete_wall2_end_piece_e"
+            "t_concrete_wall2_end_piece_w"
           ]
         }
       ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_concrete_wall_flesh/t_concrete_wall_flesh.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_concrete_wall_flesh/t_concrete_wall_flesh.json
@@ -3,50 +3,35 @@
   "fg": "t_concrete_wall_flesh_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_flesh_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_flesh_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_flesh_corner_nw",
-        "t_concrete_wall_flesh_corner_sw",
+        "t_concrete_wall_flesh_corner_ne",
         "t_concrete_wall_flesh_corner_se",
-        "t_concrete_wall_flesh_corner_ne"
+        "t_concrete_wall_flesh_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_flesh_t_connection_n",
-        "t_concrete_wall_flesh_t_connection_w",
+        "t_concrete_wall_flesh_t_connection_e",
         "t_concrete_wall_flesh_t_connection_s",
-        "t_concrete_wall_flesh_t_connection_e"
+        "t_concrete_wall_flesh_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_flesh_edge_ns",
-        "t_concrete_wall_flesh_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_flesh_edge_ns", "t_concrete_wall_flesh_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_flesh_end_piece_n",
-        "t_concrete_wall_flesh_end_piece_w",
+        "t_concrete_wall_flesh_end_piece_e",
         "t_concrete_wall_flesh_end_piece_s",
-        "t_concrete_wall_flesh_end_piece_e"
+        "t_concrete_wall_flesh_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_concrete_wall_flesh_unconnected",
-        "t_concrete_wall_flesh_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_concrete_wall_flesh_unconnected", "t_concrete_wall_flesh_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_dirt/t_dirt.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_dirt/t_dirt.json
@@ -5,15 +5,15 @@
     "multitile": true,
     "additional_tiles": [
       { "id": "center", "fg": "t_dirt_center" },
-      { "id": "corner", "fg": [ "t_dirt_corner_nw", "t_dirt_corner_sw", "t_dirt_corner_se", "t_dirt_corner_ne" ] },
+      { "id": "corner", "fg": [ "t_dirt_corner_nw", "t_dirt_corner_ne", "t_dirt_corner_se", "t_dirt_corner_sw" ] },
       {
         "id": "t_connection",
-        "fg": [ "t_dirt_t_connection_n", "t_dirt_t_connection_w", "t_dirt_t_connection_s", "t_dirt_t_connection_e" ]
+        "fg": [ "t_dirt_t_connection_n", "t_dirt_t_connection_e", "t_dirt_t_connection_s", "t_dirt_t_connection_w" ]
       },
       { "id": "edge", "fg": [ "t_dirt_edge_ns", "t_dirt_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_dirt_end_piece_n", "t_dirt_end_piece_w", "t_dirt_end_piece_s", "t_dirt_end_piece_e" ]
+        "fg": [ "t_dirt_end_piece_n", "t_dirt_end_piece_e", "t_dirt_end_piece_s", "t_dirt_end_piece_w" ]
       },
       { "id": "unconnected", "fg": [ "t_dirt_unconnected", "t_dirt_unconnected" ] }
     ]
@@ -26,21 +26,21 @@
       { "id": "center", "fg": "t_dirt_winter_center" },
       {
         "id": "corner",
-        "fg": [ "t_dirt_winter_corner_nw", "t_dirt_winter_corner_sw", "t_dirt_winter_corner_se", "t_dirt_winter_corner_ne" ]
+        "fg": [ "t_dirt_winter_corner_nw", "t_dirt_winter_corner_ne", "t_dirt_winter_corner_se", "t_dirt_winter_corner_sw" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_dirt_winter_t_connection_n",
-          "t_dirt_winter_t_connection_w",
+          "t_dirt_winter_t_connection_e",
           "t_dirt_winter_t_connection_s",
-          "t_dirt_winter_t_connection_e"
+          "t_dirt_winter_t_connection_w"
         ]
       },
       { "id": "edge", "fg": [ "t_dirt_winter_edge_ns", "t_dirt_winter_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_dirt_winter_end_piece_n", "t_dirt_winter_end_piece_w", "t_dirt_winter_end_piece_s", "t_dirt_winter_end_piece_e" ]
+        "fg": [ "t_dirt_winter_end_piece_n", "t_dirt_winter_end_piece_e", "t_dirt_winter_end_piece_s", "t_dirt_winter_end_piece_w" ]
       },
       {
         "id": "unconnected",
@@ -60,21 +60,21 @@
       { "id": "center", "fg": "t_dirt_autumn_center" },
       {
         "id": "corner",
-        "fg": [ "t_dirt_autumn_corner_nw", "t_dirt_autumn_corner_sw", "t_dirt_autumn_corner_se", "t_dirt_autumn_corner_ne" ]
+        "fg": [ "t_dirt_autumn_corner_nw", "t_dirt_autumn_corner_ne", "t_dirt_autumn_corner_se", "t_dirt_autumn_corner_sw" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_dirt_autumn_t_connection_n",
-          "t_dirt_autumn_t_connection_w",
+          "t_dirt_autumn_t_connection_e",
           "t_dirt_autumn_t_connection_s",
-          "t_dirt_autumn_t_connection_e"
+          "t_dirt_autumn_t_connection_w"
         ]
       },
       { "id": "edge", "fg": [ "t_dirt_autumn_edge_ns", "t_dirt_autumn_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_dirt_autumn_end_piece_n", "t_dirt_autumn_end_piece_w", "t_dirt_autumn_end_piece_s", "t_dirt_autumn_end_piece_e" ]
+        "fg": [ "t_dirt_autumn_end_piece_n", "t_dirt_autumn_end_piece_e", "t_dirt_autumn_end_piece_s", "t_dirt_autumn_end_piece_w" ]
       },
       { "id": "unconnected", "fg": [ "t_dirt_autumn_unconnected", "t_dirt_autumn_unconnected" ] }
     ]
@@ -87,21 +87,21 @@
       { "id": "center", "fg": "t_dirt_summer_center" },
       {
         "id": "corner",
-        "fg": [ "t_dirt_summer_corner_nw", "t_dirt_summer_corner_sw", "t_dirt_summer_corner_se", "t_dirt_summer_corner_ne" ]
+        "fg": [ "t_dirt_summer_corner_nw", "t_dirt_summer_corner_ne", "t_dirt_summer_corner_se", "t_dirt_summer_corner_sw" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_dirt_summer_t_connection_n",
-          "t_dirt_summer_t_connection_w",
+          "t_dirt_summer_t_connection_e",
           "t_dirt_summer_t_connection_s",
-          "t_dirt_summer_t_connection_e"
+          "t_dirt_summer_t_connection_w"
         ]
       },
       { "id": "edge", "fg": [ "t_dirt_summer_edge_ns", "t_dirt_summer_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_dirt_summer_end_piece_n", "t_dirt_summer_end_piece_w", "t_dirt_summer_end_piece_s", "t_dirt_summer_end_piece_e" ]
+        "fg": [ "t_dirt_summer_end_piece_n", "t_dirt_summer_end_piece_e", "t_dirt_summer_end_piece_s", "t_dirt_summer_end_piece_w" ]
       },
       { "id": "unconnected", "fg": [ "t_dirt_summer_unconnected", "t_dirt_summer_unconnected" ] }
     ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_dock/t_dock.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_dock/t_dock.json
@@ -4,56 +4,23 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_dock_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "t_dock_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "t_dock_corner_nw",
-        "t_dock_corner_sw",
-        "t_dock_corner_se",
-        "t_dock_corner_ne"
-      ],
+      "fg": [ "t_dock_corner_nw", "t_dock_corner_ne", "t_dock_corner_se", "t_dock_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_dock_t_connection_n",
-        "t_dock_t_connection_w",
-        "t_dock_t_connection_s",
-        "t_dock_t_connection_e"
-      ],
+      "fg": [ "t_dock_t_connection_n", "t_dock_t_connection_e", "t_dock_t_connection_s", "t_dock_t_connection_w" ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_dock_edge_ns",
-        "t_dock_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "t_dock_edge_ns", "t_dock_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "t_dock_end_piece_n",
-        "t_dock_end_piece_w",
-        "t_dock_end_piece_s",
-        "t_dock_end_piece_e"
-      ],
+      "fg": [ "t_dock_end_piece_n", "t_dock_end_piece_e", "t_dock_end_piece_s", "t_dock_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_dock_unconnected",
-        "t_dock_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "t_dock_unconnected", "t_dock_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_dock_deep/t_dock_deep.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_dock_deep/t_dock_deep.json
@@ -4,56 +4,28 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_dock_deep_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "t_dock_deep_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "t_dock_deep_corner_nw",
-        "t_dock_deep_corner_sw",
-        "t_dock_deep_corner_se",
-        "t_dock_deep_corner_ne"
-      ],
+      "fg": [ "t_dock_deep_corner_nw", "t_dock_deep_corner_ne", "t_dock_deep_corner_se", "t_dock_deep_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
       "fg": [
         "t_dock_deep_t_connection_n",
-        "t_dock_deep_t_connection_w",
+        "t_dock_deep_t_connection_e",
         "t_dock_deep_t_connection_s",
-        "t_dock_deep_t_connection_e"
+        "t_dock_deep_t_connection_w"
       ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_dock_deep_edge_ns",
-        "t_dock_deep_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "t_dock_deep_edge_ns", "t_dock_deep_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "t_dock_deep_end_piece_n",
-        "t_dock_deep_end_piece_w",
-        "t_dock_deep_end_piece_s",
-        "t_dock_deep_end_piece_e"
-      ],
+      "fg": [ "t_dock_deep_end_piece_n", "t_dock_deep_end_piece_e", "t_dock_deep_end_piece_s", "t_dock_deep_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_dock_deep_unconnected",
-        "t_dock_deep_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "t_dock_deep_unconnected", "t_dock_deep_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_fence_metal/t_fence_metal.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_fence_metal/t_fence_metal.json
@@ -4,56 +4,28 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_fence_metal_unconnected",
-      "bg": "t_floor"
-    },
+    { "id": "center", "fg": "t_fence_metal_unconnected", "bg": "t_floor" },
     {
       "id": "corner",
-      "fg": [
-        "t_fence_metal_corner_nw",
-        "t_fence_metal_corner_sw",
-        "t_fence_metal_corner_se",
-        "t_fence_metal_corner_ne"
-      ],
+      "fg": [ "t_fence_metal_corner_nw", "t_fence_metal_corner_ne", "t_fence_metal_corner_se", "t_fence_metal_corner_sw" ],
       "bg": "t_floor"
     },
     {
       "id": "t_connection",
       "fg": [
         "t_fence_metal_unconnected",
-        "t_fence_metal_t_connection_w",
+        "t_fence_metal_t_connection_e",
         "t_fence_metal_unconnected",
-        "t_fence_metal_t_connection_e"
+        "t_fence_metal_t_connection_w"
       ],
       "bg": "t_floor"
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_fence_metal_edge_ns",
-        "t_fence_metal_unconnected"
-      ],
-      "bg": "t_floor"
-    },
+    { "id": "edge", "fg": [ "t_fence_metal_edge_ns", "t_fence_metal_unconnected" ], "bg": "t_floor" },
     {
       "id": "end_piece",
-      "fg": [
-        "t_fence_metal_end_piece_n",
-        "t_fence_metal_unconnected",
-        "t_fence_metal_end_piece_s",
-        "t_fence_metal_unconnected"
-      ],
+      "fg": [ "t_fence_metal_end_piece_n", "t_fence_metal_unconnected", "t_fence_metal_end_piece_s", "t_fence_metal_unconnected" ],
       "bg": "t_floor"
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_fence_metal_unconnected",
-        "t_fence_metal_unconnected"
-      ],
-      "bg": "t_floor"
-    }
+    { "id": "unconnected", "fg": [ "t_fence_metal_unconnected", "t_fence_metal_unconnected" ], "bg": "t_floor" }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_fence_rope/t_fence_rope.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_fence_rope/t_fence_rope.json
@@ -16,7 +16,7 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_sw", "t_fence_rope_corner_se", "t_fence_rope_corner_ne" ],
+        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_ne", "t_fence_rope_corner_se", "t_fence_rope_corner_sw" ],
         "bg": [
           { "weight": 100, "sprite": "t_grass" },
           { "weight": 100, "sprite": "t_grass_1" },
@@ -43,7 +43,7 @@
       },
       {
         "id": "end_piece",
-        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_w", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_e" ],
+        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_e", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_w" ],
         "bg": [
           { "weight": 100, "sprite": "t_grass" },
           { "weight": 100, "sprite": "t_grass_1" },
@@ -78,7 +78,7 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_sw", "t_fence_rope_corner_se", "t_fence_rope_corner_ne" ],
+        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_ne", "t_fence_rope_corner_se", "t_fence_rope_corner_sw" ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_summer" },
           { "weight": 100, "sprite": "t_grass_summer_1" },
@@ -105,7 +105,7 @@
       },
       {
         "id": "end_piece",
-        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_w", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_e" ],
+        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_e", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_w" ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_summer" },
           { "weight": 100, "sprite": "t_grass_summer_1" },
@@ -140,7 +140,7 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_sw", "t_fence_rope_corner_se", "t_fence_rope_corner_ne" ],
+        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_ne", "t_fence_rope_corner_se", "t_fence_rope_corner_sw" ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_autumn" },
           { "weight": 100, "sprite": "t_grass_autumn_1" },
@@ -167,7 +167,7 @@
       },
       {
         "id": "end_piece",
-        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_w", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_e" ],
+        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_e", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_w" ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_autumn" },
           { "weight": 100, "sprite": "t_grass_autumn_1" },
@@ -202,7 +202,7 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_sw", "t_fence_rope_corner_se", "t_fence_rope_corner_ne" ],
+        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_ne", "t_fence_rope_corner_se", "t_fence_rope_corner_sw" ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_winter" },
           { "weight": 100, "sprite": "t_grass_winter_1" },
@@ -229,7 +229,7 @@
       },
       {
         "id": "end_piece",
-        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_w", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_e" ],
+        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_e", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_w" ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_winter" },
           { "weight": 100, "sprite": "t_grass_winter_1" },

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_glass_railing/t_glass_railing.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_glass_railing/t_glass_railing.json
@@ -6,48 +6,33 @@
   "additional_tiles": [
     {
       "id": "corner",
-      "fg": [
-        "t_glass_railing_corner_nw",
-        "t_glass_railing_corner_sw",
-        "t_glass_railing_corner_se",
-        "t_glass_railing_corner_ne"
-      ],
+      "fg": [ "t_glass_railing_corner_nw", "t_glass_railing_corner_ne", "t_glass_railing_corner_se", "t_glass_railing_corner_sw" ],
       "bg": "t_pavement"
     },
     {
       "id": "t_connection",
       "fg": [
         "t_glass_railing_t_connection_n",
-        "t_glass_railing_t_connection_w",
+        "t_glass_railing_t_connection_e",
         "t_glass_railing_t_connection_s",
-        "t_glass_railing_t_connection_e"
+        "t_glass_railing_t_connection_w"
       ],
       "bg": "t_pavement"
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_glass_railing_edge_ns",
-        "t_glass_railing_edge_ew"
-      ],
-      "bg": "t_pavement"
-    },
+    { "id": "edge", "fg": [ "t_glass_railing_edge_ns", "t_glass_railing_edge_ew" ], "bg": "t_pavement" },
     {
       "id": "end_piece",
       "fg": [
         "t_glass_railing_end_piece_n",
-        "t_glass_railing_end_piece_w",
+        "t_glass_railing_end_piece_e",
         "t_glass_railing_end_piece_s",
-        "t_glass_railing_end_piece_e"
+        "t_glass_railing_end_piece_w"
       ],
       "bg": "t_pavement"
     },
     {
       "id": "unconnected",
-      "fg": [
-        "t_glass_railing_unconnected",
-        "t_glass_railing_unconnected"
-      ],
+      "fg": [ "t_glass_railing_unconnected", "t_glass_railing_unconnected" ],
       "bg": "t_pavement"
     }
   ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_glass_roof/t_glass_roof.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_glass_roof/t_glass_roof.json
@@ -3,50 +3,25 @@
   "fg": "t_glass_roof_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_glass_roof_center"
-    },
+    { "id": "center", "fg": "t_glass_roof_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_glass_roof_corner_nw",
-        "t_glass_roof_corner_sw",
-        "t_glass_roof_corner_se",
-        "t_glass_roof_corner_ne"
-      ]
+      "fg": [ "t_glass_roof_corner_nw", "t_glass_roof_corner_ne", "t_glass_roof_corner_se", "t_glass_roof_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_glass_roof_t_connection_n",
-        "t_glass_roof_t_connection_w",
+        "t_glass_roof_t_connection_e",
         "t_glass_roof_t_connection_s",
-        "t_glass_roof_t_connection_e"
+        "t_glass_roof_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_glass_roof_edge_ns",
-        "t_glass_roof_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_glass_roof_edge_ns", "t_glass_roof_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_glass_roof_end_piece_n",
-        "t_glass_roof_end_piece_w",
-        "t_glass_roof_end_piece_s",
-        "t_glass_roof_end_piece_e"
-      ]
+      "fg": [ "t_glass_roof_end_piece_n", "t_glass_roof_end_piece_e", "t_glass_roof_end_piece_s", "t_glass_roof_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_glass_roof_unconnected",
-        "t_glass_roof_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_glass_roof_unconnected", "t_glass_roof_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_grass_dead/t_grass_dead.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_grass_dead/t_grass_dead.json
@@ -7,21 +7,21 @@
       { "id": "center", "fg": "t_grass_dead_center" },
       {
         "id": "corner",
-        "fg": [ "t_grass_dead_corner_nw", "t_grass_dead_corner_sw", "t_grass_dead_corner_se", "t_grass_dead_corner_ne" ]
+        "fg": [ "t_grass_dead_corner_nw", "t_grass_dead_corner_ne", "t_grass_dead_corner_se", "t_grass_dead_corner_sw" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_grass_dead_t_connection_n",
-          "t_grass_dead_t_connection_w",
+          "t_grass_dead_t_connection_e",
           "t_grass_dead_t_connection_s",
-          "t_grass_dead_t_connection_e"
+          "t_grass_dead_t_connection_w"
         ]
       },
       { "id": "edge", "fg": [ "t_grass_dead_edge_ns", "t_grass_dead_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_grass_dead_end_piece_n", "t_grass_dead_end_piece_w", "t_grass_dead_end_piece_s", "t_grass_dead_end_piece_e" ]
+        "fg": [ "t_grass_dead_end_piece_n", "t_grass_dead_end_piece_e", "t_grass_dead_end_piece_s", "t_grass_dead_end_piece_w" ]
       },
       { "id": "unconnected", "fg": [ "t_grass_dead_unconnected", "t_grass_dead_unconnected" ] }
     ]
@@ -45,18 +45,18 @@
         "id": "corner",
         "fg": [
           "t_grass_dead_winter_corner_nw",
-          "t_grass_dead_winter_corner_sw",
+          "t_grass_dead_winter_corner_ne",
           "t_grass_dead_winter_corner_se",
-          "t_grass_dead_winter_corner_ne"
+          "t_grass_dead_winter_corner_sw"
         ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_grass_dead_winter_t_connection_n",
-          "t_grass_dead_winter_t_connection_w",
+          "t_grass_dead_winter_t_connection_e",
           "t_grass_dead_winter_t_connection_s",
-          "t_grass_dead_winter_t_connection_e"
+          "t_grass_dead_winter_t_connection_w"
         ]
       },
       { "id": "edge", "fg": [ "t_grass_dead_winter_edge_ns", "t_grass_dead_winter_edge_ew" ] },
@@ -64,9 +64,9 @@
         "id": "end_piece",
         "fg": [
           "t_grass_dead_winter_end_piece_n",
-          "t_grass_dead_winter_end_piece_w",
+          "t_grass_dead_winter_end_piece_e",
           "t_grass_dead_winter_end_piece_s",
-          "t_grass_dead_winter_end_piece_e"
+          "t_grass_dead_winter_end_piece_w"
         ]
       },
       {
@@ -89,18 +89,18 @@
         "id": "corner",
         "fg": [
           "t_grass_dead_autumn_corner_nw",
-          "t_grass_dead_autumn_corner_sw",
+          "t_grass_dead_autumn_corner_ne",
           "t_grass_dead_autumn_corner_se",
-          "t_grass_dead_autumn_corner_ne"
+          "t_grass_dead_autumn_corner_sw"
         ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_grass_dead_autumn_t_connection_n",
-          "t_grass_dead_autumn_t_connection_w",
+          "t_grass_dead_autumn_t_connection_e",
           "t_grass_dead_autumn_t_connection_s",
-          "t_grass_dead_autumn_t_connection_e"
+          "t_grass_dead_autumn_t_connection_w"
         ]
       },
       { "id": "edge", "fg": [ "t_grass_dead_autumn_edge_ns", "t_grass_dead_autumn_edge_ew" ] },
@@ -108,9 +108,9 @@
         "id": "end_piece",
         "fg": [
           "t_grass_dead_autumn_end_piece_n",
-          "t_grass_dead_autumn_end_piece_w",
+          "t_grass_dead_autumn_end_piece_e",
           "t_grass_dead_autumn_end_piece_s",
-          "t_grass_dead_autumn_end_piece_e"
+          "t_grass_dead_autumn_end_piece_w"
         ]
       },
       { "id": "unconnected", "fg": [ "t_grass_dead_autumn_unconnected", "t_grass_dead_autumn_unconnected" ] }
@@ -126,18 +126,18 @@
         "id": "corner",
         "fg": [
           "t_grass_dead_summer_corner_nw",
-          "t_grass_dead_summer_corner_sw",
+          "t_grass_dead_summer_corner_ne",
           "t_grass_dead_summer_corner_se",
-          "t_grass_dead_summer_corner_ne"
+          "t_grass_dead_summer_corner_sw"
         ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_grass_dead_summer_t_connection_n",
-          "t_grass_dead_summer_t_connection_w",
+          "t_grass_dead_summer_t_connection_e",
           "t_grass_dead_summer_t_connection_s",
-          "t_grass_dead_summer_t_connection_e"
+          "t_grass_dead_summer_t_connection_w"
         ]
       },
       { "id": "edge", "fg": [ "t_grass_dead_summer_edge_ns", "t_grass_dead_summer_edge_ew" ] },
@@ -145,9 +145,9 @@
         "id": "end_piece",
         "fg": [
           "t_grass_dead_summer_end_piece_n",
-          "t_grass_dead_summer_end_piece_w",
+          "t_grass_dead_summer_end_piece_e",
           "t_grass_dead_summer_end_piece_s",
-          "t_grass_dead_summer_end_piece_e"
+          "t_grass_dead_summer_end_piece_w"
         ]
       },
       { "id": "unconnected", "fg": [ "t_grass_dead_summer_unconnected", "t_grass_dead_summer_unconnected" ] }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_grass_long/t_grass_long.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_grass_long/t_grass_long.json
@@ -11,16 +11,16 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_grass_long_corner_nw", "t_grass_long_corner_sw", "t_grass_long_corner_se", "t_grass_long_corner_ne" ],
+        "fg": [ "t_grass_long_corner_nw", "t_grass_long_corner_ne", "t_grass_long_corner_se", "t_grass_long_corner_sw" ],
         "bg": [ { "weight": 1, "sprite": "t_grass" }, { "weight": 1, "sprite": "t_grass_1" }, { "weight": 1, "sprite": "t_grass_2" } ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_grass_long_t_connection_n",
-          "t_grass_long_t_connection_w",
+          "t_grass_long_t_connection_e",
           "t_grass_long_t_connection_s",
-          "t_grass_long_t_connection_e"
+          "t_grass_long_t_connection_w"
         ],
         "bg": [ { "weight": 1, "sprite": "t_grass" }, { "weight": 1, "sprite": "t_grass_1" }, { "weight": 1, "sprite": "t_grass_2" } ]
       },
@@ -31,7 +31,7 @@
       },
       {
         "id": "end_piece",
-        "fg": [ "t_grass_long_end_piece_n", "t_grass_long_end_piece_w", "t_grass_long_end_piece_s", "t_grass_long_end_piece_e" ],
+        "fg": [ "t_grass_long_end_piece_n", "t_grass_long_end_piece_e", "t_grass_long_end_piece_s", "t_grass_long_end_piece_w" ],
         "bg": [ { "weight": 1, "sprite": "t_grass" }, { "weight": 1, "sprite": "t_grass_1" }, { "weight": 1, "sprite": "t_grass_2" } ]
       },
       {
@@ -59,9 +59,9 @@
         "id": "corner",
         "fg": [
           "t_grass_long_autumn_corner_nw",
-          "t_grass_long_autumn_corner_sw",
+          "t_grass_long_autumn_corner_ne",
           "t_grass_long_autumn_corner_se",
-          "t_grass_long_autumn_corner_ne"
+          "t_grass_long_autumn_corner_sw"
         ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_autumn" },
@@ -73,9 +73,9 @@
         "id": "t_connection",
         "fg": [
           "t_grass_long_autumn_t_connection_n",
-          "t_grass_long_autumn_t_connection_w",
+          "t_grass_long_autumn_t_connection_e",
           "t_grass_long_autumn_t_connection_s",
-          "t_grass_long_autumn_t_connection_e"
+          "t_grass_long_autumn_t_connection_w"
         ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_autumn" },
@@ -96,9 +96,9 @@
         "id": "end_piece",
         "fg": [
           "t_grass_long_autumn_end_piece_n",
-          "t_grass_long_autumn_end_piece_w",
+          "t_grass_long_autumn_end_piece_e",
           "t_grass_long_autumn_end_piece_s",
-          "t_grass_long_autumn_end_piece_e"
+          "t_grass_long_autumn_end_piece_w"
         ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_autumn" },
@@ -135,9 +135,9 @@
         "id": "corner",
         "fg": [
           "t_grass_long_summer_corner_nw",
-          "t_grass_long_summer_corner_sw",
+          "t_grass_long_summer_corner_ne",
           "t_grass_long_summer_corner_se",
-          "t_grass_long_summer_corner_ne"
+          "t_grass_long_summer_corner_sw"
         ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_summer" },
@@ -149,9 +149,9 @@
         "id": "t_connection",
         "fg": [
           "t_grass_long_summer_t_connection_n",
-          "t_grass_long_summer_t_connection_w",
+          "t_grass_long_summer_t_connection_e",
           "t_grass_long_summer_t_connection_s",
-          "t_grass_long_summer_t_connection_e"
+          "t_grass_long_summer_t_connection_w"
         ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_summer" },
@@ -172,9 +172,9 @@
         "id": "end_piece",
         "fg": [
           "t_grass_long_summer_end_piece_n",
-          "t_grass_long_summer_end_piece_w",
+          "t_grass_long_summer_end_piece_e",
           "t_grass_long_summer_end_piece_s",
-          "t_grass_long_summer_end_piece_e"
+          "t_grass_long_summer_end_piece_w"
         ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_summer" },
@@ -211,9 +211,9 @@
         "id": "corner",
         "fg": [
           "t_grass_long_winter_corner_nw",
-          "t_grass_long_winter_corner_sw",
+          "t_grass_long_winter_corner_ne",
           "t_grass_long_winter_corner_se",
-          "t_grass_long_winter_corner_ne"
+          "t_grass_long_winter_corner_sw"
         ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_winter" },
@@ -225,9 +225,9 @@
         "id": "t_connection",
         "fg": [
           "t_grass_long_winter_t_connection_n",
-          "t_grass_long_winter_t_connection_w",
+          "t_grass_long_winter_t_connection_e",
           "t_grass_long_winter_t_connection_s",
-          "t_grass_long_winter_t_connection_e"
+          "t_grass_long_winter_t_connection_w"
         ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_winter" },
@@ -248,9 +248,9 @@
         "id": "end_piece",
         "fg": [
           "t_grass_long_winter_end_piece_n",
-          "t_grass_long_winter_end_piece_w",
+          "t_grass_long_winter_end_piece_e",
           "t_grass_long_winter_end_piece_s",
-          "t_grass_long_winter_end_piece_e"
+          "t_grass_long_winter_end_piece_w"
         ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_winter" },

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_grass_tall/t_grass_tall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_grass_tall/t_grass_tall.json
@@ -11,16 +11,16 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_grass_tall_corner_nw", "t_grass_tall_corner_sw", "t_grass_tall_corner_se", "t_grass_tall_corner_ne" ],
+        "fg": [ "t_grass_tall_corner_nw", "t_grass_tall_corner_ne", "t_grass_tall_corner_se", "t_grass_tall_corner_sw" ],
         "bg": [ { "weight": 1, "sprite": "t_grass" }, { "weight": 1, "sprite": "t_grass_1" }, { "weight": 1, "sprite": "t_grass_2" } ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_grass_tall_t_connection_n",
-          "t_grass_tall_t_connection_w",
+          "t_grass_tall_t_connection_e",
           "t_grass_tall_t_connection_s",
-          "t_grass_tall_t_connection_e"
+          "t_grass_tall_t_connection_w"
         ],
         "bg": [ { "weight": 1, "sprite": "t_grass" }, { "weight": 1, "sprite": "t_grass_1" }, { "weight": 1, "sprite": "t_grass_2" } ]
       },
@@ -31,7 +31,7 @@
       },
       {
         "id": "end_piece",
-        "fg": [ "t_grass_tall_end_piece_n", "t_grass_tall_end_piece_w", "t_grass_tall_end_piece_s", "t_grass_tall_end_piece_e" ],
+        "fg": [ "t_grass_tall_end_piece_n", "t_grass_tall_end_piece_e", "t_grass_tall_end_piece_s", "t_grass_tall_end_piece_w" ],
         "bg": [ { "weight": 1, "sprite": "t_grass" }, { "weight": 1, "sprite": "t_grass_1" }, { "weight": 1, "sprite": "t_grass_2" } ]
       },
       {
@@ -59,9 +59,9 @@
         "id": "corner",
         "fg": [
           "t_grass_tall_winter_corner_nw",
-          "t_grass_tall_winter_corner_sw",
+          "t_grass_tall_winter_corner_ne",
           "t_grass_tall_winter_corner_se",
-          "t_grass_tall_winter_corner_ne"
+          "t_grass_tall_winter_corner_sw"
         ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_winter" },
@@ -73,9 +73,9 @@
         "id": "t_connection",
         "fg": [
           "t_grass_tall_winter_t_connection_n",
-          "t_grass_tall_winter_t_connection_w",
+          "t_grass_tall_winter_t_connection_e",
           "t_grass_tall_winter_t_connection_s",
-          "t_grass_tall_winter_t_connection_e"
+          "t_grass_tall_winter_t_connection_w"
         ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_winter" },
@@ -96,9 +96,9 @@
         "id": "end_piece",
         "fg": [
           "t_grass_tall_winter_end_piece_n",
-          "t_grass_tall_winter_end_piece_w",
+          "t_grass_tall_winter_end_piece_e",
           "t_grass_tall_winter_end_piece_s",
-          "t_grass_tall_winter_end_piece_e"
+          "t_grass_tall_winter_end_piece_w"
         ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_winter" },
@@ -135,9 +135,9 @@
         "id": "corner",
         "fg": [
           "t_grass_tall_summer_corner_nw",
-          "t_grass_tall_summer_corner_sw",
+          "t_grass_tall_summer_corner_ne",
           "t_grass_tall_summer_corner_se",
-          "t_grass_tall_summer_corner_ne"
+          "t_grass_tall_summer_corner_sw"
         ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_summer" },
@@ -149,9 +149,9 @@
         "id": "t_connection",
         "fg": [
           "t_grass_tall_summer_t_connection_n",
-          "t_grass_tall_summer_t_connection_w",
+          "t_grass_tall_summer_t_connection_e",
           "t_grass_tall_summer_t_connection_s",
-          "t_grass_tall_summer_t_connection_e"
+          "t_grass_tall_summer_t_connection_w"
         ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_summer" },
@@ -172,9 +172,9 @@
         "id": "end_piece",
         "fg": [
           "t_grass_tall_summer_end_piece_n",
-          "t_grass_tall_summer_end_piece_w",
+          "t_grass_tall_summer_end_piece_e",
           "t_grass_tall_summer_end_piece_s",
-          "t_grass_tall_summer_end_piece_e"
+          "t_grass_tall_summer_end_piece_w"
         ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_summer" },
@@ -211,9 +211,9 @@
         "id": "corner",
         "fg": [
           "t_grass_tall_autumn_corner_nw",
-          "t_grass_tall_autumn_corner_sw",
+          "t_grass_tall_autumn_corner_ne",
           "t_grass_tall_autumn_corner_se",
-          "t_grass_tall_autumn_corner_ne"
+          "t_grass_tall_autumn_corner_sw"
         ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_autumn" },
@@ -225,9 +225,9 @@
         "id": "t_connection",
         "fg": [
           "t_grass_tall_autumn_t_connection_n",
-          "t_grass_tall_autumn_t_connection_w",
+          "t_grass_tall_autumn_t_connection_e",
           "t_grass_tall_autumn_t_connection_s",
-          "t_grass_tall_autumn_t_connection_e"
+          "t_grass_tall_autumn_t_connection_w"
         ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_autumn" },
@@ -248,9 +248,9 @@
         "id": "end_piece",
         "fg": [
           "t_grass_tall_autumn_end_piece_n",
-          "t_grass_tall_autumn_end_piece_w",
+          "t_grass_tall_autumn_end_piece_e",
           "t_grass_tall_autumn_end_piece_s",
-          "t_grass_tall_autumn_end_piece_e"
+          "t_grass_tall_autumn_end_piece_w"
         ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_autumn" },

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_gutter/t_gutter.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_gutter/t_gutter.json
@@ -6,7 +6,7 @@
     { "id": "center", "fg": "t_gutter_center" },
     {
       "id": "corner",
-      "fg": [ "t_gutter_corner_nw", "t_gutter_corner_sw", "t_gutter_corner_se", "t_gutter_corner_ne" ]
+      "fg": [ "t_gutter_corner_nw", "t_gutter_corner_ne", "t_gutter_corner_se", "t_gutter_corner_sw" ]
     },
     {
       "id": "t_connection",

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_ice/t_ice_thick/t_ice_thick.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_ice/t_ice_thick/t_ice_thick.json
@@ -7,16 +7,16 @@
       { "id": "center", "fg": [ "t_ice_dp_thick_center" ], "bg": [ "t_grass" ] },
       {
         "id": "corner",
-        "fg": [ "t_ice_dp_thick_corner_nw", "t_ice_dp_thick_corner_sw", "t_ice_dp_thick_corner_se", "t_ice_dp_thick_corner_ne" ],
+        "fg": [ "t_ice_dp_thick_corner_nw", "t_ice_dp_thick_corner_ne", "t_ice_dp_thick_corner_se", "t_ice_dp_thick_corner_sw" ],
         "bg": [ "t_grass" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_ice_dp_thick_t_connection_n",
-          "t_ice_dp_thick_t_connection_w",
+          "t_ice_dp_thick_t_connection_e",
           "t_ice_dp_thick_t_connection_s",
-          "t_ice_dp_thick_t_connection_e"
+          "t_ice_dp_thick_t_connection_w"
         ],
         "bg": [ "t_grass" ]
       },
@@ -25,9 +25,9 @@
         "id": "end_piece",
         "fg": [
           "t_ice_dp_thick_end_piece_n",
-          "t_ice_dp_thick_end_piece_w",
+          "t_ice_dp_thick_end_piece_e",
           "t_ice_dp_thick_end_piece_s",
-          "t_ice_dp_thick_end_piece_e"
+          "t_ice_dp_thick_end_piece_w"
         ],
         "bg": [ "t_grass" ]
       },
@@ -46,16 +46,16 @@
       { "id": "center", "fg": [ "t_ice_dp_thick_center" ], "bg": [ "t_grass_winter" ] },
       {
         "id": "corner",
-        "fg": [ "t_ice_dp_thick_corner_nw", "t_ice_dp_thick_corner_sw", "t_ice_dp_thick_corner_se", "t_ice_dp_thick_corner_ne" ],
+        "fg": [ "t_ice_dp_thick_corner_nw", "t_ice_dp_thick_corner_ne", "t_ice_dp_thick_corner_se", "t_ice_dp_thick_corner_sw" ],
         "bg": [ "t_grass_winter" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_ice_dp_thick_t_connection_n",
-          "t_ice_dp_thick_t_connection_w",
+          "t_ice_dp_thick_t_connection_e",
           "t_ice_dp_thick_t_connection_s",
-          "t_ice_dp_thick_t_connection_e"
+          "t_ice_dp_thick_t_connection_w"
         ],
         "bg": [ "t_grass_winter" ]
       },
@@ -64,9 +64,9 @@
         "id": "end_piece",
         "fg": [
           "t_ice_dp_thick_end_piece_n",
-          "t_ice_dp_thick_end_piece_w",
+          "t_ice_dp_thick_end_piece_e",
           "t_ice_dp_thick_end_piece_s",
-          "t_ice_dp_thick_end_piece_e"
+          "t_ice_dp_thick_end_piece_w"
         ],
         "bg": [ "t_grass_winter" ]
       },
@@ -85,16 +85,16 @@
       { "id": "center", "fg": [ "t_ice_dp_thick_center" ], "bg": [ "t_grass_summer" ] },
       {
         "id": "corner",
-        "fg": [ "t_ice_dp_thick_corner_nw", "t_ice_dp_thick_corner_sw", "t_ice_dp_thick_corner_se", "t_ice_dp_thick_corner_ne" ],
+        "fg": [ "t_ice_dp_thick_corner_nw", "t_ice_dp_thick_corner_ne", "t_ice_dp_thick_corner_se", "t_ice_dp_thick_corner_sw" ],
         "bg": [ "t_grass_summer" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_ice_dp_thick_t_connection_n",
-          "t_ice_dp_thick_t_connection_w",
+          "t_ice_dp_thick_t_connection_e",
           "t_ice_dp_thick_t_connection_s",
-          "t_ice_dp_thick_t_connection_e"
+          "t_ice_dp_thick_t_connection_w"
         ],
         "bg": [ "t_grass_summer" ]
       },
@@ -103,9 +103,9 @@
         "id": "end_piece",
         "fg": [
           "t_ice_dp_thick_end_piece_n",
-          "t_ice_dp_thick_end_piece_w",
+          "t_ice_dp_thick_end_piece_e",
           "t_ice_dp_thick_end_piece_s",
-          "t_ice_dp_thick_end_piece_e"
+          "t_ice_dp_thick_end_piece_w"
         ],
         "bg": [ "t_grass_summer" ]
       },
@@ -124,16 +124,16 @@
       { "id": "center", "fg": [ "t_ice_dp_thick_center" ], "bg": [ "t_grass_autumn" ] },
       {
         "id": "corner",
-        "fg": [ "t_ice_dp_thick_corner_nw", "t_ice_dp_thick_corner_sw", "t_ice_dp_thick_corner_se", "t_ice_dp_thick_corner_ne" ],
+        "fg": [ "t_ice_dp_thick_corner_nw", "t_ice_dp_thick_corner_ne", "t_ice_dp_thick_corner_se", "t_ice_dp_thick_corner_sw" ],
         "bg": [ "t_grass_autumn" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_ice_dp_thick_t_connection_n",
-          "t_ice_dp_thick_t_connection_w",
+          "t_ice_dp_thick_t_connection_e",
           "t_ice_dp_thick_t_connection_s",
-          "t_ice_dp_thick_t_connection_e"
+          "t_ice_dp_thick_t_connection_w"
         ],
         "bg": [ "t_grass_autumn" ]
       },
@@ -142,9 +142,9 @@
         "id": "end_piece",
         "fg": [
           "t_ice_dp_thick_end_piece_n",
-          "t_ice_dp_thick_end_piece_w",
+          "t_ice_dp_thick_end_piece_e",
           "t_ice_dp_thick_end_piece_s",
-          "t_ice_dp_thick_end_piece_e"
+          "t_ice_dp_thick_end_piece_w"
         ],
         "bg": [ "t_grass_autumn" ]
       },

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_ice/t_ice_thin/t_ice_thin.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_ice/t_ice_thin/t_ice_thin.json
@@ -7,35 +7,26 @@
       { "id": "center", "fg": [ "t_ice_dp_thin_center" ], "bg": [ "t_grass" ] },
       {
         "id": "corner",
-        "fg": [ "t_ice_dp_thin_corner_nw", "t_ice_dp_thin_corner_sw", "t_ice_dp_thin_corner_se", "t_ice_dp_thin_corner_ne" ],
+        "fg": [ "t_ice_dp_thin_corner_nw", "t_ice_dp_thin_corner_ne", "t_ice_dp_thin_corner_se", "t_ice_dp_thin_corner_sw" ],
         "bg": [ "t_grass" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_ice_dp_thin_t_connection_n",
-          "t_ice_dp_thin_t_connection_w",
+          "t_ice_dp_thin_t_connection_e",
           "t_ice_dp_thin_t_connection_s",
-          "t_ice_dp_thin_t_connection_e"
+          "t_ice_dp_thin_t_connection_w"
         ],
         "bg": [ "t_grass" ]
       },
       { "id": "edge", "fg": [ "t_ice_dp_thin_edge_ns", "t_ice_dp_thin_edge_ew" ], "bg": [ "t_grass" ] },
       {
         "id": "end_piece",
-        "fg": [
-          "t_ice_dp_thin_end_piece_n",
-          "t_ice_dp_thin_end_piece_w",
-          "t_ice_dp_thin_end_piece_s",
-          "t_ice_dp_thin_end_piece_e"
-        ],
+        "fg": [ "t_ice_dp_thin_end_piece_n", "t_ice_dp_thin_end_piece_e", "t_ice_dp_thin_end_piece_s", "t_ice_dp_thin_end_piece_w" ],
         "bg": [ "t_grass" ]
       },
-      {
-        "id": "unconnected",
-        "fg": [ "t_ice_dp_thin_unconnected", "t_ice_dp_thin_unconnected" ],
-        "bg": [ "t_grass" ]
-      }
+      { "id": "unconnected", "fg": [ "t_ice_dp_thin_unconnected", "t_ice_dp_thin_unconnected" ], "bg": [ "t_grass" ] }
     ]
   },
   {
@@ -46,28 +37,23 @@
       { "id": "center", "fg": [ "t_ice_dp_thin_center" ], "bg": [ "t_grass_winter" ] },
       {
         "id": "corner",
-        "fg": [ "t_ice_dp_thin_corner_nw", "t_ice_dp_thin_corner_sw", "t_ice_dp_thin_corner_se", "t_ice_dp_thin_corner_ne" ],
+        "fg": [ "t_ice_dp_thin_corner_nw", "t_ice_dp_thin_corner_ne", "t_ice_dp_thin_corner_se", "t_ice_dp_thin_corner_sw" ],
         "bg": [ "t_grass_winter" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_ice_dp_thin_t_connection_n",
-          "t_ice_dp_thin_t_connection_w",
+          "t_ice_dp_thin_t_connection_e",
           "t_ice_dp_thin_t_connection_s",
-          "t_ice_dp_thin_t_connection_e"
+          "t_ice_dp_thin_t_connection_w"
         ],
         "bg": [ "t_grass_winter" ]
       },
       { "id": "edge", "fg": [ "t_ice_dp_thin_edge_ns", "t_ice_dp_thin_edge_ew" ], "bg": [ "t_grass_winter" ] },
       {
         "id": "end_piece",
-        "fg": [
-          "t_ice_dp_thin_end_piece_n",
-          "t_ice_dp_thin_end_piece_w",
-          "t_ice_dp_thin_end_piece_s",
-          "t_ice_dp_thin_end_piece_e"
-        ],
+        "fg": [ "t_ice_dp_thin_end_piece_n", "t_ice_dp_thin_end_piece_e", "t_ice_dp_thin_end_piece_s", "t_ice_dp_thin_end_piece_w" ],
         "bg": [ "t_grass_winter" ]
       },
       {
@@ -85,28 +71,23 @@
       { "id": "center", "fg": [ "t_ice_dp_thin_center" ], "bg": [ "t_grass_summer" ] },
       {
         "id": "corner",
-        "fg": [ "t_ice_dp_thin_corner_nw", "t_ice_dp_thin_corner_sw", "t_ice_dp_thin_corner_se", "t_ice_dp_thin_corner_ne" ],
+        "fg": [ "t_ice_dp_thin_corner_nw", "t_ice_dp_thin_corner_ne", "t_ice_dp_thin_corner_se", "t_ice_dp_thin_corner_sw" ],
         "bg": [ "t_grass_summer" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_ice_dp_thin_t_connection_n",
-          "t_ice_dp_thin_t_connection_w",
+          "t_ice_dp_thin_t_connection_e",
           "t_ice_dp_thin_t_connection_s",
-          "t_ice_dp_thin_t_connection_e"
+          "t_ice_dp_thin_t_connection_w"
         ],
         "bg": [ "t_grass_summer" ]
       },
       { "id": "edge", "fg": [ "t_ice_dp_thin_edge_ns", "t_ice_dp_thin_edge_ew" ], "bg": [ "t_grass_summer" ] },
       {
         "id": "end_piece",
-        "fg": [
-          "t_ice_dp_thin_end_piece_n",
-          "t_ice_dp_thin_end_piece_w",
-          "t_ice_dp_thin_end_piece_s",
-          "t_ice_dp_thin_end_piece_e"
-        ],
+        "fg": [ "t_ice_dp_thin_end_piece_n", "t_ice_dp_thin_end_piece_e", "t_ice_dp_thin_end_piece_s", "t_ice_dp_thin_end_piece_w" ],
         "bg": [ "t_grass_summer" ]
       },
       {
@@ -124,28 +105,23 @@
       { "id": "center", "fg": [ "t_ice_dp_thin_center" ], "bg": [ "t_grass_autumn" ] },
       {
         "id": "corner",
-        "fg": [ "t_ice_dp_thin_corner_nw", "t_ice_dp_thin_corner_sw", "t_ice_dp_thin_corner_se", "t_ice_dp_thin_corner_ne" ],
+        "fg": [ "t_ice_dp_thin_corner_nw", "t_ice_dp_thin_corner_ne", "t_ice_dp_thin_corner_se", "t_ice_dp_thin_corner_sw" ],
         "bg": [ "t_grass_autumn" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_ice_dp_thin_t_connection_n",
-          "t_ice_dp_thin_t_connection_w",
+          "t_ice_dp_thin_t_connection_e",
           "t_ice_dp_thin_t_connection_s",
-          "t_ice_dp_thin_t_connection_e"
+          "t_ice_dp_thin_t_connection_w"
         ],
         "bg": [ "t_grass_autumn" ]
       },
       { "id": "edge", "fg": [ "t_ice_dp_thin_edge_ns", "t_ice_dp_thin_edge_ew" ], "bg": [ "t_grass_autumn" ] },
       {
         "id": "end_piece",
-        "fg": [
-          "t_ice_dp_thin_end_piece_n",
-          "t_ice_dp_thin_end_piece_w",
-          "t_ice_dp_thin_end_piece_s",
-          "t_ice_dp_thin_end_piece_e"
-        ],
+        "fg": [ "t_ice_dp_thin_end_piece_n", "t_ice_dp_thin_end_piece_e", "t_ice_dp_thin_end_piece_s", "t_ice_dp_thin_end_piece_w" ],
         "bg": [ "t_grass_autumn" ]
       },
       {

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_metal_railing/t_metal_railing.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_metal_railing/t_metal_railing.json
@@ -4,39 +4,18 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_metal_railing_unconnected",
-      "bg": "t_pavement"
-    },
+    { "id": "center", "fg": "t_metal_railing_unconnected", "bg": "t_pavement" },
     {
       "id": "corner",
-      "fg": [
-        "t_metal_railing_corner_nw",
-        "t_metal_railing_corner_sw",
-        "t_metal_railing_corner_se",
-        "t_metal_railing_corner_ne"
-      ],
+      "fg": [ "t_metal_railing_corner_nw", "t_metal_railing_corner_ne", "t_metal_railing_corner_se", "t_metal_railing_corner_sw" ],
       "bg": "t_pavement"
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_metal_railing_unconnected",
-        "t_metal_railing_edge_ns",
-        "t_metal_railing_unconnected",
-        "t_metal_railing_edge_ns"
-      ],
+      "fg": [ "t_metal_railing_unconnected", "t_metal_railing_edge_ns", "t_metal_railing_unconnected", "t_metal_railing_edge_ns" ],
       "bg": "t_pavement"
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_metal_railing_edge_ns",
-        "t_metal_railing_unconnected"
-      ],
-      "bg": "t_pavement"
-    },
+    { "id": "edge", "fg": [ "t_metal_railing_edge_ns", "t_metal_railing_unconnected" ], "bg": "t_pavement" },
     {
       "id": "end_piece",
       "fg": [
@@ -49,10 +28,7 @@
     },
     {
       "id": "unconnected",
-      "fg": [
-        "t_metal_railing_unconnected",
-        "t_metal_railing_unconnected"
-      ],
+      "fg": [ "t_metal_railing_unconnected", "t_metal_railing_unconnected" ],
       "bg": "t_pavement"
     }
   ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_paper/t_paper.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_paper/t_paper.json
@@ -4,56 +4,23 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_paper_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "t_paper_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "t_paper_corner_nw",
-        "t_paper_corner_sw",
-        "t_paper_corner_se",
-        "t_paper_corner_ne"
-      ],
+      "fg": [ "t_paper_corner_nw", "t_paper_corner_ne", "t_paper_corner_se", "t_paper_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_paper_t_connection_n",
-        "t_paper_t_connection_w",
-        "t_paper_t_connection_s",
-        "t_paper_t_connection_e"
-      ],
+      "fg": [ "t_paper_t_connection_n", "t_paper_t_connection_e", "t_paper_t_connection_s", "t_paper_t_connection_w" ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_paper_edge_ns",
-        "t_paper_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "t_paper_edge_ns", "t_paper_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "t_paper_end_piece_n",
-        "t_paper_end_piece_w",
-        "t_paper_end_piece_s",
-        "t_paper_end_piece_e"
-      ],
+      "fg": [ "t_paper_end_piece_n", "t_paper_end_piece_e", "t_paper_end_piece_s", "t_paper_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_paper_unconnected",
-        "t_paper_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "t_paper_unconnected", "t_paper_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_paper_hard/t_paper_hard.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_paper_hard/t_paper_hard.json
@@ -3,50 +3,25 @@
   "fg": "t_paper_hard_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_paper_hard_center"
-    },
+    { "id": "center", "fg": "t_paper_hard_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_paper_hard_corner_nw",
-        "t_paper_hard_corner_sw",
-        "t_paper_hard_corner_se",
-        "t_paper_hard_corner_ne"
-      ]
+      "fg": [ "t_paper_hard_corner_nw", "t_paper_hard_corner_ne", "t_paper_hard_corner_se", "t_paper_hard_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_paper_hard_t_connection_n",
-        "t_paper_hard_t_connection_w",
+        "t_paper_hard_t_connection_e",
         "t_paper_hard_t_connection_s",
-        "t_paper_hard_t_connection_e"
+        "t_paper_hard_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_paper_hard_edge_ns",
-        "t_paper_hard_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_paper_hard_edge_ns", "t_paper_hard_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_paper_hard_end_piece_n",
-        "t_paper_hard_end_piece_w",
-        "t_paper_hard_end_piece_s",
-        "t_paper_hard_end_piece_e"
-      ]
+      "fg": [ "t_paper_hard_end_piece_n", "t_paper_hard_end_piece_e", "t_paper_hard_end_piece_s", "t_paper_hard_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_paper_hard_unconnected",
-        "t_paper_hard_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_paper_hard_unconnected", "t_paper_hard_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_pontoon/t_pontoon.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_pontoon/t_pontoon.json
@@ -4,56 +4,23 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pontoon_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "t_pontoon_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "t_pontoon_corner_nw",
-        "t_pontoon_corner_sw",
-        "t_pontoon_corner_se",
-        "t_pontoon_corner_ne"
-      ],
+      "fg": [ "t_pontoon_corner_nw", "t_pontoon_corner_ne", "t_pontoon_corner_se", "t_pontoon_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_pontoon_t_connection_n",
-        "t_pontoon_t_connection_w",
-        "t_pontoon_t_connection_s",
-        "t_pontoon_t_connection_e"
-      ],
+      "fg": [ "t_pontoon_t_connection_n", "t_pontoon_t_connection_e", "t_pontoon_t_connection_s", "t_pontoon_t_connection_w" ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_pontoon_edge_ns",
-        "t_pontoon_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "t_pontoon_edge_ns", "t_pontoon_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "t_pontoon_end_piece_n",
-        "t_pontoon_end_piece_w",
-        "t_pontoon_end_piece_s",
-        "t_pontoon_end_piece_e"
-      ],
+      "fg": [ "t_pontoon_end_piece_n", "t_pontoon_end_piece_e", "t_pontoon_end_piece_s", "t_pontoon_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_pontoon_unconnected",
-        "t_pontoon_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "t_pontoon_unconnected", "t_pontoon_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_reinforced_glass/t_reinforced_glass.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_reinforced_glass/t_reinforced_glass.json
@@ -3,50 +3,35 @@
   "fg": "t_reinforced_glass_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_reinforced_glass_center"
-    },
+    { "id": "center", "fg": "t_reinforced_glass_center" },
     {
       "id": "corner",
       "fg": [
         "t_reinforced_glass_corner_nw",
-        "t_reinforced_glass_corner_sw",
+        "t_reinforced_glass_corner_ne",
         "t_reinforced_glass_corner_se",
-        "t_reinforced_glass_corner_ne"
+        "t_reinforced_glass_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_reinforced_glass_t_connection_n",
-        "t_reinforced_glass_t_connection_w",
+        "t_reinforced_glass_t_connection_e",
         "t_reinforced_glass_t_connection_s",
-        "t_reinforced_glass_t_connection_e"
+        "t_reinforced_glass_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_reinforced_glass_edge_ns",
-        "t_reinforced_glass_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_reinforced_glass_edge_ns", "t_reinforced_glass_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_reinforced_glass_end_piece_n",
-        "t_reinforced_glass_end_piece_w",
+        "t_reinforced_glass_end_piece_e",
         "t_reinforced_glass_end_piece_s",
-        "t_reinforced_glass_end_piece_e"
+        "t_reinforced_glass_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_reinforced_glass_unconnected",
-        "t_reinforced_glass_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_reinforced_glass_unconnected", "t_reinforced_glass_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_rock/t_rock.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_rock/t_rock.json
@@ -3,50 +3,17 @@
   "fg": "t_rock_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_rock_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_rock_corner_nw",
-        "t_rock_corner_sw",
-        "t_rock_corner_se",
-        "t_rock_corner_ne"
-      ]
-    },
+    { "id": "center", "fg": "t_rock_center" },
+    { "id": "corner", "fg": [ "t_rock_corner_nw", "t_rock_corner_ne", "t_rock_corner_se", "t_rock_corner_sw" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "t_rock_t_connection_n",
-        "t_rock_t_connection_w",
-        "t_rock_t_connection_s",
-        "t_rock_t_connection_e"
-      ]
+      "fg": [ "t_rock_t_connection_n", "t_rock_t_connection_e", "t_rock_t_connection_s", "t_rock_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_rock_edge_ns",
-        "t_rock_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_rock_edge_ns", "t_rock_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_rock_end_piece_n",
-        "t_rock_end_piece_w",
-        "t_rock_end_piece_s",
-        "t_rock_end_piece_e"
-      ]
+      "fg": [ "t_rock_end_piece_n", "t_rock_end_piece_e", "t_rock_end_piece_s", "t_rock_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_rock_unconnected",
-        "t_rock_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_rock_unconnected", "t_rock_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_rock_blue/t_rock_blue.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_rock_blue/t_rock_blue.json
@@ -3,50 +3,25 @@
   "fg": "t_rock_blue_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_rock_blue_center"
-    },
+    { "id": "center", "fg": "t_rock_blue_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_rock_blue_corner_nw",
-        "t_rock_blue_corner_sw",
-        "t_rock_blue_corner_se",
-        "t_rock_blue_corner_ne"
-      ]
+      "fg": [ "t_rock_blue_corner_nw", "t_rock_blue_corner_ne", "t_rock_blue_corner_se", "t_rock_blue_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_rock_blue_t_connection_n",
-        "t_rock_blue_t_connection_w",
+        "t_rock_blue_t_connection_e",
         "t_rock_blue_t_connection_s",
-        "t_rock_blue_t_connection_e"
+        "t_rock_blue_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_rock_blue_edge_ns",
-        "t_rock_blue_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_rock_blue_edge_ns", "t_rock_blue_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_rock_blue_end_piece_n",
-        "t_rock_blue_end_piece_w",
-        "t_rock_blue_end_piece_s",
-        "t_rock_blue_end_piece_e"
-      ]
+      "fg": [ "t_rock_blue_end_piece_n", "t_rock_blue_end_piece_e", "t_rock_blue_end_piece_s", "t_rock_blue_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_rock_blue_unconnected",
-        "t_rock_blue_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_rock_blue_unconnected", "t_rock_blue_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_rock_green/t_rock_green.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_rock_green/t_rock_green.json
@@ -3,50 +3,25 @@
   "fg": "t_rock_green_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_rock_green_center"
-    },
+    { "id": "center", "fg": "t_rock_green_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_rock_green_corner_nw",
-        "t_rock_green_corner_sw",
-        "t_rock_green_corner_se",
-        "t_rock_green_corner_ne"
-      ]
+      "fg": [ "t_rock_green_corner_nw", "t_rock_green_corner_ne", "t_rock_green_corner_se", "t_rock_green_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_rock_green_t_connection_n",
-        "t_rock_green_t_connection_w",
+        "t_rock_green_t_connection_e",
         "t_rock_green_t_connection_s",
-        "t_rock_green_t_connection_e"
+        "t_rock_green_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_rock_green_edge_ns",
-        "t_rock_green_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_rock_green_edge_ns", "t_rock_green_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_rock_green_end_piece_n",
-        "t_rock_green_end_piece_w",
-        "t_rock_green_end_piece_s",
-        "t_rock_green_end_piece_e"
-      ]
+      "fg": [ "t_rock_green_end_piece_n", "t_rock_green_end_piece_e", "t_rock_green_end_piece_s", "t_rock_green_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_rock_green_unconnected",
-        "t_rock_green_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_rock_green_unconnected", "t_rock_green_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_rock_red/t_rock_red.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_rock_red/t_rock_red.json
@@ -3,50 +3,20 @@
   "fg": "t_rock_red_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_rock_red_center"
-    },
+    { "id": "center", "fg": "t_rock_red_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_rock_red_corner_nw",
-        "t_rock_red_corner_sw",
-        "t_rock_red_corner_se",
-        "t_rock_red_corner_ne"
-      ]
+      "fg": [ "t_rock_red_corner_nw", "t_rock_red_corner_ne", "t_rock_red_corner_se", "t_rock_red_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_rock_red_t_connection_n",
-        "t_rock_red_t_connection_w",
-        "t_rock_red_t_connection_s",
-        "t_rock_red_t_connection_e"
-      ]
+      "fg": [ "t_rock_red_t_connection_n", "t_rock_red_t_connection_e", "t_rock_red_t_connection_s", "t_rock_red_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_rock_red_edge_ns",
-        "t_rock_red_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_rock_red_edge_ns", "t_rock_red_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_rock_red_end_piece_n",
-        "t_rock_red_end_piece_w",
-        "t_rock_red_end_piece_s",
-        "t_rock_red_end_piece_e"
-      ]
+      "fg": [ "t_rock_red_end_piece_n", "t_rock_red_end_piece_e", "t_rock_red_end_piece_s", "t_rock_red_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_rock_red_unconnected",
-        "t_rock_red_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_rock_red_unconnected", "t_rock_red_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_rock_smooth/t_rock_smooth.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_rock_smooth/t_rock_smooth.json
@@ -3,50 +3,25 @@
   "fg": "t_rock_smooth_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_rock_smooth_center"
-    },
+    { "id": "center", "fg": "t_rock_smooth_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_rock_smooth_corner_nw",
-        "t_rock_smooth_corner_sw",
-        "t_rock_smooth_corner_se",
-        "t_rock_smooth_corner_ne"
-      ]
+      "fg": [ "t_rock_smooth_corner_nw", "t_rock_smooth_corner_ne", "t_rock_smooth_corner_se", "t_rock_smooth_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_rock_smooth_t_connection_n",
-        "t_rock_smooth_t_connection_w",
+        "t_rock_smooth_t_connection_e",
         "t_rock_smooth_t_connection_s",
-        "t_rock_smooth_t_connection_e"
+        "t_rock_smooth_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_rock_smooth_edge_ns",
-        "t_rock_smooth_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_rock_smooth_edge_ns", "t_rock_smooth_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_rock_smooth_end_piece_n",
-        "t_rock_smooth_end_piece_w",
-        "t_rock_smooth_end_piece_s",
-        "t_rock_smooth_end_piece_e"
-      ]
+      "fg": [ "t_rock_smooth_end_piece_n", "t_rock_smooth_end_piece_e", "t_rock_smooth_end_piece_s", "t_rock_smooth_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_rock_smooth_unconnected",
-        "t_rock_smooth_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_rock_smooth_unconnected", "t_rock_smooth_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_rock_wall/t_rock_wall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_rock_wall/t_rock_wall.json
@@ -3,50 +3,25 @@
   "fg": "t_rock_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_rock_wall_center"
-    },
+    { "id": "center", "fg": "t_rock_wall_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_rock_wall_corner_nw",
-        "t_rock_wall_corner_sw",
-        "t_rock_wall_corner_se",
-        "t_rock_wall_corner_ne"
-      ]
+      "fg": [ "t_rock_wall_corner_nw", "t_rock_wall_corner_ne", "t_rock_wall_corner_se", "t_rock_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_rock_wall_t_connection_n",
-        "t_rock_wall_t_connection_w",
+        "t_rock_wall_t_connection_e",
         "t_rock_wall_t_connection_s",
-        "t_rock_wall_t_connection_e"
+        "t_rock_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_rock_wall_edge_ns",
-        "t_rock_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_rock_wall_edge_ns", "t_rock_wall_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_rock_wall_end_piece_n",
-        "t_rock_wall_end_piece_w",
-        "t_rock_wall_end_piece_s",
-        "t_rock_wall_end_piece_e"
-      ]
+      "fg": [ "t_rock_wall_end_piece_n", "t_rock_wall_end_piece_e", "t_rock_wall_end_piece_s", "t_rock_wall_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_rock_wall_unconnected",
-        "t_rock_wall_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_rock_wall_unconnected", "t_rock_wall_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_sand/t_sand.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_sand/t_sand.json
@@ -11,12 +11,12 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_sand_corner_nw", "t_sand_corner_sw", "t_sand_corner_se", "t_sand_corner_ne" ],
+        "fg": [ "t_sand_corner_nw", "t_sand_corner_ne", "t_sand_corner_se", "t_sand_corner_sw" ],
         "bg": [ { "weight": 1, "sprite": "t_grass" }, { "weight": 1, "sprite": "t_grass_1" }, { "weight": 1, "sprite": "t_grass_2" } ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_w", "t_sand_t_connection_s", "t_sand_t_connection_e" ],
+        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_e", "t_sand_t_connection_s", "t_sand_t_connection_w" ],
         "bg": [ { "weight": 1, "sprite": "t_grass" }, { "weight": 1, "sprite": "t_grass_1" }, { "weight": 1, "sprite": "t_grass_2" } ]
       },
       {
@@ -26,7 +26,7 @@
       },
       {
         "id": "end_piece",
-        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_w", "t_sand_end_piece_s", "t_sand_end_piece_e" ],
+        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_e", "t_sand_end_piece_s", "t_sand_end_piece_w" ],
         "bg": [ { "weight": 1, "sprite": "t_grass" }, { "weight": 1, "sprite": "t_grass_1" }, { "weight": 1, "sprite": "t_grass_2" } ]
       },
       {
@@ -52,7 +52,7 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_sand_corner_nw", "t_sand_corner_sw", "t_sand_corner_se", "t_sand_corner_ne" ],
+        "fg": [ "t_sand_corner_nw", "t_sand_corner_ne", "t_sand_corner_se", "t_sand_corner_sw" ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_summer" },
           { "weight": 1, "sprite": "t_grass_summer_1" },
@@ -61,7 +61,7 @@
       },
       {
         "id": "t_connection",
-        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_w", "t_sand_t_connection_s", "t_sand_t_connection_e" ],
+        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_e", "t_sand_t_connection_s", "t_sand_t_connection_w" ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_summer" },
           { "weight": 1, "sprite": "t_grass_summer_1" },
@@ -79,7 +79,7 @@
       },
       {
         "id": "end_piece",
-        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_w", "t_sand_end_piece_s", "t_sand_end_piece_e" ],
+        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_e", "t_sand_end_piece_s", "t_sand_end_piece_w" ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_summer" },
           { "weight": 1, "sprite": "t_grass_summer_1" },
@@ -113,7 +113,7 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_sand_corner_nw", "t_sand_corner_sw", "t_sand_corner_se", "t_sand_corner_ne" ],
+        "fg": [ "t_sand_corner_nw", "t_sand_corner_ne", "t_sand_corner_se", "t_sand_corner_sw" ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_autumn" },
           { "weight": 1, "sprite": "t_grass_autumn_1" },
@@ -122,7 +122,7 @@
       },
       {
         "id": "t_connection",
-        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_w", "t_sand_t_connection_s", "t_sand_t_connection_e" ],
+        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_e", "t_sand_t_connection_s", "t_sand_t_connection_w" ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_autumn" },
           { "weight": 1, "sprite": "t_grass_autumn_1" },
@@ -140,7 +140,7 @@
       },
       {
         "id": "end_piece",
-        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_w", "t_sand_end_piece_s", "t_sand_end_piece_e" ],
+        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_e", "t_sand_end_piece_s", "t_sand_end_piece_w" ],
         "bg": [
           { "weight": 1, "sprite": "t_grass_autumn" },
           { "weight": 1, "sprite": "t_grass_autumn_1" },
@@ -174,7 +174,7 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_sand_corner_nw", "t_sand_corner_sw", "t_sand_corner_se", "t_sand_corner_ne" ],
+        "fg": [ "t_sand_corner_nw", "t_sand_corner_ne", "t_sand_corner_se", "t_sand_corner_sw" ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_winter" },
           { "weight": 100, "sprite": "t_grass_winter_1" },
@@ -183,7 +183,7 @@
       },
       {
         "id": "t_connection",
-        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_w", "t_sand_t_connection_s", "t_sand_t_connection_e" ],
+        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_e", "t_sand_t_connection_s", "t_sand_t_connection_w" ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_winter" },
           { "weight": 100, "sprite": "t_grass_winter_1" },
@@ -201,7 +201,7 @@
       },
       {
         "id": "end_piece",
-        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_w", "t_sand_end_piece_s", "t_sand_end_piece_e" ],
+        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_e", "t_sand_end_piece_s", "t_sand_end_piece_w" ],
         "bg": [
           { "weight": 100, "sprite": "t_grass_winter" },
           { "weight": 100, "sprite": "t_grass_winter_1" },

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_sandbox/t_sandbox.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_sandbox/t_sandbox.json
@@ -3,50 +3,20 @@
   "fg": "t_sandbox_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sandbox_center"
-    },
+    { "id": "center", "fg": "t_sandbox_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_sandbox_corner_nw",
-        "t_sandbox_corner_sw",
-        "t_sandbox_corner_se",
-        "t_sandbox_corner_ne"
-      ]
+      "fg": [ "t_sandbox_corner_nw", "t_sandbox_corner_ne", "t_sandbox_corner_se", "t_sandbox_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_sandbox_t_connection_n",
-        "t_sandbox_t_connection_w",
-        "t_sandbox_t_connection_s",
-        "t_sandbox_t_connection_e"
-      ]
+      "fg": [ "t_sandbox_t_connection_n", "t_sandbox_t_connection_e", "t_sandbox_t_connection_s", "t_sandbox_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sandbox_edge_ns",
-        "t_sandbox_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sandbox_edge_ns", "t_sandbox_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_sandbox_end_piece_n",
-        "t_sandbox_end_piece_w",
-        "t_sandbox_end_piece_s",
-        "t_sandbox_end_piece_e"
-      ]
+      "fg": [ "t_sandbox_end_piece_n", "t_sandbox_end_piece_e", "t_sandbox_end_piece_s", "t_sandbox_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_sandbox_unconnected",
-        "t_sandbox_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_sandbox_unconnected", "t_sandbox_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_sconc_wall/t_sconc_wall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_sconc_wall/t_sconc_wall.json
@@ -3,50 +3,25 @@
   "fg": "t_sconc_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_sconc_wall_corner_nw",
-        "t_sconc_wall_corner_sw",
-        "t_sconc_wall_corner_se",
-        "t_sconc_wall_corner_ne"
-      ]
+      "fg": [ "t_sconc_wall_corner_nw", "t_sconc_wall_corner_ne", "t_sconc_wall_corner_se", "t_sconc_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_t_connection_n",
-        "t_sconc_wall_t_connection_w",
+        "t_sconc_wall_t_connection_e",
         "t_sconc_wall_t_connection_s",
-        "t_sconc_wall_t_connection_e"
+        "t_sconc_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_edge_ns",
-        "t_sconc_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_edge_ns", "t_sconc_wall_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_sconc_wall_end_piece_n",
-        "t_sconc_wall_end_piece_w",
-        "t_sconc_wall_end_piece_s",
-        "t_sconc_wall_end_piece_e"
-      ]
+      "fg": [ "t_sconc_wall_end_piece_n", "t_sconc_wall_end_piece_e", "t_sconc_wall_end_piece_s", "t_sconc_wall_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_sconc_wall_unconnected",
-        "t_sconc_wall_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_sconc_wall_unconnected", "t_sconc_wall_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_scrap_wall/t_scrap_wall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_scrap_wall/t_scrap_wall.json
@@ -3,50 +3,25 @@
   "fg": "t_scrap_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_scrap_wall_center"
-    },
+    { "id": "center", "fg": "t_scrap_wall_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_scrap_wall_corner_nw",
-        "t_scrap_wall_corner_sw",
-        "t_scrap_wall_corner_se",
-        "t_scrap_wall_corner_ne"
-      ]
+      "fg": [ "t_scrap_wall_corner_nw", "t_scrap_wall_corner_ne", "t_scrap_wall_corner_se", "t_scrap_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_scrap_wall_t_connection_n",
-        "t_scrap_wall_t_connection_w",
+        "t_scrap_wall_t_connection_e",
         "t_scrap_wall_t_connection_s",
-        "t_scrap_wall_t_connection_e"
+        "t_scrap_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_scrap_wall_edge_ns",
-        "t_scrap_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_scrap_wall_edge_ns", "t_scrap_wall_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_scrap_wall_end_piece_n",
-        "t_scrap_wall_end_piece_w",
-        "t_scrap_wall_end_piece_s",
-        "t_scrap_wall_end_piece_e"
-      ]
+      "fg": [ "t_scrap_wall_end_piece_n", "t_scrap_wall_end_piece_e", "t_scrap_wall_end_piece_s", "t_scrap_wall_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_scrap_wall_unconnected",
-        "t_scrap_wall_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_scrap_wall_unconnected", "t_scrap_wall_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_screened_porch_wall/t_screened_porch_wall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_screened_porch_wall/t_screened_porch_wall.json
@@ -4,18 +4,14 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_screened_porch_wall_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "t_screened_porch_wall_center", "bg": "" },
     {
       "id": "corner",
       "fg": [
         "t_screened_porch_wall_corner_nw",
-        "t_screened_porch_wall_corner_sw",
+        "t_screened_porch_wall_corner_ne",
         "t_screened_porch_wall_corner_se",
-        "t_screened_porch_wall_corner_ne"
+        "t_screened_porch_wall_corner_sw"
       ],
       "bg": ""
     },
@@ -23,36 +19,26 @@
       "id": "t_connection",
       "fg": [
         "t_screened_porch_wall_t_connection_n",
-        "t_screened_porch_wall_t_connection_w",
+        "t_screened_porch_wall_t_connection_e",
         "t_screened_porch_wall_t_connection_s",
-        "t_screened_porch_wall_t_connection_e"
+        "t_screened_porch_wall_t_connection_w"
       ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_screened_porch_wall_edge_ns",
-        "t_screened_porch_wall_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "t_screened_porch_wall_edge_ns", "t_screened_porch_wall_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
       "fg": [
         "t_screened_porch_wall_end_piece_n",
-        "t_screened_porch_wall_end_piece_w",
+        "t_screened_porch_wall_end_piece_e",
         "t_screened_porch_wall_end_piece_s",
-        "t_screened_porch_wall_end_piece_e"
+        "t_screened_porch_wall_end_piece_w"
       ],
       "bg": ""
     },
     {
       "id": "unconnected",
-      "fg": [
-        "t_screened_porch_wall_unconnected",
-        "t_screened_porch_wall_unconnected"
-      ],
+      "fg": [ "t_screened_porch_wall_unconnected", "t_screened_porch_wall_unconnected" ],
       "bg": ""
     }
   ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_sidewalk/t_sidewalk.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_sidewalk/t_sidewalk.json
@@ -39,18 +39,18 @@
       {
         "id": "corner",
         "bg": "",
-        "fg": [ "t_sidewalk_corner_nw", "t_sidewalk_corner_sw", "t_sidewalk_corner_se", "t_sidewalk_corner_ne" ]
+        "fg": [ "t_sidewalk_corner_nw", "t_sidewalk_corner_ne", "t_sidewalk_corner_se", "t_sidewalk_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "",
-        "fg": [ "t_sidewalk_t_connection_n", "t_sidewalk_t_connection_w", "t_sidewalk_t_connection_s", "t_sidewalk_t_connection_e" ]
+        "fg": [ "t_sidewalk_t_connection_n", "t_sidewalk_t_connection_e", "t_sidewalk_t_connection_s", "t_sidewalk_t_connection_w" ]
       },
       { "id": "edge", "bg": "", "fg": [ "t_sidewalk_edge_ns", "t_sidewalk_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "",
-        "fg": [ "t_sidewalk_end_piece_n", "t_sidewalk_end_piece_w", "t_sidewalk_end_piece_s", "t_sidewalk_end_piece_e" ]
+        "fg": [ "t_sidewalk_end_piece_n", "t_sidewalk_end_piece_e", "t_sidewalk_end_piece_s", "t_sidewalk_end_piece_w" ]
       },
       { "bg": "", "id": "unconnected", "fg": "t_sidewalk_unconnected" }
     ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_slime/t_slime.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_slime/t_slime.json
@@ -3,50 +3,17 @@
   "fg": "t_slime_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_slime_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_slime_corner_nw",
-        "t_slime_corner_sw",
-        "t_slime_corner_se",
-        "t_slime_corner_ne"
-      ]
-    },
+    { "id": "center", "fg": "t_slime_center" },
+    { "id": "corner", "fg": [ "t_slime_corner_nw", "t_slime_corner_ne", "t_slime_corner_se", "t_slime_corner_sw" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "t_slime_t_connection_n",
-        "t_slime_t_connection_w",
-        "t_slime_t_connection_s",
-        "t_slime_t_connection_e"
-      ]
+      "fg": [ "t_slime_t_connection_n", "t_slime_t_connection_e", "t_slime_t_connection_s", "t_slime_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_slime_edge_ns",
-        "t_slime_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_slime_edge_ns", "t_slime_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_slime_end_piece_n",
-        "t_slime_end_piece_w",
-        "t_slime_end_piece_s",
-        "t_slime_end_piece_e"
-      ]
+      "fg": [ "t_slime_end_piece_n", "t_slime_end_piece_e", "t_slime_end_piece_s", "t_slime_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_slime_unconnected",
-        "t_slime_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_slime_unconnected", "t_slime_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_slope_down/t_slope_down.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_slope_down/t_slope_down.json
@@ -19,19 +19,19 @@
       "fg": [
         {
           "weight": 15,
-          "sprite": [ "t_slope_down_1_corner_nw", "t_slope_down_1_corner_sw", "t_slope_down_1_corner_se", "t_slope_down_1_corner_ne" ]
+          "sprite": [ "t_slope_down_1_corner_nw", "t_slope_down_1_corner_ne", "t_slope_down_1_corner_se", "t_slope_down_1_corner_sw" ]
         },
         {
           "weight": 15,
-          "sprite": [ "t_slope_down_2_corner_nw", "t_slope_down_2_corner_sw", "t_slope_down_2_corner_se", "t_slope_down_2_corner_ne" ]
+          "sprite": [ "t_slope_down_2_corner_nw", "t_slope_down_2_corner_ne", "t_slope_down_2_corner_se", "t_slope_down_2_corner_sw" ]
         },
         {
           "weight": 15,
-          "sprite": [ "t_slope_down_3_corner_nw", "t_slope_down_3_corner_sw", "t_slope_down_3_corner_se", "t_slope_down_3_corner_ne" ]
+          "sprite": [ "t_slope_down_3_corner_nw", "t_slope_down_3_corner_ne", "t_slope_down_3_corner_se", "t_slope_down_3_corner_sw" ]
         },
         {
           "weight": 15,
-          "sprite": [ "t_slope_down_2_corner_nw", "t_slope_down_2_corner_sw", "t_slope_down_2_corner_se", "t_slope_down_2_corner_ne" ]
+          "sprite": [ "t_slope_down_2_corner_nw", "t_slope_down_2_corner_ne", "t_slope_down_2_corner_se", "t_slope_down_2_corner_sw" ]
         }
       ]
     },
@@ -43,36 +43,36 @@
           "weight": 15,
           "sprite": [
             "t_slope_down_1_t_connection_n",
-            "t_slope_down_1_t_connection_w",
+            "t_slope_down_1_t_connection_e",
             "t_slope_down_1_t_connection_s",
-            "t_slope_down_1_t_connection_e"
+            "t_slope_down_1_t_connection_w"
           ]
         },
         {
           "weight": 15,
           "sprite": [
             "t_slope_down_2_t_connection_n",
-            "t_slope_down_2_t_connection_w",
+            "t_slope_down_2_t_connection_e",
             "t_slope_down_2_t_connection_s",
-            "t_slope_down_2_t_connection_e"
+            "t_slope_down_2_t_connection_w"
           ]
         },
         {
           "weight": 15,
           "sprite": [
             "t_slope_down_3_t_connection_n",
-            "t_slope_down_3_t_connection_w",
+            "t_slope_down_3_t_connection_e",
             "t_slope_down_3_t_connection_s",
-            "t_slope_down_3_t_connection_e"
+            "t_slope_down_3_t_connection_w"
           ]
         },
         {
           "weight": 15,
           "sprite": [
             "t_slope_down_2_t_connection_n",
-            "t_slope_down_2_t_connection_w",
+            "t_slope_down_2_t_connection_e",
             "t_slope_down_2_t_connection_s",
-            "t_slope_down_2_t_connection_e"
+            "t_slope_down_2_t_connection_w"
           ]
         }
       ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_slope_up/t_slope_up.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_slope_up/t_slope_up.json
@@ -19,19 +19,19 @@
       "fg": [
         {
           "weight": 15,
-          "sprite": [ "t_slope_up_1_corner_nw", "t_slope_up_1_corner_sw", "t_slope_up_1_corner_se", "t_slope_up_1_corner_ne" ]
+          "sprite": [ "t_slope_up_1_corner_nw", "t_slope_up_1_corner_ne", "t_slope_up_1_corner_se", "t_slope_up_1_corner_sw" ]
         },
         {
           "weight": 15,
-          "sprite": [ "t_slope_up_2_corner_nw", "t_slope_up_2_corner_sw", "t_slope_up_2_corner_se", "t_slope_up_2_corner_ne" ]
+          "sprite": [ "t_slope_up_2_corner_nw", "t_slope_up_2_corner_ne", "t_slope_up_2_corner_se", "t_slope_up_2_corner_sw" ]
         },
         {
           "weight": 15,
-          "sprite": [ "t_slope_up_3_corner_nw", "t_slope_up_3_corner_sw", "t_slope_up_3_corner_se", "t_slope_up_3_corner_ne" ]
+          "sprite": [ "t_slope_up_3_corner_nw", "t_slope_up_3_corner_ne", "t_slope_up_3_corner_se", "t_slope_up_3_corner_sw" ]
         },
         {
           "weight": 15,
-          "sprite": [ "t_slope_up_2_corner_nw", "t_slope_up_2_corner_sw", "t_slope_up_2_corner_se", "t_slope_up_2_corner_ne" ]
+          "sprite": [ "t_slope_up_2_corner_nw", "t_slope_up_2_corner_ne", "t_slope_up_2_corner_se", "t_slope_up_2_corner_sw" ]
         }
       ]
     },
@@ -43,36 +43,36 @@
           "weight": 15,
           "sprite": [
             "t_slope_up_1_t_connection_n",
-            "t_slope_up_1_t_connection_w",
+            "t_slope_up_1_t_connection_e",
             "t_slope_up_1_t_connection_s",
-            "t_slope_up_1_t_connection_e"
+            "t_slope_up_1_t_connection_w"
           ]
         },
         {
           "weight": 15,
           "sprite": [
             "t_slope_up_2_t_connection_n",
-            "t_slope_up_2_t_connection_w",
+            "t_slope_up_2_t_connection_e",
             "t_slope_up_2_t_connection_s",
-            "t_slope_up_2_t_connection_e"
+            "t_slope_up_2_t_connection_w"
           ]
         },
         {
           "weight": 15,
           "sprite": [
             "t_slope_up_3_t_connection_n",
-            "t_slope_up_3_t_connection_w",
+            "t_slope_up_3_t_connection_e",
             "t_slope_up_3_t_connection_s",
-            "t_slope_up_3_t_connection_e"
+            "t_slope_up_3_t_connection_w"
           ]
         },
         {
           "weight": 15,
           "sprite": [
             "t_slope_up_2_t_connection_n",
-            "t_slope_up_2_t_connection_w",
+            "t_slope_up_2_t_connection_e",
             "t_slope_up_2_t_connection_s",
-            "t_slope_up_2_t_connection_e"
+            "t_slope_up_2_t_connection_w"
           ]
         }
       ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_soil/t_soil.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_soil/t_soil.json
@@ -7,9 +7,9 @@
     {
       "id": "corner",
       "fg": [
-        { "weight": 2, "sprite": [ "t_soil_corner_nw", "t_soil_corner_sw", "t_soil_corner_se", "t_soil_corner_ne" ] },
-        { "weight": 1, "sprite": [ "t_soil_corner_nw", "t_soil_corner_sw2", "t_soil_corner_se", "t_soil_corner_ne" ] },
-        { "weight": 1, "sprite": [ "t_soil_corner_nw", "t_soil_corner_sw", "t_soil_corner_se2", "t_soil_corner_ne" ] }
+        { "weight": 2, "sprite": [ "t_soil_corner_nw", "t_soil_corner_ne", "t_soil_corner_se", "t_soil_corner_sw" ] },
+        { "weight": 1, "sprite": [ "t_soil_corner_nw", "t_soil_corner_ne", "t_soil_corner_se", "t_soil_corner_sw2" ] },
+        { "weight": 1, "sprite": [ "t_soil_corner_nw", "t_soil_corner_ne", "t_soil_corner_se2", "t_soil_corner_sw" ] }
       ]
     },
     {
@@ -17,11 +17,11 @@
       "fg": [
         {
           "weight": 2,
-          "sprite": [ "t_soil_t_connection_n", "t_soil_t_connection_w", "t_soil_t_connection_s", "t_soil_t_connection_e" ]
+          "sprite": [ "t_soil_t_connection_n", "t_soil_t_connection_e", "t_soil_t_connection_s", "t_soil_t_connection_w" ]
         },
         {
           "weight": 1,
-          "sprite": [ "t_soil_t_connection_n", "t_soil_t_connection_w", "t_soil_t_connection_s2", "t_soil_t_connection_e" ]
+          "sprite": [ "t_soil_t_connection_n", "t_soil_t_connection_e", "t_soil_t_connection_s2", "t_soil_t_connection_w" ]
         }
       ]
     },
@@ -35,18 +35,18 @@
     {
       "id": "end_piece",
       "fg": [
-        { "weight": 2, "sprite": [ "t_soil_end_piece_n", "t_soil_end_piece_w", "t_soil_end_piece_s", "t_soil_end_piece_e" ] },
+        { "weight": 2, "sprite": [ "t_soil_end_piece_n", "t_soil_end_piece_e", "t_soil_end_piece_s", "t_soil_end_piece_w" ] },
         {
           "weight": 1,
-          "sprite": [ "t_soil_end_piece_n", "t_soil_end_piece_w2", "t_soil_end_piece_s", "t_soil_end_piece_e" ]
+          "sprite": [ "t_soil_end_piece_n", "t_soil_end_piece_e", "t_soil_end_piece_s", "t_soil_end_piece_w2" ]
         },
         {
           "weight": 1,
-          "sprite": [ "t_soil_end_piece_n", "t_soil_end_piece_w", "t_soil_end_piece_s2", "t_soil_end_piece_e" ]
+          "sprite": [ "t_soil_end_piece_n", "t_soil_end_piece_e", "t_soil_end_piece_s2", "t_soil_end_piece_w" ]
         },
         {
           "weight": 1,
-          "sprite": [ "t_soil_end_piece_n", "t_soil_end_piece_w", "t_soil_end_piece_s", "t_soil_end_piece_e2" ]
+          "sprite": [ "t_soil_end_piece_n", "t_soil_end_piece_e2", "t_soil_end_piece_s", "t_soil_end_piece_w" ]
         }
       ]
     },

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_stronc_wall/t_strconc_wall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_stronc_wall/t_strconc_wall.json
@@ -3,50 +3,30 @@
   "fg": "t_strconc_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_strconc_wall_corner_nw",
-        "t_strconc_wall_corner_sw",
-        "t_strconc_wall_corner_se",
-        "t_strconc_wall_corner_ne"
-      ]
+      "fg": [ "t_strconc_wall_corner_nw", "t_strconc_wall_corner_ne", "t_strconc_wall_corner_se", "t_strconc_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_t_connection_n",
-        "t_strconc_wall_t_connection_w",
+        "t_strconc_wall_t_connection_e",
         "t_strconc_wall_t_connection_s",
-        "t_strconc_wall_t_connection_e"
+        "t_strconc_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_edge_ns",
-        "t_strconc_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_edge_ns", "t_strconc_wall_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_end_piece_n",
-        "t_strconc_wall_end_piece_w",
+        "t_strconc_wall_end_piece_e",
         "t_strconc_wall_end_piece_s",
-        "t_strconc_wall_end_piece_e"
+        "t_strconc_wall_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_strconc_wall_unconnected",
-        "t_strconc_wall_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_strconc_wall_unconnected", "t_strconc_wall_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_swater_dp/t_swater_dp.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_swater_dp/t_swater_dp.json
@@ -7,29 +7,34 @@
       {
         "id": "center",
         "fg": [
-        { "weight": 4, "sprite": "t_swater_dp" },
-        { "weight": 4, "sprite": "t_swater_dp_0" },
-        { "weight": 4, "sprite": "t_swater_dp_1" },
-        { "weight": 4, "sprite": "t_swater_dp_2" },
-        { "weight": 1, "sprite": "t_swater_dp_3" },
-        { "weight": 1, "sprite": "t_swater_dp_4" }
+          { "weight": 4, "sprite": "t_swater_dp" },
+          { "weight": 4, "sprite": "t_swater_dp_0" },
+          { "weight": 4, "sprite": "t_swater_dp_1" },
+          { "weight": 4, "sprite": "t_swater_dp_2" },
+          { "weight": 1, "sprite": "t_swater_dp_3" },
+          { "weight": 1, "sprite": "t_swater_dp_4" }
         ],
         "bg": [ "t_grass" ]
       },
       {
         "id": "corner",
-        "fg": [ "t_swater_dp_corner_nw", "t_swater_dp_corner_sw", "t_swater_dp_corner_se", "t_swater_dp_corner_ne" ],
+        "fg": [ "t_swater_dp_corner_nw", "t_swater_dp_corner_ne", "t_swater_dp_corner_se", "t_swater_dp_corner_sw" ],
         "bg": [ "t_grass" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_swater_dp_t_connection_n", "t_swater_dp_t_connection_w", "t_swater_dp_t_connection_s", "t_swater_dp_t_connection_e" ],
+        "fg": [
+          "t_swater_dp_t_connection_n",
+          "t_swater_dp_t_connection_e",
+          "t_swater_dp_t_connection_s",
+          "t_swater_dp_t_connection_w"
+        ],
         "bg": [ "t_grass" ]
       },
       { "id": "edge", "fg": [ "t_swater_dp_edge_ns", "t_swater_dp_edge_ew" ], "bg": [ "t_grass" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_swater_dp_end_piece_n", "t_swater_dp_end_piece_w", "t_swater_dp_end_piece_s", "t_swater_dp_end_piece_e" ],
+        "fg": [ "t_swater_dp_end_piece_n", "t_swater_dp_end_piece_e", "t_swater_dp_end_piece_s", "t_swater_dp_end_piece_w" ],
         "bg": [ "t_grass" ]
       },
       { "id": "unconnected", "fg": [ "t_swater_dp_unconnected", "t_swater_dp_unconnected" ], "bg": [ "t_grass" ] }
@@ -43,29 +48,34 @@
       {
         "id": "center",
         "fg": [
-        { "weight": 4, "sprite": "t_swater_dp" },
-        { "weight": 4, "sprite": "t_swater_dp_0" },
-        { "weight": 4, "sprite": "t_swater_dp_1" },
-        { "weight": 4, "sprite": "t_swater_dp_2" },
-        { "weight": 1, "sprite": "t_swater_dp_3" },
-        { "weight": 1, "sprite": "t_swater_dp_4" }
+          { "weight": 4, "sprite": "t_swater_dp" },
+          { "weight": 4, "sprite": "t_swater_dp_0" },
+          { "weight": 4, "sprite": "t_swater_dp_1" },
+          { "weight": 4, "sprite": "t_swater_dp_2" },
+          { "weight": 1, "sprite": "t_swater_dp_3" },
+          { "weight": 1, "sprite": "t_swater_dp_4" }
         ],
         "bg": [ "t_grass_winter" ]
       },
       {
         "id": "corner",
-        "fg": [ "t_swater_dp_corner_nw", "t_swater_dp_corner_sw", "t_swater_dp_corner_se", "t_swater_dp_corner_ne" ],
+        "fg": [ "t_swater_dp_corner_nw", "t_swater_dp_corner_ne", "t_swater_dp_corner_se", "t_swater_dp_corner_sw" ],
         "bg": [ "t_grass_winter" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_swater_dp_t_connection_n", "t_swater_dp_t_connection_w", "t_swater_dp_t_connection_s", "t_swater_dp_t_connection_e" ],
+        "fg": [
+          "t_swater_dp_t_connection_n",
+          "t_swater_dp_t_connection_e",
+          "t_swater_dp_t_connection_s",
+          "t_swater_dp_t_connection_w"
+        ],
         "bg": [ "t_grass_winter" ]
       },
       { "id": "edge", "fg": [ "t_swater_dp_edge_ns", "t_swater_dp_edge_ew" ], "bg": [ "t_grass_winter" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_swater_dp_end_piece_n", "t_swater_dp_end_piece_w", "t_swater_dp_end_piece_s", "t_swater_dp_end_piece_e" ],
+        "fg": [ "t_swater_dp_end_piece_n", "t_swater_dp_end_piece_e", "t_swater_dp_end_piece_s", "t_swater_dp_end_piece_w" ],
         "bg": [ "t_grass_winter" ]
       },
       {
@@ -83,32 +93,41 @@
       {
         "id": "center",
         "fg": [
-        { "weight": 4, "sprite": "t_swater_dp" },
-        { "weight": 4, "sprite": "t_swater_dp_0" },
-        { "weight": 4, "sprite": "t_swater_dp_1" },
-        { "weight": 4, "sprite": "t_swater_dp_2" },
-        { "weight": 1, "sprite": "t_swater_dp_3" },
-        { "weight": 1, "sprite": "t_swater_dp_4" }
+          { "weight": 4, "sprite": "t_swater_dp" },
+          { "weight": 4, "sprite": "t_swater_dp_0" },
+          { "weight": 4, "sprite": "t_swater_dp_1" },
+          { "weight": 4, "sprite": "t_swater_dp_2" },
+          { "weight": 1, "sprite": "t_swater_dp_3" },
+          { "weight": 1, "sprite": "t_swater_dp_4" }
         ],
         "bg": [ "t_grass_summer" ]
       },
       {
         "id": "corner",
-        "fg": [ "t_swater_dp_corner_nw", "t_swater_dp_corner_sw", "t_swater_dp_corner_se", "t_swater_dp_corner_ne" ],
+        "fg": [ "t_swater_dp_corner_nw", "t_swater_dp_corner_ne", "t_swater_dp_corner_se", "t_swater_dp_corner_sw" ],
         "bg": [ "t_grass_summer" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_swater_dp_t_connection_n", "t_swater_dp_t_connection_w", "t_swater_dp_t_connection_s", "t_swater_dp_t_connection_e" ],
+        "fg": [
+          "t_swater_dp_t_connection_n",
+          "t_swater_dp_t_connection_e",
+          "t_swater_dp_t_connection_s",
+          "t_swater_dp_t_connection_w"
+        ],
         "bg": [ "t_grass_summer" ]
       },
       { "id": "edge", "fg": [ "t_swater_dp_edge_ns", "t_swater_dp_edge_ew" ], "bg": [ "t_grass_summer" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_swater_dp_end_piece_n", "t_swater_dp_end_piece_w", "t_swater_dp_end_piece_s", "t_swater_dp_end_piece_e" ],
+        "fg": [ "t_swater_dp_end_piece_n", "t_swater_dp_end_piece_e", "t_swater_dp_end_piece_s", "t_swater_dp_end_piece_w" ],
         "bg": [ "t_grass_summer" ]
       },
-      { "id": "unconnected", "fg": [ "t_swater_dp_unconnected", "t_swater_dp_unconnected" ], "bg": [ "t_grass_summer" ] }
+      {
+        "id": "unconnected",
+        "fg": [ "t_swater_dp_unconnected", "t_swater_dp_unconnected" ],
+        "bg": [ "t_grass_summer" ]
+      }
     ]
   },
   {
@@ -119,33 +138,41 @@
       {
         "id": "center",
         "fg": [
-        { "weight": 4, "sprite": "t_swater_dp" },
-        { "weight": 4, "sprite": "t_swater_dp_0" },
-        { "weight": 4, "sprite": "t_swater_dp_1" },
-        { "weight": 4, "sprite": "t_swater_dp_2" },
-        { "weight": 1, "sprite": "t_swater_dp_3" },
-        { "weight": 1, "sprite": "t_swater_dp_4" }
+          { "weight": 4, "sprite": "t_swater_dp" },
+          { "weight": 4, "sprite": "t_swater_dp_0" },
+          { "weight": 4, "sprite": "t_swater_dp_1" },
+          { "weight": 4, "sprite": "t_swater_dp_2" },
+          { "weight": 1, "sprite": "t_swater_dp_3" },
+          { "weight": 1, "sprite": "t_swater_dp_4" }
         ],
         "bg": [ "t_grass_autumn" ]
       },
       {
         "id": "corner",
-        "fg": [ "t_swater_dp_corner_nw", "t_swater_dp_corner_sw", "t_swater_dp_corner_se", "t_swater_dp_corner_ne" ],
+        "fg": [ "t_swater_dp_corner_nw", "t_swater_dp_corner_ne", "t_swater_dp_corner_se", "t_swater_dp_corner_sw" ],
         "bg": [ "t_grass_autumn" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_swater_dp_t_connection_n", "t_swater_dp_t_connection_w", "t_swater_dp_t_connection_s", "t_swater_dp_t_connection_e" ],
+        "fg": [
+          "t_swater_dp_t_connection_n",
+          "t_swater_dp_t_connection_e",
+          "t_swater_dp_t_connection_s",
+          "t_swater_dp_t_connection_w"
+        ],
         "bg": [ "t_grass_autumn" ]
       },
       { "id": "edge", "fg": [ "t_swater_dp_edge_ns", "t_swater_dp_edge_ew" ], "bg": [ "t_grass_autumn" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_swater_dp_end_piece_n", "t_swater_dp_end_piece_w", "t_swater_dp_end_piece_s", "t_swater_dp_end_piece_e" ],
+        "fg": [ "t_swater_dp_end_piece_n", "t_swater_dp_end_piece_e", "t_swater_dp_end_piece_s", "t_swater_dp_end_piece_w" ],
         "bg": [ "t_grass_autumn" ]
       },
-      { "id": "unconnected", "fg": [ "t_swater_dp_unconnected", "t_swater_dp_unconnected" ], "bg": [ "t_grass_autumn" ] }
+      {
+        "id": "unconnected",
+        "fg": [ "t_swater_dp_unconnected", "t_swater_dp_unconnected" ],
+        "bg": [ "t_grass_autumn" ]
+      }
     ]
   }
 ]
-

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_swater_sh/t_swater_sh.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_swater_sh/t_swater_sh.json
@@ -7,29 +7,34 @@
       {
         "id": "center",
         "fg": [
-        { "weight": 4, "sprite": "t_swater_sh" },
-        { "weight": 4, "sprite": "t_swater_sh_0" },
-        { "weight": 4, "sprite": "t_swater_sh_1" },
-        { "weight": 4, "sprite": "t_swater_sh_2" },
-        { "weight": 1, "sprite": "t_swater_sh_3" },
-        { "weight": 1, "sprite": "t_swater_sh_4" }
+          { "weight": 4, "sprite": "t_swater_sh" },
+          { "weight": 4, "sprite": "t_swater_sh_0" },
+          { "weight": 4, "sprite": "t_swater_sh_1" },
+          { "weight": 4, "sprite": "t_swater_sh_2" },
+          { "weight": 1, "sprite": "t_swater_sh_3" },
+          { "weight": 1, "sprite": "t_swater_sh_4" }
         ],
         "bg": [ "t_grass" ]
       },
       {
         "id": "corner",
-        "fg": [ "t_swater_sh_corner_nw", "t_swater_sh_corner_sw", "t_swater_sh_corner_se", "t_swater_sh_corner_ne" ],
+        "fg": [ "t_swater_sh_corner_nw", "t_swater_sh_corner_ne", "t_swater_sh_corner_se", "t_swater_sh_corner_sw" ],
         "bg": [ "t_grass" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_swater_sh_t_connection_n", "t_swater_sh_t_connection_w", "t_swater_sh_t_connection_s", "t_swater_sh_t_connection_e" ],
+        "fg": [
+          "t_swater_sh_t_connection_n",
+          "t_swater_sh_t_connection_e",
+          "t_swater_sh_t_connection_s",
+          "t_swater_sh_t_connection_w"
+        ],
         "bg": [ "t_grass" ]
       },
       { "id": "edge", "fg": [ "t_swater_sh_edge_ns", "t_swater_sh_edge_ew" ], "bg": [ "t_grass" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_swater_sh_end_piece_n", "t_swater_sh_end_piece_w", "t_swater_sh_end_piece_s", "t_swater_sh_end_piece_e" ],
+        "fg": [ "t_swater_sh_end_piece_n", "t_swater_sh_end_piece_e", "t_swater_sh_end_piece_s", "t_swater_sh_end_piece_w" ],
         "bg": [ "t_grass" ]
       },
       { "id": "unconnected", "fg": [ "t_swater_sh_unconnected", "t_swater_sh_unconnected" ], "bg": [ "t_grass" ] }
@@ -43,29 +48,34 @@
       {
         "id": "center",
         "fg": [
-        { "weight": 4, "sprite": "t_swater_sh" },
-        { "weight": 4, "sprite": "t_swater_sh_0" },
-        { "weight": 4, "sprite": "t_swater_sh_1" },
-        { "weight": 4, "sprite": "t_swater_sh_2" },
-        { "weight": 1, "sprite": "t_swater_sh_3" },
-        { "weight": 1, "sprite": "t_swater_sh_4" }
+          { "weight": 4, "sprite": "t_swater_sh" },
+          { "weight": 4, "sprite": "t_swater_sh_0" },
+          { "weight": 4, "sprite": "t_swater_sh_1" },
+          { "weight": 4, "sprite": "t_swater_sh_2" },
+          { "weight": 1, "sprite": "t_swater_sh_3" },
+          { "weight": 1, "sprite": "t_swater_sh_4" }
         ],
         "bg": [ "t_grass_winter" ]
       },
       {
         "id": "corner",
-        "fg": [ "t_swater_sh_corner_nw", "t_swater_sh_corner_sw", "t_swater_sh_corner_se", "t_swater_sh_corner_ne" ],
+        "fg": [ "t_swater_sh_corner_nw", "t_swater_sh_corner_ne", "t_swater_sh_corner_se", "t_swater_sh_corner_sw" ],
         "bg": [ "t_grass_winter" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_swater_sh_t_connection_n", "t_swater_sh_t_connection_w", "t_swater_sh_t_connection_s", "t_swater_sh_t_connection_e" ],
+        "fg": [
+          "t_swater_sh_t_connection_n",
+          "t_swater_sh_t_connection_e",
+          "t_swater_sh_t_connection_s",
+          "t_swater_sh_t_connection_w"
+        ],
         "bg": [ "t_grass_winter" ]
       },
       { "id": "edge", "fg": [ "t_swater_sh_edge_ns", "t_swater_sh_edge_ew" ], "bg": [ "t_grass_winter" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_swater_sh_end_piece_n", "t_swater_sh_end_piece_w", "t_swater_sh_end_piece_s", "t_swater_sh_end_piece_e" ],
+        "fg": [ "t_swater_sh_end_piece_n", "t_swater_sh_end_piece_e", "t_swater_sh_end_piece_s", "t_swater_sh_end_piece_w" ],
         "bg": [ "t_grass_winter" ]
       },
       {
@@ -83,32 +93,41 @@
       {
         "id": "center",
         "fg": [
-        { "weight": 4, "sprite": "t_swater_sh" },
-        { "weight": 4, "sprite": "t_swater_sh_0" },
-        { "weight": 4, "sprite": "t_swater_sh_1" },
-        { "weight": 4, "sprite": "t_swater_sh_2" },
-        { "weight": 1, "sprite": "t_swater_sh_3" },
-        { "weight": 1, "sprite": "t_swater_sh_4" }
+          { "weight": 4, "sprite": "t_swater_sh" },
+          { "weight": 4, "sprite": "t_swater_sh_0" },
+          { "weight": 4, "sprite": "t_swater_sh_1" },
+          { "weight": 4, "sprite": "t_swater_sh_2" },
+          { "weight": 1, "sprite": "t_swater_sh_3" },
+          { "weight": 1, "sprite": "t_swater_sh_4" }
         ],
         "bg": [ "t_grass_summer" ]
       },
       {
         "id": "corner",
-        "fg": [ "t_swater_sh_corner_nw", "t_swater_sh_corner_sw", "t_swater_sh_corner_se", "t_swater_sh_corner_ne" ],
+        "fg": [ "t_swater_sh_corner_nw", "t_swater_sh_corner_ne", "t_swater_sh_corner_se", "t_swater_sh_corner_sw" ],
         "bg": [ "t_grass_summer" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_swater_sh_t_connection_n", "t_swater_sh_t_connection_w", "t_swater_sh_t_connection_s", "t_swater_sh_t_connection_e" ],
+        "fg": [
+          "t_swater_sh_t_connection_n",
+          "t_swater_sh_t_connection_e",
+          "t_swater_sh_t_connection_s",
+          "t_swater_sh_t_connection_w"
+        ],
         "bg": [ "t_grass_summer" ]
       },
       { "id": "edge", "fg": [ "t_swater_sh_edge_ns", "t_swater_sh_edge_ew" ], "bg": [ "t_grass_summer" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_swater_sh_end_piece_n", "t_swater_sh_end_piece_w", "t_swater_sh_end_piece_s", "t_swater_sh_end_piece_e" ],
+        "fg": [ "t_swater_sh_end_piece_n", "t_swater_sh_end_piece_e", "t_swater_sh_end_piece_s", "t_swater_sh_end_piece_w" ],
         "bg": [ "t_grass_summer" ]
       },
-      { "id": "unconnected", "fg": [ "t_swater_sh_unconnected", "t_swater_sh_unconnected" ], "bg": [ "t_grass_summer" ] }
+      {
+        "id": "unconnected",
+        "fg": [ "t_swater_sh_unconnected", "t_swater_sh_unconnected" ],
+        "bg": [ "t_grass_summer" ]
+      }
     ]
   },
   {
@@ -119,33 +138,41 @@
       {
         "id": "center",
         "fg": [
-        { "weight": 4, "sprite": "t_swater_sh" },
-        { "weight": 4, "sprite": "t_swater_sh_0" },
-        { "weight": 4, "sprite": "t_swater_sh_1" },
-        { "weight": 4, "sprite": "t_swater_sh_2" },
-        { "weight": 1, "sprite": "t_swater_sh_3" },
-        { "weight": 1, "sprite": "t_swater_sh_4" }
+          { "weight": 4, "sprite": "t_swater_sh" },
+          { "weight": 4, "sprite": "t_swater_sh_0" },
+          { "weight": 4, "sprite": "t_swater_sh_1" },
+          { "weight": 4, "sprite": "t_swater_sh_2" },
+          { "weight": 1, "sprite": "t_swater_sh_3" },
+          { "weight": 1, "sprite": "t_swater_sh_4" }
         ],
         "bg": [ "t_grass_autumn" ]
       },
       {
         "id": "corner",
-        "fg": [ "t_swater_sh_corner_nw", "t_swater_sh_corner_sw", "t_swater_sh_corner_se", "t_swater_sh_corner_ne" ],
+        "fg": [ "t_swater_sh_corner_nw", "t_swater_sh_corner_ne", "t_swater_sh_corner_se", "t_swater_sh_corner_sw" ],
         "bg": [ "t_grass_autumn" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_swater_sh_t_connection_n", "t_swater_sh_t_connection_w", "t_swater_sh_t_connection_s", "t_swater_sh_t_connection_e" ],
+        "fg": [
+          "t_swater_sh_t_connection_n",
+          "t_swater_sh_t_connection_e",
+          "t_swater_sh_t_connection_s",
+          "t_swater_sh_t_connection_w"
+        ],
         "bg": [ "t_grass_autumn" ]
       },
       { "id": "edge", "fg": [ "t_swater_sh_edge_ns", "t_swater_sh_edge_ew" ], "bg": [ "t_grass_autumn" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_swater_sh_end_piece_n", "t_swater_sh_end_piece_w", "t_swater_sh_end_piece_s", "t_swater_sh_end_piece_e" ],
+        "fg": [ "t_swater_sh_end_piece_n", "t_swater_sh_end_piece_e", "t_swater_sh_end_piece_s", "t_swater_sh_end_piece_w" ],
         "bg": [ "t_grass_autumn" ]
       },
-      { "id": "unconnected", "fg": [ "t_swater_sh_unconnected", "t_swater_sh_unconnected" ], "bg": [ "t_grass_autumn" ] }
+      {
+        "id": "unconnected",
+        "fg": [ "t_swater_sh_unconnected", "t_swater_sh_unconnected" ],
+        "bg": [ "t_grass_autumn" ]
+      }
     ]
   }
 ]
-

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_thatch_roof/t_thatch_roof.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_thatch_roof/t_thatch_roof.json
@@ -4,56 +4,28 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_thatch_roof_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "t_thatch_roof_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "t_thatch_roof_corner_nw",
-        "t_thatch_roof_corner_sw",
-        "t_thatch_roof_corner_se",
-        "t_thatch_roof_corner_ne"
-      ],
+      "fg": [ "t_thatch_roof_corner_nw", "t_thatch_roof_corner_ne", "t_thatch_roof_corner_se", "t_thatch_roof_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
       "fg": [
         "t_thatch_roof_t_connection_n",
-        "t_thatch_roof_t_connection_w",
+        "t_thatch_roof_t_connection_e",
         "t_thatch_roof_t_connection_s",
-        "t_thatch_roof_t_connection_e"
+        "t_thatch_roof_t_connection_w"
       ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_thatch_roof_edge_ns",
-        "t_thatch_roof_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "t_thatch_roof_edge_ns", "t_thatch_roof_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "t_thatch_roof_end_piece_n",
-        "t_thatch_roof_end_piece_w",
-        "t_thatch_roof_end_piece_s",
-        "t_thatch_roof_end_piece_e"
-      ],
+      "fg": [ "t_thatch_roof_end_piece_n", "t_thatch_roof_end_piece_e", "t_thatch_roof_end_piece_s", "t_thatch_roof_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_thatch_roof_unconnected",
-        "t_thatch_roof_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "t_thatch_roof_unconnected", "t_thatch_roof_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_vitrified_grass/t_vitrified_grass.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_vitrified_grass/t_vitrified_grass.json
@@ -3,50 +3,35 @@
   "fg": "t_vitrified_grass_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_vitrified_grass_center"
-    },
+    { "id": "center", "fg": "t_vitrified_grass_center" },
     {
       "id": "corner",
       "fg": [
         "t_vitrified_grass_corner_nw",
-        "t_vitrified_grass_corner_sw",
+        "t_vitrified_grass_corner_ne",
         "t_vitrified_grass_corner_se",
-        "t_vitrified_grass_corner_ne"
+        "t_vitrified_grass_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_vitrified_grass_t_connection_n",
-        "t_vitrified_grass_t_connection_w",
+        "t_vitrified_grass_t_connection_e",
         "t_vitrified_grass_t_connection_s",
-        "t_vitrified_grass_t_connection_e"
+        "t_vitrified_grass_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_vitrified_grass_edge_ns",
-        "t_vitrified_grass_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_vitrified_grass_edge_ns", "t_vitrified_grass_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_vitrified_grass_end_piece_n",
-        "t_vitrified_grass_end_piece_w",
+        "t_vitrified_grass_end_piece_e",
         "t_vitrified_grass_end_piece_s",
-        "t_vitrified_grass_end_piece_e"
+        "t_vitrified_grass_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_vitrified_grass_unconnected",
-        "t_vitrified_grass_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_vitrified_grass_unconnected", "t_vitrified_grass_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall.json
@@ -3,50 +3,17 @@
   "fg": "t_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_wall_corner_nw",
-        "t_wall_corner_sw",
-        "t_wall_corner_se",
-        "t_wall_corner_ne"
-      ]
-    },
+    { "id": "center", "fg": "t_wall_center" },
+    { "id": "corner", "fg": [ "t_wall_corner_nw", "t_wall_corner_ne", "t_wall_corner_se", "t_wall_corner_sw" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_t_connection_n",
-        "t_wall_t_connection_w",
-        "t_wall_t_connection_s",
-        "t_wall_t_connection_e"
-      ]
+      "fg": [ "t_wall_t_connection_n", "t_wall_t_connection_e", "t_wall_t_connection_s", "t_wall_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_edge_ns",
-        "t_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_edge_ns", "t_wall_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_end_piece_n",
-        "t_wall_end_piece_w",
-        "t_wall_end_piece_s",
-        "t_wall_end_piece_e"
-      ]
+      "fg": [ "t_wall_end_piece_n", "t_wall_end_piece_e", "t_wall_end_piece_s", "t_wall_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_unconnected",
-        "t_wall_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_unconnected", "t_wall_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_P/t_wall_P.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_P/t_wall_P.json
@@ -3,50 +3,20 @@
   "fg": "t_wall_P_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_P_center"
-    },
+    { "id": "center", "fg": "t_wall_P_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_P_corner_nw",
-        "t_wall_P_corner_sw",
-        "t_wall_P_corner_se",
-        "t_wall_P_corner_ne"
-      ]
+      "fg": [ "t_wall_P_corner_nw", "t_wall_P_corner_ne", "t_wall_P_corner_se", "t_wall_P_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_P_t_connection_n",
-        "t_wall_P_t_connection_w",
-        "t_wall_P_t_connection_s",
-        "t_wall_P_t_connection_e"
-      ]
+      "fg": [ "t_wall_P_t_connection_n", "t_wall_P_t_connection_e", "t_wall_P_t_connection_s", "t_wall_P_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_P_edge_ns",
-        "t_wall_P_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_P_edge_ns", "t_wall_P_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_P_end_piece_n",
-        "t_wall_P_end_piece_w",
-        "t_wall_P_end_piece_s",
-        "t_wall_P_end_piece_e"
-      ]
+      "fg": [ "t_wall_P_end_piece_n", "t_wall_P_end_piece_e", "t_wall_P_end_piece_s", "t_wall_P_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_P_unconnected",
-        "t_wall_P_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_P_unconnected", "t_wall_P_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_b/t_wall_b.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_b/t_wall_b.json
@@ -3,50 +3,20 @@
   "fg": "t_wall_b_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_b_center"
-    },
+    { "id": "center", "fg": "t_wall_b_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_b_corner_nw",
-        "t_wall_b_corner_sw",
-        "t_wall_b_corner_se",
-        "t_wall_b_corner_ne"
-      ]
+      "fg": [ "t_wall_b_corner_nw", "t_wall_b_corner_ne", "t_wall_b_corner_se", "t_wall_b_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_b_t_connection_n",
-        "t_wall_b_t_connection_w",
-        "t_wall_b_t_connection_s",
-        "t_wall_b_t_connection_e"
-      ]
+      "fg": [ "t_wall_b_t_connection_n", "t_wall_b_t_connection_e", "t_wall_b_t_connection_s", "t_wall_b_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_b_edge_ns",
-        "t_wall_b_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_b_edge_ns", "t_wall_b_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_b_end_piece_n",
-        "t_wall_b_end_piece_w",
-        "t_wall_b_end_piece_s",
-        "t_wall_b_end_piece_e"
-      ]
+      "fg": [ "t_wall_b_end_piece_n", "t_wall_b_end_piece_e", "t_wall_b_end_piece_s", "t_wall_b_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_b_unconnected",
-        "t_wall_b_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_b_unconnected", "t_wall_b_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_black/t_wall_black.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_black/t_wall_black.json
@@ -1,52 +1,30 @@
 {
-  "id": [ "t_wall_black", "t_vitrified_wall" ],
+  "id": [
+    "t_wall_black",
+    "t_vitrified_wall"
+  ],
   "fg": "t_wall_black_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_black_center"
-    },
+    { "id": "center", "fg": "t_wall_black_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_black_corner_nw",
-        "t_wall_black_corner_sw",
-        "t_wall_black_corner_se",
-        "t_wall_black_corner_ne"
-      ]
+      "fg": [ "t_wall_black_corner_nw", "t_wall_black_corner_ne", "t_wall_black_corner_se", "t_wall_black_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_black_t_connection_n",
-        "t_wall_black_t_connection_w",
+        "t_wall_black_t_connection_e",
         "t_wall_black_t_connection_s",
-        "t_wall_black_t_connection_e"
+        "t_wall_black_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_black_edge_ns",
-        "t_wall_black_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_black_edge_ns", "t_wall_black_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_black_end_piece_n",
-        "t_wall_black_end_piece_w",
-        "t_wall_black_end_piece_s",
-        "t_wall_black_end_piece_e"
-      ]
+      "fg": [ "t_wall_black_end_piece_n", "t_wall_black_end_piece_e", "t_wall_black_end_piece_s", "t_wall_black_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_black_unconnected",
-        "t_wall_black_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_black_unconnected", "t_wall_black_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_g/t_wall_g.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_g/t_wall_g.json
@@ -3,50 +3,20 @@
   "fg": "t_wall_g_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_g_center"
-    },
+    { "id": "center", "fg": "t_wall_g_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_g_corner_nw",
-        "t_wall_g_corner_sw",
-        "t_wall_g_corner_se",
-        "t_wall_g_corner_ne"
-      ]
+      "fg": [ "t_wall_g_corner_nw", "t_wall_g_corner_ne", "t_wall_g_corner_se", "t_wall_g_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_g_t_connection_n",
-        "t_wall_g_t_connection_w",
-        "t_wall_g_t_connection_s",
-        "t_wall_g_t_connection_e"
-      ]
+      "fg": [ "t_wall_g_t_connection_n", "t_wall_g_t_connection_e", "t_wall_g_t_connection_s", "t_wall_g_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_g_edge_ns",
-        "t_wall_g_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_g_edge_ns", "t_wall_g_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_g_end_piece_n",
-        "t_wall_g_end_piece_w",
-        "t_wall_g_end_piece_s",
-        "t_wall_g_end_piece_e"
-      ]
+      "fg": [ "t_wall_g_end_piece_n", "t_wall_g_end_piece_e", "t_wall_g_end_piece_s", "t_wall_g_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_g_unconnected",
-        "t_wall_g_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_g_unconnected", "t_wall_g_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_purple/t_wall_p.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_purple/t_wall_p.json
@@ -3,50 +3,20 @@
   "fg": "t_wall_p_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_p_center"
-    },
+    { "id": "center", "fg": "t_wall_p_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_p_corner_nw",
-        "t_wall_p_corner_sw",
-        "t_wall_p_corner_se",
-        "t_wall_p_corner_ne"
-      ]
+      "fg": [ "t_wall_p_corner_nw", "t_wall_p_corner_ne", "t_wall_p_corner_se", "t_wall_p_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_p_t_connection_n",
-        "t_wall_p_t_connection_w",
-        "t_wall_p_t_connection_s",
-        "t_wall_p_t_connection_e"
-      ]
+      "fg": [ "t_wall_p_t_connection_n", "t_wall_p_t_connection_e", "t_wall_p_t_connection_s", "t_wall_p_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_p_edge_ns",
-        "t_wall_p_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_p_edge_ns", "t_wall_p_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_p_end_piece_n",
-        "t_wall_p_end_piece_w",
-        "t_wall_p_end_piece_s",
-        "t_wall_p_end_piece_e"
-      ]
+      "fg": [ "t_wall_p_end_piece_n", "t_wall_p_end_piece_e", "t_wall_p_end_piece_s", "t_wall_p_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_p_unconnected",
-        "t_wall_p_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_p_unconnected", "t_wall_p_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_r/t_wall_r.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_r/t_wall_r.json
@@ -3,50 +3,20 @@
   "fg": "t_wall_r_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_r_center"
-    },
+    { "id": "center", "fg": "t_wall_r_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_r_corner_nw",
-        "t_wall_r_corner_sw",
-        "t_wall_r_corner_se",
-        "t_wall_r_corner_ne"
-      ]
+      "fg": [ "t_wall_r_corner_nw", "t_wall_r_corner_ne", "t_wall_r_corner_se", "t_wall_r_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_r_t_connection_n",
-        "t_wall_r_t_connection_w",
-        "t_wall_r_t_connection_s",
-        "t_wall_r_t_connection_e"
-      ]
+      "fg": [ "t_wall_r_t_connection_n", "t_wall_r_t_connection_e", "t_wall_r_t_connection_s", "t_wall_r_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_r_edge_ns",
-        "t_wall_r_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_r_edge_ns", "t_wall_r_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_r_end_piece_n",
-        "t_wall_r_end_piece_w",
-        "t_wall_r_end_piece_s",
-        "t_wall_r_end_piece_e"
-      ]
+      "fg": [ "t_wall_r_end_piece_n", "t_wall_r_end_piece_e", "t_wall_r_end_piece_s", "t_wall_r_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_r_unconnected",
-        "t_wall_r_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_r_unconnected", "t_wall_r_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_w/t_wall_w.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_w/t_wall_w.json
@@ -3,50 +3,20 @@
   "fg": "t_wall_w_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_w_center"
-    },
+    { "id": "center", "fg": "t_wall_w_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_w_corner_nw",
-        "t_wall_w_corner_sw",
-        "t_wall_w_corner_se",
-        "t_wall_w_corner_ne"
-      ]
+      "fg": [ "t_wall_w_corner_nw", "t_wall_w_corner_ne", "t_wall_w_corner_se", "t_wall_w_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_w_t_connection_n",
-        "t_wall_w_t_connection_w",
-        "t_wall_w_t_connection_s",
-        "t_wall_w_t_connection_e"
-      ]
+      "fg": [ "t_wall_w_t_connection_n", "t_wall_w_t_connection_e", "t_wall_w_t_connection_s", "t_wall_w_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_w_edge_ns",
-        "t_wall_w_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_w_edge_ns", "t_wall_w_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_w_end_piece_n",
-        "t_wall_w_end_piece_w",
-        "t_wall_w_end_piece_s",
-        "t_wall_w_end_piece_e"
-      ]
+      "fg": [ "t_wall_w_end_piece_n", "t_wall_w_end_piece_e", "t_wall_w_end_piece_s", "t_wall_w_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_w_unconnected",
-        "t_wall_w_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_w_unconnected", "t_wall_w_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_y/t_wall_y.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall/t_wall_y/t_wall_y.json
@@ -3,50 +3,20 @@
   "fg": "t_wall_y_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_y_center"
-    },
+    { "id": "center", "fg": "t_wall_y_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_y_corner_nw",
-        "t_wall_y_corner_sw",
-        "t_wall_y_corner_se",
-        "t_wall_y_corner_ne"
-      ]
+      "fg": [ "t_wall_y_corner_nw", "t_wall_y_corner_ne", "t_wall_y_corner_se", "t_wall_y_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_y_t_connection_n",
-        "t_wall_y_t_connection_w",
-        "t_wall_y_t_connection_s",
-        "t_wall_y_t_connection_e"
-      ]
+      "fg": [ "t_wall_y_t_connection_n", "t_wall_y_t_connection_e", "t_wall_y_t_connection_s", "t_wall_y_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_y_edge_ns",
-        "t_wall_y_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_y_edge_ns", "t_wall_y_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_y_end_piece_n",
-        "t_wall_y_end_piece_w",
-        "t_wall_y_end_piece_s",
-        "t_wall_y_end_piece_e"
-      ]
+      "fg": [ "t_wall_y_end_piece_n", "t_wall_y_end_piece_e", "t_wall_y_end_piece_s", "t_wall_y_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_y_unconnected",
-        "t_wall_y_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_y_unconnected", "t_wall_y_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_burnt/t_wall_burnt.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_burnt/t_wall_burnt.json
@@ -1,53 +1,29 @@
 [
- {
-  "id": "t_wall_burnt",
-  "fg": "t_wall_burnt_unconnected",
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_burnt_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_wall_burnt_corner_nw",
-        "t_wall_burnt_corner_sw",
-        "t_wall_burnt_corner_se",
-        "t_wall_burnt_corner_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "t_wall_burnt_t_connection_n",
-        "t_wall_burnt_t_connection_w",
-        "t_wall_burnt_t_connection_s",
-        "t_wall_burnt_t_connection_e"
-      ]
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_burnt_edge_ns",
-        "t_wall_burnt_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "t_wall_burnt_end_piece_n",
-        "t_wall_burnt_end_piece_w",
-        "t_wall_burnt_end_piece_s",
-        "t_wall_burnt_end_piece_e"
-      ]
-    },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_burnt_unconnected"
-      ]
-    }
-  ]
-} 
+  {
+    "id": "t_wall_burnt",
+    "fg": "t_wall_burnt_unconnected",
+    "multitile": true,
+    "additional_tiles": [
+      { "id": "center", "fg": "t_wall_burnt_center" },
+      {
+        "id": "corner",
+        "fg": [ "t_wall_burnt_corner_nw", "t_wall_burnt_corner_ne", "t_wall_burnt_corner_se", "t_wall_burnt_corner_sw" ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_wall_burnt_t_connection_n",
+          "t_wall_burnt_t_connection_e",
+          "t_wall_burnt_t_connection_s",
+          "t_wall_burnt_t_connection_w"
+        ]
+      },
+      { "id": "edge", "fg": [ "t_wall_burnt_edge_ns", "t_wall_burnt_edge_ew" ] },
+      {
+        "id": "end_piece",
+        "fg": [ "t_wall_burnt_end_piece_n", "t_wall_burnt_end_piece_e", "t_wall_burnt_end_piece_s", "t_wall_burnt_end_piece_w" ]
+      },
+      { "id": "unconnected", "fg": [ "t_wall_burnt_unconnected" ] }
+    ]
+  }
 ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_glass/t_wall_glass.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_glass/t_wall_glass.json
@@ -3,50 +3,25 @@
   "fg": "t_wall_glass_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_glass_center"
-    },
+    { "id": "center", "fg": "t_wall_glass_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_glass_corner_nw",
-        "t_wall_glass_corner_sw",
-        "t_wall_glass_corner_se",
-        "t_wall_glass_corner_ne"
-      ]
+      "fg": [ "t_wall_glass_corner_nw", "t_wall_glass_corner_ne", "t_wall_glass_corner_se", "t_wall_glass_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_glass_t_connection_n",
-        "t_wall_glass_t_connection_w",
+        "t_wall_glass_t_connection_e",
         "t_wall_glass_t_connection_s",
-        "t_wall_glass_t_connection_e"
+        "t_wall_glass_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_glass_edge_ns",
-        "t_wall_glass_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_glass_edge_ns", "t_wall_glass_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_glass_end_piece_n",
-        "t_wall_glass_end_piece_w",
-        "t_wall_glass_end_piece_s",
-        "t_wall_glass_end_piece_e"
-      ]
+      "fg": [ "t_wall_glass_end_piece_n", "t_wall_glass_end_piece_e", "t_wall_glass_end_piece_s", "t_wall_glass_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_glass_unconnected",
-        "t_wall_glass_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_glass_unconnected", "t_wall_glass_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_log/t_wall_log.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_log/t_wall_log.json
@@ -3,50 +3,20 @@
   "fg": "t_wall_log_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_log_center"
-    },
+    { "id": "center", "fg": "t_wall_log_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_log_corner_nw",
-        "t_wall_log_corner_sw",
-        "t_wall_log_corner_se",
-        "t_wall_log_corner_ne"
-      ]
+      "fg": [ "t_wall_log_corner_nw", "t_wall_log_corner_ne", "t_wall_log_corner_se", "t_wall_log_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_log_t_connection_n",
-        "t_wall_log_t_connection_w",
-        "t_wall_log_t_connection_s",
-        "t_wall_log_t_connection_e"
-      ]
+      "fg": [ "t_wall_log_t_connection_n", "t_wall_log_t_connection_e", "t_wall_log_t_connection_s", "t_wall_log_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_log_edge_ns",
-        "t_wall_log_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_log_edge_ns", "t_wall_log_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_log_end_piece_n",
-        "t_wall_log_end_piece_w",
-        "t_wall_log_end_piece_s",
-        "t_wall_log_end_piece_e"
-      ]
+      "fg": [ "t_wall_log_end_piece_n", "t_wall_log_end_piece_e", "t_wall_log_end_piece_s", "t_wall_log_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_log_unconnected",
-        "t_wall_log_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_log_unconnected", "t_wall_log_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_log_broken/t_wall_log_broken.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_log_broken/t_wall_log_broken.json
@@ -3,50 +3,35 @@
   "fg": "t_wall_log_broken_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_log_broken_center"
-    },
+    { "id": "center", "fg": "t_wall_log_broken_center" },
     {
       "id": "corner",
       "fg": [
         "t_wall_log_broken_corner_nw",
-        "t_wall_log_broken_corner_sw",
+        "t_wall_log_broken_corner_ne",
         "t_wall_log_broken_corner_se",
-        "t_wall_log_broken_corner_ne"
+        "t_wall_log_broken_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_log_broken_t_connection_n",
-        "t_wall_log_broken_t_connection_w",
+        "t_wall_log_broken_t_connection_e",
         "t_wall_log_broken_t_connection_s",
-        "t_wall_log_broken_t_connection_e"
+        "t_wall_log_broken_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_log_broken_edge_ns",
-        "t_wall_log_broken_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_log_broken_edge_ns", "t_wall_log_broken_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wall_log_broken_end_piece_n",
-        "t_wall_log_broken_end_piece_w",
+        "t_wall_log_broken_end_piece_e",
         "t_wall_log_broken_end_piece_s",
-        "t_wall_log_broken_end_piece_e"
+        "t_wall_log_broken_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_log_broken_unconnected",
-        "t_wall_log_broken_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_log_broken_unconnected", "t_wall_log_broken_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_log_chipped/t_wall_log_chipped.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_log_chipped/t_wall_log_chipped.json
@@ -3,50 +3,35 @@
   "fg": "t_wall_log_chipped_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_log_chipped_center"
-    },
+    { "id": "center", "fg": "t_wall_log_chipped_center" },
     {
       "id": "corner",
       "fg": [
         "t_wall_log_chipped_corner_nw",
-        "t_wall_log_chipped_corner_sw",
+        "t_wall_log_chipped_corner_ne",
         "t_wall_log_chipped_corner_se",
-        "t_wall_log_chipped_corner_ne"
+        "t_wall_log_chipped_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_log_chipped_t_connection_n",
-        "t_wall_log_chipped_t_connection_w",
+        "t_wall_log_chipped_t_connection_e",
         "t_wall_log_chipped_t_connection_s",
-        "t_wall_log_chipped_t_connection_e"
+        "t_wall_log_chipped_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_log_chipped_edge_ns",
-        "t_wall_log_chipped_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_log_chipped_edge_ns", "t_wall_log_chipped_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wall_log_chipped_end_piece_n",
-        "t_wall_log_chipped_end_piece_w",
+        "t_wall_log_chipped_end_piece_e",
         "t_wall_log_chipped_end_piece_s",
-        "t_wall_log_chipped_end_piece_e"
+        "t_wall_log_chipped_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_log_chipped_unconnected",
-        "t_wall_log_chipped_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_log_chipped_unconnected", "t_wall_log_chipped_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_metal/t_wall_metal.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_metal/t_wall_metal.json
@@ -3,50 +3,25 @@
   "fg": "t_wall_metal_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_metal_center"
-    },
+    { "id": "center", "fg": "t_wall_metal_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_metal_corner_nw",
-        "t_wall_metal_corner_sw",
-        "t_wall_metal_corner_se",
-        "t_wall_metal_corner_ne"
-      ]
+      "fg": [ "t_wall_metal_corner_nw", "t_wall_metal_corner_ne", "t_wall_metal_corner_se", "t_wall_metal_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_metal_t_connection_n",
-        "t_wall_metal_t_connection_w",
+        "t_wall_metal_t_connection_e",
         "t_wall_metal_t_connection_s",
-        "t_wall_metal_t_connection_e"
+        "t_wall_metal_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_metal_edge_ns",
-        "t_wall_metal_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_metal_edge_ns", "t_wall_metal_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_metal_end_piece_n",
-        "t_wall_metal_end_piece_w",
-        "t_wall_metal_end_piece_s",
-        "t_wall_metal_end_piece_e"
-      ]
+      "fg": [ "t_wall_metal_end_piece_n", "t_wall_metal_end_piece_e", "t_wall_metal_end_piece_s", "t_wall_metal_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_metal_unconnected",
-        "t_wall_metal_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_metal_unconnected", "t_wall_metal_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_rammed_earth/t_wall_rammed_earth_season_autumn/t_wall_rammed_earth_autumn.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_rammed_earth/t_wall_rammed_earth_season_autumn/t_wall_rammed_earth_autumn.json
@@ -3,50 +3,38 @@
   "fg": "t_wall_rammed_earth_autumn_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_rammed_earth_autumn_center"
-    },
+    { "id": "center", "fg": "t_wall_rammed_earth_autumn_center" },
     {
       "id": "corner",
       "fg": [
         "t_wall_rammed_earth_autumn_corner_nw",
-        "t_wall_rammed_earth_autumn_corner_sw",
+        "t_wall_rammed_earth_autumn_corner_ne",
         "t_wall_rammed_earth_autumn_corner_se",
-        "t_wall_rammed_earth_autumn_corner_ne"
+        "t_wall_rammed_earth_autumn_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_rammed_earth_autumn_t_connection_n",
-        "t_wall_rammed_earth_autumn_t_connection_w",
+        "t_wall_rammed_earth_autumn_t_connection_e",
         "t_wall_rammed_earth_autumn_t_connection_s",
-        "t_wall_rammed_earth_autumn_t_connection_e"
+        "t_wall_rammed_earth_autumn_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_rammed_earth_autumn_edge_ns",
-        "t_wall_rammed_earth_autumn_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_rammed_earth_autumn_edge_ns", "t_wall_rammed_earth_autumn_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wall_rammed_earth_autumn_end_piece_n",
-        "t_wall_rammed_earth_autumn_end_piece_w",
+        "t_wall_rammed_earth_autumn_end_piece_e",
         "t_wall_rammed_earth_autumn_end_piece_s",
-        "t_wall_rammed_earth_autumn_end_piece_e"
+        "t_wall_rammed_earth_autumn_end_piece_w"
       ]
     },
     {
       "id": "unconnected",
-      "fg": [
-        "t_wall_rammed_earth_autumn_unconnected",
-        "t_wall_rammed_earth_autumn_unconnected"
-      ]
+      "fg": [ "t_wall_rammed_earth_autumn_unconnected", "t_wall_rammed_earth_autumn_unconnected" ]
     }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_rammed_earth/t_wall_rammed_earth_season_spring/t_wall_rammed_earth.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_rammed_earth/t_wall_rammed_earth_season_spring/t_wall_rammed_earth.json
@@ -3,50 +3,35 @@
   "fg": "t_wall_rammed_earth_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_rammed_earth_center"
-    },
+    { "id": "center", "fg": "t_wall_rammed_earth_center" },
     {
       "id": "corner",
       "fg": [
         "t_wall_rammed_earth_corner_nw",
-        "t_wall_rammed_earth_corner_sw",
+        "t_wall_rammed_earth_corner_ne",
         "t_wall_rammed_earth_corner_se",
-        "t_wall_rammed_earth_corner_ne"
+        "t_wall_rammed_earth_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_rammed_earth_t_connection_n",
-        "t_wall_rammed_earth_t_connection_w",
+        "t_wall_rammed_earth_t_connection_e",
         "t_wall_rammed_earth_t_connection_s",
-        "t_wall_rammed_earth_t_connection_e"
+        "t_wall_rammed_earth_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_rammed_earth_edge_ns",
-        "t_wall_rammed_earth_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_rammed_earth_edge_ns", "t_wall_rammed_earth_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wall_rammed_earth_end_piece_n",
-        "t_wall_rammed_earth_end_piece_w",
+        "t_wall_rammed_earth_end_piece_e",
         "t_wall_rammed_earth_end_piece_s",
-        "t_wall_rammed_earth_end_piece_e"
+        "t_wall_rammed_earth_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_rammed_earth_unconnected",
-        "t_wall_rammed_earth_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_rammed_earth_unconnected", "t_wall_rammed_earth_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_rammed_earth/t_wall_rammed_earth_season_summer/t_wall_rammed_earth_summer.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_rammed_earth/t_wall_rammed_earth_season_summer/t_wall_rammed_earth_summer.json
@@ -3,50 +3,38 @@
   "fg": "t_wall_rammed_earth_summer_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_rammed_earth_summer_center"
-    },
+    { "id": "center", "fg": "t_wall_rammed_earth_summer_center" },
     {
       "id": "corner",
       "fg": [
         "t_wall_rammed_earth_summer_corner_nw",
-        "t_wall_rammed_earth_summer_corner_sw",
+        "t_wall_rammed_earth_summer_corner_ne",
         "t_wall_rammed_earth_summer_corner_se",
-        "t_wall_rammed_earth_summer_corner_ne"
+        "t_wall_rammed_earth_summer_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_rammed_earth_summer_t_connection_n",
-        "t_wall_rammed_earth_summer_t_connection_w",
+        "t_wall_rammed_earth_summer_t_connection_e",
         "t_wall_rammed_earth_summer_t_connection_s",
-        "t_wall_rammed_earth_summer_t_connection_e"
+        "t_wall_rammed_earth_summer_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_rammed_earth_summer_edge_ns",
-        "t_wall_rammed_earth_summer_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_rammed_earth_summer_edge_ns", "t_wall_rammed_earth_summer_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wall_rammed_earth_summer_end_piece_n",
-        "t_wall_rammed_earth_summer_end_piece_w",
+        "t_wall_rammed_earth_summer_end_piece_e",
         "t_wall_rammed_earth_summer_end_piece_s",
-        "t_wall_rammed_earth_summer_end_piece_e"
+        "t_wall_rammed_earth_summer_end_piece_w"
       ]
     },
     {
       "id": "unconnected",
-      "fg": [
-        "t_wall_rammed_earth_summer_unconnected",
-        "t_wall_rammed_earth_summer_unconnected"
-      ]
+      "fg": [ "t_wall_rammed_earth_summer_unconnected", "t_wall_rammed_earth_summer_unconnected" ]
     }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_rammed_earth/t_wall_rammed_earth_season_winter/t_wall_rammed_earth_winter.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_rammed_earth/t_wall_rammed_earth_season_winter/t_wall_rammed_earth_winter.json
@@ -3,50 +3,38 @@
   "fg": "t_wall_rammed_earth_winter_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_rammed_earth_winter_center"
-    },
+    { "id": "center", "fg": "t_wall_rammed_earth_winter_center" },
     {
       "id": "corner",
       "fg": [
         "t_wall_rammed_earth_winter_corner_nw",
-        "t_wall_rammed_earth_winter_corner_sw",
+        "t_wall_rammed_earth_winter_corner_ne",
         "t_wall_rammed_earth_winter_corner_se",
-        "t_wall_rammed_earth_winter_corner_ne"
+        "t_wall_rammed_earth_winter_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_rammed_earth_winter_t_connection_n",
-        "t_wall_rammed_earth_winter_t_connection_w",
+        "t_wall_rammed_earth_winter_t_connection_e",
         "t_wall_rammed_earth_winter_t_connection_s",
-        "t_wall_rammed_earth_winter_t_connection_e"
+        "t_wall_rammed_earth_winter_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_rammed_earth_winter_edge_ns",
-        "t_wall_rammed_earth_winter_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_rammed_earth_winter_edge_ns", "t_wall_rammed_earth_winter_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wall_rammed_earth_winter_end_piece_n",
-        "t_wall_rammed_earth_winter_end_piece_w",
+        "t_wall_rammed_earth_winter_end_piece_e",
         "t_wall_rammed_earth_winter_end_piece_s",
-        "t_wall_rammed_earth_winter_end_piece_e"
+        "t_wall_rammed_earth_winter_end_piece_w"
       ]
     },
     {
       "id": "unconnected",
-      "fg": [
-        "t_wall_rammed_earth_winter_unconnected",
-        "t_wall_rammed_earth_winter_unconnected"
-      ]
+      "fg": [ "t_wall_rammed_earth_winter_unconnected", "t_wall_rammed_earth_winter_unconnected" ]
     }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_resin_cage/t_wall_resin_cage.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_resin_cage/t_wall_resin_cage.json
@@ -3,50 +3,35 @@
   "fg": "t_wall_resin_cage_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_resin_cage_center"
-    },
+    { "id": "center", "fg": "t_wall_resin_cage_center" },
     {
       "id": "corner",
       "fg": [
         "t_wall_resin_cage_corner_nw",
-        "t_wall_resin_cage_corner_sw",
+        "t_wall_resin_cage_corner_ne",
         "t_wall_resin_cage_corner_se",
-        "t_wall_resin_cage_corner_ne"
+        "t_wall_resin_cage_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_resin_cage_t_connection_n",
-        "t_wall_resin_cage_t_connection_w",
+        "t_wall_resin_cage_t_connection_e",
         "t_wall_resin_cage_t_connection_s",
-        "t_wall_resin_cage_t_connection_e"
+        "t_wall_resin_cage_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_resin_cage_edge_ns",
-        "t_wall_resin_cage_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_resin_cage_edge_ns", "t_wall_resin_cage_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wall_resin_cage_end_piece_n",
-        "t_wall_resin_cage_end_piece_w",
+        "t_wall_resin_cage_end_piece_e",
         "t_wall_resin_cage_end_piece_s",
-        "t_wall_resin_cage_end_piece_e"
+        "t_wall_resin_cage_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_resin_cage_unconnected",
-        "t_wall_resin_cage_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_resin_cage_unconnected", "t_wall_resin_cage_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_warped/t_wall_warped.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_warped/t_wall_warped.json
@@ -19,19 +19,19 @@
       "fg": [
         {
           "weight": 20,
-          "sprite": [ "t_wall_warped_corner_nw", "t_wall_warped_corner_sw", "t_wall_warped_corner_se", "t_wall_warped_corner_ne" ]
+          "sprite": [ "t_wall_warped_corner_nw", "t_wall_warped_corner_ne", "t_wall_warped_corner_se", "t_wall_warped_corner_sw" ]
         },
         {
           "weight": 20,
-          "sprite": [ "t_wall_warped_2_corner_nw", "t_wall_warped_2_corner_sw", "t_wall_warped_2_corner_se", "t_wall_warped_2_corner_ne" ]
+          "sprite": [ "t_wall_warped_2_corner_nw", "t_wall_warped_2_corner_ne", "t_wall_warped_2_corner_se", "t_wall_warped_2_corner_sw" ]
         },
         {
           "weight": 40,
-          "sprite": [ "t_wall_warped_1_corner_nw", "t_wall_warped_1_corner_sw", "t_wall_warped_1_corner_se", "t_wall_warped_1_corner_ne" ]
+          "sprite": [ "t_wall_warped_1_corner_nw", "t_wall_warped_1_corner_ne", "t_wall_warped_1_corner_se", "t_wall_warped_1_corner_sw" ]
         },
         {
           "weight": 20,
-          "sprite": [ "t_wall_warped_2_corner_nw", "t_wall_warped_2_corner_sw", "t_wall_warped_2_corner_se", "t_wall_warped_2_corner_ne" ]
+          "sprite": [ "t_wall_warped_2_corner_nw", "t_wall_warped_2_corner_ne", "t_wall_warped_2_corner_se", "t_wall_warped_2_corner_sw" ]
         }
       ]
     },
@@ -41,19 +41,39 @@
       "fg": [
         {
           "weight": 20,
-          "sprite": [ "t_wall_warped_t_connection_n", "t_wall_warped_t_connection_w", "t_wall_warped_t_connection_s", "t_wall_warped_t_connection_e" ]
+          "sprite": [
+            "t_wall_warped_t_connection_n",
+            "t_wall_warped_t_connection_e",
+            "t_wall_warped_t_connection_s",
+            "t_wall_warped_t_connection_w"
+          ]
         },
         {
           "weight": 20,
-          "sprite": [ "t_wall_warped_2_t_connection_n", "t_wall_warped_2_t_connection_w", "t_wall_warped_2_t_connection_s", "t_wall_warped_2_t_connection_e" ]
+          "sprite": [
+            "t_wall_warped_2_t_connection_n",
+            "t_wall_warped_2_t_connection_e",
+            "t_wall_warped_2_t_connection_s",
+            "t_wall_warped_2_t_connection_w"
+          ]
         },
         {
           "weight": 40,
-          "sprite": [ "t_wall_warped_1_t_connection_n", "t_wall_warped_1_t_connection_w", "t_wall_warped_1_t_connection_s", "t_wall_warped_1_t_connection_e" ]
+          "sprite": [
+            "t_wall_warped_1_t_connection_n",
+            "t_wall_warped_1_t_connection_e",
+            "t_wall_warped_1_t_connection_s",
+            "t_wall_warped_1_t_connection_w"
+          ]
         },
         {
           "weight": 20,
-          "sprite": [ "t_wall_warped_2_t_connection_n", "t_wall_warped_2_t_connection_w", "t_wall_warped_2_t_connection_s", "t_wall_warped_2_t_connection_e" ]
+          "sprite": [
+            "t_wall_warped_2_t_connection_n",
+            "t_wall_warped_2_t_connection_e",
+            "t_wall_warped_2_t_connection_s",
+            "t_wall_warped_2_t_connection_w"
+          ]
         }
       ]
     },
@@ -73,19 +93,34 @@
       "fg": [
         {
           "weight": 20,
-          "sprite": [ "t_wall_warped_end_piece_n", "t_wall_warped_end_piece_w", "t_wall_warped_end_piece_s", "t_wall_warped_end_piece_e" ]
+          "sprite": [ "t_wall_warped_end_piece_n", "t_wall_warped_end_piece_e", "t_wall_warped_end_piece_s", "t_wall_warped_end_piece_w" ]
         },
         {
           "weight": 20,
-          "sprite": [ "t_wall_warped_2_end_piece_n", "t_wall_warped_2_end_piece_w", "t_wall_warped_2_end_piece_s", "t_wall_warped_2_end_piece_e" ]
+          "sprite": [
+            "t_wall_warped_2_end_piece_n",
+            "t_wall_warped_2_end_piece_e",
+            "t_wall_warped_2_end_piece_s",
+            "t_wall_warped_2_end_piece_w"
+          ]
         },
         {
           "weight": 40,
-          "sprite": [ "t_wall_warped_1_end_piece_n", "t_wall_warped_1_end_piece_w", "t_wall_warped_1_end_piece_s", "t_wall_warped_1_end_piece_e" ]
+          "sprite": [
+            "t_wall_warped_1_end_piece_n",
+            "t_wall_warped_1_end_piece_e",
+            "t_wall_warped_1_end_piece_s",
+            "t_wall_warped_1_end_piece_w"
+          ]
         },
         {
           "weight": 20,
-          "sprite": [ "t_wall_warped_2_end_piece_n", "t_wall_warped_2_end_piece_w", "t_wall_warped_2_end_piece_s", "t_wall_warped_2_end_piece_e" ]
+          "sprite": [
+            "t_wall_warped_2_end_piece_n",
+            "t_wall_warped_2_end_piece_e",
+            "t_wall_warped_2_end_piece_s",
+            "t_wall_warped_2_end_piece_w"
+          ]
         }
       ]
     },

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_wood/t_wall_wood.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_wood/t_wall_wood.json
@@ -3,50 +3,25 @@
   "fg": "t_wall_wood_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_wood_center"
-    },
+    { "id": "center", "fg": "t_wall_wood_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_wood_corner_nw",
-        "t_wall_wood_corner_sw",
-        "t_wall_wood_corner_se",
-        "t_wall_wood_corner_ne"
-      ]
+      "fg": [ "t_wall_wood_corner_nw", "t_wall_wood_corner_ne", "t_wall_wood_corner_se", "t_wall_wood_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_wood_t_connection_n",
-        "t_wall_wood_t_connection_w",
+        "t_wall_wood_t_connection_e",
         "t_wall_wood_t_connection_s",
-        "t_wall_wood_t_connection_e"
+        "t_wall_wood_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_wood_edge_ns",
-        "t_wall_wood_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_wood_edge_ns", "t_wall_wood_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_wood_end_piece_n",
-        "t_wall_wood_end_piece_w",
-        "t_wall_wood_end_piece_s",
-        "t_wall_wood_end_piece_e"
-      ]
+      "fg": [ "t_wall_wood_end_piece_n", "t_wall_wood_end_piece_e", "t_wall_wood_end_piece_s", "t_wall_wood_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_wood_unconnected",
-        "t_wall_wood_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_wood_unconnected", "t_wall_wood_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_wood_broken/t_wall_wood_broken.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_wood_broken/t_wall_wood_broken.json
@@ -3,50 +3,35 @@
   "fg": "t_wall_wood_broken_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_wood_broken_center"
-    },
+    { "id": "center", "fg": "t_wall_wood_broken_center" },
     {
       "id": "corner",
       "fg": [
         "t_wall_wood_broken_corner_nw",
-        "t_wall_wood_broken_corner_sw",
+        "t_wall_wood_broken_corner_ne",
         "t_wall_wood_broken_corner_se",
-        "t_wall_wood_broken_corner_ne"
+        "t_wall_wood_broken_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_wood_broken_t_connection_n",
-        "t_wall_wood_broken_t_connection_w",
+        "t_wall_wood_broken_t_connection_e",
         "t_wall_wood_broken_t_connection_s",
-        "t_wall_wood_broken_t_connection_e"
+        "t_wall_wood_broken_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_wood_broken_edge_ns",
-        "t_wall_wood_broken_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_wood_broken_edge_ns", "t_wall_wood_broken_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wall_wood_broken_end_piece_n",
-        "t_wall_wood_broken_end_piece_w",
+        "t_wall_wood_broken_end_piece_e",
         "t_wall_wood_broken_end_piece_s",
-        "t_wall_wood_broken_end_piece_e"
+        "t_wall_wood_broken_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_wood_broken_unconnected",
-        "t_wall_wood_broken_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_wood_broken_unconnected", "t_wall_wood_broken_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_wood_chipped/t_wall_wood_chipped.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wall_wood_chipped/t_wall_wood_chipped.json
@@ -3,50 +3,35 @@
   "fg": "t_wall_wood_chipped_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_wood_chipped_center"
-    },
+    { "id": "center", "fg": "t_wall_wood_chipped_center" },
     {
       "id": "corner",
       "fg": [
         "t_wall_wood_chipped_corner_nw",
-        "t_wall_wood_chipped_corner_sw",
+        "t_wall_wood_chipped_corner_ne",
         "t_wall_wood_chipped_corner_se",
-        "t_wall_wood_chipped_corner_ne"
+        "t_wall_wood_chipped_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_wood_chipped_t_connection_n",
-        "t_wall_wood_chipped_t_connection_w",
+        "t_wall_wood_chipped_t_connection_e",
         "t_wall_wood_chipped_t_connection_s",
-        "t_wall_wood_chipped_t_connection_e"
+        "t_wall_wood_chipped_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_wood_chipped_edge_ns",
-        "t_wall_wood_chipped_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_wood_chipped_edge_ns", "t_wall_wood_chipped_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wall_wood_chipped_end_piece_n",
-        "t_wall_wood_chipped_end_piece_w",
+        "t_wall_wood_chipped_end_piece_e",
         "t_wall_wood_chipped_end_piece_s",
-        "t_wall_wood_chipped_end_piece_e"
+        "t_wall_wood_chipped_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_wood_chipped_unconnected",
-        "t_wall_wood_chipped_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_wood_chipped_unconnected", "t_wall_wood_chipped_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_water_dp/t_water_dp.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_water_dp/t_water_dp.json
@@ -7,29 +7,29 @@
       {
         "id": "center",
         "fg": [
-        { "weight": 4, "sprite": "t_water_dp" },
-        { "weight": 4, "sprite": "t_water_dp_0" },
-        { "weight": 4, "sprite": "t_water_dp_1" },
-        { "weight": 4, "sprite": "t_water_dp_2" },
-        { "weight": 1, "sprite": "t_water_dp_3" },
-        { "weight": 1, "sprite": "t_water_dp_4" }
+          { "weight": 4, "sprite": "t_water_dp" },
+          { "weight": 4, "sprite": "t_water_dp_0" },
+          { "weight": 4, "sprite": "t_water_dp_1" },
+          { "weight": 4, "sprite": "t_water_dp_2" },
+          { "weight": 1, "sprite": "t_water_dp_3" },
+          { "weight": 1, "sprite": "t_water_dp_4" }
         ],
         "bg": [ "t_grass" ]
       },
       {
         "id": "corner",
-        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_sw", "t_water_dp_corner_se", "t_water_dp_corner_ne" ],
+        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_ne", "t_water_dp_corner_se", "t_water_dp_corner_sw" ],
         "bg": [ "t_grass" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_w", "t_water_dp_t_connection_s", "t_water_dp_t_connection_e" ],
+        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_e", "t_water_dp_t_connection_s", "t_water_dp_t_connection_w" ],
         "bg": [ "t_grass" ]
       },
       { "id": "edge", "fg": [ "t_water_dp_edge_ns", "t_water_dp_edge_ew" ], "bg": [ "t_grass" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_w", "t_water_dp_end_piece_s", "t_water_dp_end_piece_e" ],
+        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_e", "t_water_dp_end_piece_s", "t_water_dp_end_piece_w" ],
         "bg": [ "t_grass" ]
       },
       { "id": "unconnected", "fg": [ "t_water_dp_unconnected", "t_water_dp_unconnected" ], "bg": [ "t_grass" ] }
@@ -43,29 +43,29 @@
       {
         "id": "center",
         "fg": [
-        { "weight": 4, "sprite": "t_water_dp" },
-        { "weight": 4, "sprite": "t_water_dp_0" },
-        { "weight": 4, "sprite": "t_water_dp_1" },
-        { "weight": 4, "sprite": "t_water_dp_2" },
-        { "weight": 1, "sprite": "t_water_dp_3" },
-        { "weight": 1, "sprite": "t_water_dp_4" }
+          { "weight": 4, "sprite": "t_water_dp" },
+          { "weight": 4, "sprite": "t_water_dp_0" },
+          { "weight": 4, "sprite": "t_water_dp_1" },
+          { "weight": 4, "sprite": "t_water_dp_2" },
+          { "weight": 1, "sprite": "t_water_dp_3" },
+          { "weight": 1, "sprite": "t_water_dp_4" }
         ],
         "bg": [ "t_grass_winter" ]
       },
       {
         "id": "corner",
-        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_sw", "t_water_dp_corner_se", "t_water_dp_corner_ne" ],
+        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_ne", "t_water_dp_corner_se", "t_water_dp_corner_sw" ],
         "bg": [ "t_grass_winter" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_w", "t_water_dp_t_connection_s", "t_water_dp_t_connection_e" ],
+        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_e", "t_water_dp_t_connection_s", "t_water_dp_t_connection_w" ],
         "bg": [ "t_grass_winter" ]
       },
       { "id": "edge", "fg": [ "t_water_dp_edge_ns", "t_water_dp_edge_ew" ], "bg": [ "t_grass_winter" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_w", "t_water_dp_end_piece_s", "t_water_dp_end_piece_e" ],
+        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_e", "t_water_dp_end_piece_s", "t_water_dp_end_piece_w" ],
         "bg": [ "t_grass_winter" ]
       },
       {
@@ -83,32 +83,36 @@
       {
         "id": "center",
         "fg": [
-        { "weight": 4, "sprite": "t_water_dp" },
-        { "weight": 4, "sprite": "t_water_dp_0" },
-        { "weight": 4, "sprite": "t_water_dp_1" },
-        { "weight": 4, "sprite": "t_water_dp_2" },
-        { "weight": 1, "sprite": "t_water_dp_3" },
-        { "weight": 1, "sprite": "t_water_dp_4" }
+          { "weight": 4, "sprite": "t_water_dp" },
+          { "weight": 4, "sprite": "t_water_dp_0" },
+          { "weight": 4, "sprite": "t_water_dp_1" },
+          { "weight": 4, "sprite": "t_water_dp_2" },
+          { "weight": 1, "sprite": "t_water_dp_3" },
+          { "weight": 1, "sprite": "t_water_dp_4" }
         ],
         "bg": [ "t_grass_summer" ]
       },
       {
         "id": "corner",
-        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_sw", "t_water_dp_corner_se", "t_water_dp_corner_ne" ],
+        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_ne", "t_water_dp_corner_se", "t_water_dp_corner_sw" ],
         "bg": [ "t_grass_summer" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_w", "t_water_dp_t_connection_s", "t_water_dp_t_connection_e" ],
+        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_e", "t_water_dp_t_connection_s", "t_water_dp_t_connection_w" ],
         "bg": [ "t_grass_summer" ]
       },
       { "id": "edge", "fg": [ "t_water_dp_edge_ns", "t_water_dp_edge_ew" ], "bg": [ "t_grass_summer" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_w", "t_water_dp_end_piece_s", "t_water_dp_end_piece_e" ],
+        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_e", "t_water_dp_end_piece_s", "t_water_dp_end_piece_w" ],
         "bg": [ "t_grass_summer" ]
       },
-      { "id": "unconnected", "fg": [ "t_water_dp_unconnected", "t_water_dp_unconnected" ], "bg": [ "t_grass_summer" ] }
+      {
+        "id": "unconnected",
+        "fg": [ "t_water_dp_unconnected", "t_water_dp_unconnected" ],
+        "bg": [ "t_grass_summer" ]
+      }
     ]
   },
   {
@@ -119,33 +123,36 @@
       {
         "id": "center",
         "fg": [
-        { "weight": 4, "sprite": "t_water_dp" },
-        { "weight": 4, "sprite": "t_water_dp_0" },
-        { "weight": 4, "sprite": "t_water_dp_1" },
-        { "weight": 4, "sprite": "t_water_dp_2" },
-        { "weight": 1, "sprite": "t_water_dp_3" },
-        { "weight": 1, "sprite": "t_water_dp_4" }
+          { "weight": 4, "sprite": "t_water_dp" },
+          { "weight": 4, "sprite": "t_water_dp_0" },
+          { "weight": 4, "sprite": "t_water_dp_1" },
+          { "weight": 4, "sprite": "t_water_dp_2" },
+          { "weight": 1, "sprite": "t_water_dp_3" },
+          { "weight": 1, "sprite": "t_water_dp_4" }
         ],
         "bg": [ "t_grass_autumn" ]
       },
       {
         "id": "corner",
-        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_sw", "t_water_dp_corner_se", "t_water_dp_corner_ne" ],
+        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_ne", "t_water_dp_corner_se", "t_water_dp_corner_sw" ],
         "bg": [ "t_grass_autumn" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_w", "t_water_dp_t_connection_s", "t_water_dp_t_connection_e" ],
+        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_e", "t_water_dp_t_connection_s", "t_water_dp_t_connection_w" ],
         "bg": [ "t_grass_autumn" ]
       },
       { "id": "edge", "fg": [ "t_water_dp_edge_ns", "t_water_dp_edge_ew" ], "bg": [ "t_grass_autumn" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_w", "t_water_dp_end_piece_s", "t_water_dp_end_piece_e" ],
+        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_e", "t_water_dp_end_piece_s", "t_water_dp_end_piece_w" ],
         "bg": [ "t_grass_autumn" ]
       },
-      { "id": "unconnected", "fg": [ "t_water_dp_unconnected", "t_water_dp_unconnected" ], "bg": [ "t_grass_autumn" ] }
+      {
+        "id": "unconnected",
+        "fg": [ "t_water_dp_unconnected", "t_water_dp_unconnected" ],
+        "bg": [ "t_grass_autumn" ]
+      }
     ]
   }
 ]
-

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_water_hot/t_water_hot.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_water_hot/t_water_hot.json
@@ -16,44 +16,22 @@
     },
     {
       "id": "corner",
-      "fg": [
-        "t_water_hot_corner_nw",
-        "t_water_hot_corner_sw",
-        "t_water_hot_corner_se",
-        "t_water_hot_corner_ne"
-      ]
+      "fg": [ "t_water_hot_corner_nw", "t_water_hot_corner_ne", "t_water_hot_corner_se", "t_water_hot_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_water_hot_t_connection_n",
-        "t_water_hot_t_connection_w",
+        "t_water_hot_t_connection_e",
         "t_water_hot_t_connection_s",
-        "t_water_hot_t_connection_e"
+        "t_water_hot_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_water_hot_edge_ns",
-        "t_water_hot_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_water_hot_edge_ns", "t_water_hot_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_water_hot_end_piece_n",
-        "t_water_hot_end_piece_w",
-        "t_water_hot_end_piece_s",
-        "t_water_hot_end_piece_e"
-      ]
+      "fg": [ "t_water_hot_end_piece_n", "t_water_hot_end_piece_e", "t_water_hot_end_piece_s", "t_water_hot_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_water_hot_unconnected",
-        "t_water_hot_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_water_hot_unconnected", "t_water_hot_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_water_pool/t_water_pool.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_water_pool/t_water_pool.json
@@ -19,21 +19,21 @@
     },
     {
       "id": "corner",
-      "fg": [ "t_water_pool_corner_nw", "t_water_pool_corner_sw", "t_water_pool_corner_se", "t_water_pool_corner_ne" ]
+      "fg": [ "t_water_pool_corner_nw", "t_water_pool_corner_ne", "t_water_pool_corner_se", "t_water_pool_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_water_pool_t_connection_n",
-        "t_water_pool_t_connection_w",
+        "t_water_pool_t_connection_e",
         "t_water_pool_t_connection_s",
-        "t_water_pool_t_connection_e"
+        "t_water_pool_t_connection_w"
       ]
     },
     { "id": "edge", "fg": [ "t_water_pool_edge_ns", "t_water_pool_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [ "t_water_pool_end_piece_n", "t_water_pool_end_piece_w", "t_water_pool_end_piece_s", "t_water_pool_end_piece_e" ]
+      "fg": [ "t_water_pool_end_piece_n", "t_water_pool_end_piece_e", "t_water_pool_end_piece_s", "t_water_pool_end_piece_w" ]
     },
     { "id": "unconnected", "fg": [ "t_water_pool_unconnected", "t_water_pool_unconnected" ] }
   ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_water_pool_shallow/t_water_pool_shallow.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_water_pool_shallow/t_water_pool_shallow.json
@@ -21,18 +21,18 @@
       "id": "corner",
       "fg": [
         "t_water_pool_shallow_corner_nw",
-        "t_water_pool_shallow_corner_sw",
+        "t_water_pool_shallow_corner_ne",
         "t_water_pool_shallow_corner_se",
-        "t_water_pool_shallow_corner_ne"
+        "t_water_pool_shallow_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_water_pool_shallow_t_connection_n",
-        "t_water_pool_shallow_t_connection_w",
+        "t_water_pool_shallow_t_connection_e",
         "t_water_pool_shallow_t_connection_s",
-        "t_water_pool_shallow_t_connection_e"
+        "t_water_pool_shallow_t_connection_w"
       ]
     },
     { "id": "edge", "fg": [ "t_water_pool_shallow_edge_ns", "t_water_pool_shallow_edge_ew" ] },
@@ -40,9 +40,9 @@
       "id": "end_piece",
       "fg": [
         "t_water_pool_shallow_end_piece_n",
-        "t_water_pool_shallow_end_piece_w",
+        "t_water_pool_shallow_end_piece_e",
         "t_water_pool_shallow_end_piece_s",
-        "t_water_pool_shallow_end_piece_e"
+        "t_water_pool_shallow_end_piece_w"
       ]
     },
     { "id": "unconnected", "fg": [ "t_water_pool_shallow_unconnected", "t_water_pool_shallow_unconnected" ] }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_water_sh/t_water_sh.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_water_sh/t_water_sh.json
@@ -18,18 +18,18 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_sw", "t_water_sh_corner_se", "t_water_sh_corner_ne" ],
+        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_ne", "t_water_sh_corner_se", "t_water_sh_corner_sw" ],
         "bg": [ "t_grass" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_w", "t_water_sh_t_connection_s", "t_water_sh_t_connection_e" ],
+        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_e", "t_water_sh_t_connection_s", "t_water_sh_t_connection_w" ],
         "bg": [ "t_grass" ]
       },
       { "id": "edge", "fg": [ "t_water_sh_edge_ns", "t_water_sh_edge_ew" ], "bg": [ "t_grass" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_w", "t_water_sh_end_piece_s", "t_water_sh_end_piece_e" ],
+        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_e", "t_water_sh_end_piece_s", "t_water_sh_end_piece_w" ],
         "bg": [ "t_grass" ]
       },
       { "id": "unconnected", "fg": [ "t_water_sh_unconnected", "t_water_sh_unconnected" ], "bg": [ "t_grass" ] }
@@ -54,18 +54,18 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_sw", "t_water_sh_corner_se", "t_water_sh_corner_ne" ],
+        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_ne", "t_water_sh_corner_se", "t_water_sh_corner_sw" ],
         "bg": [ "t_grass_winter" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_w", "t_water_sh_t_connection_s", "t_water_sh_t_connection_e" ],
+        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_e", "t_water_sh_t_connection_s", "t_water_sh_t_connection_w" ],
         "bg": [ "t_grass_winter" ]
       },
       { "id": "edge", "fg": [ "t_water_sh_edge_ns", "t_water_sh_edge_ew" ], "bg": [ "t_grass_winter" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_w", "t_water_sh_end_piece_s", "t_water_sh_end_piece_e" ],
+        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_e", "t_water_sh_end_piece_s", "t_water_sh_end_piece_w" ],
         "bg": [ "t_grass_winter" ]
       },
       {
@@ -94,21 +94,25 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_sw", "t_water_sh_corner_se", "t_water_sh_corner_ne" ],
+        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_ne", "t_water_sh_corner_se", "t_water_sh_corner_sw" ],
         "bg": [ "t_grass_summer" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_w", "t_water_sh_t_connection_s", "t_water_sh_t_connection_e" ],
+        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_e", "t_water_sh_t_connection_s", "t_water_sh_t_connection_w" ],
         "bg": [ "t_grass_summer" ]
       },
       { "id": "edge", "fg": [ "t_water_sh_edge_ns", "t_water_sh_edge_ew" ], "bg": [ "t_grass_summer" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_w", "t_water_sh_end_piece_s", "t_water_sh_end_piece_e" ],
+        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_e", "t_water_sh_end_piece_s", "t_water_sh_end_piece_w" ],
         "bg": [ "t_grass_summer" ]
       },
-      { "id": "unconnected", "fg": [ "t_water_sh_unconnected", "t_water_sh_unconnected" ], "bg": [ "t_grass_summer" ] }
+      {
+        "id": "unconnected",
+        "fg": [ "t_water_sh_unconnected", "t_water_sh_unconnected" ],
+        "bg": [ "t_grass_summer" ]
+      }
     ]
   },
   {
@@ -130,21 +134,25 @@
       },
       {
         "id": "corner",
-        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_sw", "t_water_sh_corner_se", "t_water_sh_corner_ne" ],
+        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_ne", "t_water_sh_corner_se", "t_water_sh_corner_sw" ],
         "bg": [ "t_grass_autumn" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_w", "t_water_sh_t_connection_s", "t_water_sh_t_connection_e" ],
+        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_e", "t_water_sh_t_connection_s", "t_water_sh_t_connection_w" ],
         "bg": [ "t_grass_autumn" ]
       },
       { "id": "edge", "fg": [ "t_water_sh_edge_ns", "t_water_sh_edge_ew" ], "bg": [ "t_grass_autumn" ] },
       {
         "id": "end_piece",
-        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_w", "t_water_sh_end_piece_s", "t_water_sh_end_piece_e" ],
+        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_e", "t_water_sh_end_piece_s", "t_water_sh_end_piece_w" ],
         "bg": [ "t_grass_autumn" ]
       },
-      { "id": "unconnected", "fg": [ "t_water_sh_unconnected", "t_water_sh_unconnected" ], "bg": [ "t_grass_autumn" ] }
+      {
+        "id": "unconnected",
+        "fg": [ "t_water_sh_unconnected", "t_water_sh_unconnected" ],
+        "bg": [ "t_grass_autumn" ]
+      }
     ]
   }
 ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wax/t_wax.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/terrain/t_wax/t_wax.json
@@ -3,50 +3,17 @@
   "fg": "t_wax_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wax_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_wax_corner_nw",
-        "t_wax_corner_sw",
-        "t_wax_corner_se",
-        "t_wax_corner_ne"
-      ]
-    },
+    { "id": "center", "fg": "t_wax_center" },
+    { "id": "corner", "fg": [ "t_wax_corner_nw", "t_wax_corner_ne", "t_wax_corner_se", "t_wax_corner_sw" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wax_t_connection_n",
-        "t_wax_t_connection_w",
-        "t_wax_t_connection_s",
-        "t_wax_t_connection_e"
-      ]
+      "fg": [ "t_wax_t_connection_n", "t_wax_t_connection_e", "t_wax_t_connection_s", "t_wax_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wax_edge_ns",
-        "t_wax_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wax_edge_ns", "t_wax_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wax_end_piece_n",
-        "t_wax_end_piece_w",
-        "t_wax_end_piece_s",
-        "t_wax_end_piece_e"
-      ]
+      "fg": [ "t_wax_end_piece_n", "t_wax_end_piece_e", "t_wax_end_piece_s", "t_wax_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wax_unconnected",
-        "t_wax_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wax_unconnected", "t_wax_unconnected" ] }
   ]
 }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/board.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/board.json
@@ -3,16 +3,11 @@
     "id": "vp_boat_board",
     "fg": "vp_boat_board",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "vp_boat_board_broken" ]
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": [ "vp_boat_board_broken" ] } ]
   },
   {
     "id": "vp_board_ne",
-    "fg": [ "vp_board_ne", "vp_board_ne_rotW", "vp_board_ne_rotS", "vp_board_ne_rotE" ],
+    "fg": [ "vp_board_ne", "vp_board_ne_rotE", "vp_board_ne_rotS", "vp_board_ne_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -20,13 +15,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_board_ne", "vp_board_ne_rotW", "vp_board_ne_rotS", "vp_board_ne_rotE" ]
+        "bg": [ "vp_board_ne", "vp_board_ne_rotE", "vp_board_ne_rotS", "vp_board_ne_rotW" ]
       }
     ]
   },
   {
     "id": "vp_board_nw",
-    "fg": [ "vp_board_nw", "vp_board_nw_rotW", "vp_board_nw_rotS", "vp_board_nw_rotE" ],
+    "fg": [ "vp_board_nw", "vp_board_nw_rotE", "vp_board_nw_rotS", "vp_board_nw_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -34,13 +29,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_board_nw", "vp_board_nw_rotW", "vp_board_nw_rotS", "vp_board_nw_rotE" ]
+        "bg": [ "vp_board_nw", "vp_board_nw_rotE", "vp_board_nw_rotS", "vp_board_nw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_board_se",
-    "fg": [ "vp_board_se", "vp_board_se_rotW", "vp_board_nw", "vp_board_se_rotE" ],
+    "fg": [ "vp_board_se", "vp_board_se_rotE", "vp_board_nw", "vp_board_se_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -48,13 +43,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_board_se", "vp_board_se_rotW", "vp_board_nw", "vp_board_se_rotE" ]
+        "bg": [ "vp_board_se", "vp_board_se_rotE", "vp_board_nw", "vp_board_se_rotW" ]
       }
     ]
   },
   {
     "id": "vp_board_sw",
-    "fg": [ "vp_board_sw", "vp_board_sw_rotW", "vp_board_ne", "vp_board_sw_rotE" ],
+    "fg": [ "vp_board_sw", "vp_board_sw_rotE", "vp_board_ne", "vp_board_sw_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -62,7 +57,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_board_sw", "vp_board_sw_rotW", "vp_board_ne", "vp_board_sw_rotE" ]
+        "bg": [ "vp_board_sw", "vp_board_sw_rotE", "vp_board_ne", "vp_board_sw_rotW" ]
       }
     ]
   },
@@ -70,32 +65,8 @@
     "id": "vp_board_vertical_left",
     "fg": [
       "vp_board_vertical_left",
-      "vp_board_vertical_left_rotW_right_rotE",
-      "vp_board_vertical_right",
-      "vp_board_vertical_left_rotE_right_rotW"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_board_vertical_left",
-          "vp_board_vertical_left_rotW_right_rotE",
-          "vp_board_vertical_right",
-          "vp_board_vertical_left_rotE_right_rotW"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_board_vertical_right",
-    "fg": [
-      "vp_board_vertical_right",
       "vp_board_vertical_left_rotE_right_rotW",
-      "vp_board_vertical_left",
+      "vp_board_vertical_right",
       "vp_board_vertical_left_rotW_right_rotE"
     ],
     "rotates": true,
@@ -106,10 +77,34 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_board_vertical_right",
-          "vp_board_vertical_left_rotE_right_rotW",
           "vp_board_vertical_left",
+          "vp_board_vertical_left_rotE_right_rotW",
+          "vp_board_vertical_right",
           "vp_board_vertical_left_rotW_right_rotE"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_board_vertical_right",
+    "fg": [
+      "vp_board_vertical_right",
+      "vp_board_vertical_left_rotW_right_rotE",
+      "vp_board_vertical_left",
+      "vp_board_vertical_left_rotE_right_rotW"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_board_vertical_right",
+          "vp_board_vertical_left_rotW_right_rotE",
+          "vp_board_vertical_left",
+          "vp_board_vertical_left_rotE_right_rotW"
         ]
       }
     ]
@@ -126,32 +121,8 @@
     "id": "vp_board_horizontal_front",
     "fg": [
       "vp_board_horizontal_front",
-      "vp_board_horizontal_front_rotW",
-      "vp_board_horizontal_front_rotS",
-      "vp_board_horizontal_front_rotE"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_board_horizontal_front",
-          "vp_board_horizontal_front_rotW",
-          "vp_board_horizontal_front_rotS",
-          "vp_board_horizontal_front_rotE"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_board_horizontal_rear",
-    "fg": [
-      "vp_board_horizontal_rear",
       "vp_board_horizontal_front_rotE",
-      "vp_board_horizontal_front",
+      "vp_board_horizontal_front_rotS",
       "vp_board_horizontal_front_rotW"
     ],
     "rotates": true,
@@ -162,10 +133,34 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_board_horizontal_rear",
-          "vp_board_horizontal_front_rotE",
           "vp_board_horizontal_front",
+          "vp_board_horizontal_front_rotE",
+          "vp_board_horizontal_front_rotS",
           "vp_board_horizontal_front_rotW"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_board_horizontal_rear",
+    "fg": [
+      "vp_board_horizontal_rear",
+      "vp_board_horizontal_front_rotW",
+      "vp_board_horizontal_front",
+      "vp_board_horizontal_front_rotE"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_board_horizontal_rear",
+          "vp_board_horizontal_front_rotW",
+          "vp_board_horizontal_front",
+          "vp_board_horizontal_front_rotE"
         ]
       }
     ]
@@ -180,7 +175,7 @@
   },
   {
     "id": "vp_hdboard_ne",
-    "fg": [ "vp_hdboard_ne", "vp_hdboard_ne_rotW", "vp_hdboard_ne_rotS", "vp_hdboard_ne_rotE" ],
+    "fg": [ "vp_hdboard_ne", "vp_hdboard_ne_rotE", "vp_hdboard_ne_rotS", "vp_hdboard_ne_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -188,13 +183,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hdboard_ne", "vp_hdboard_ne_rotW", "vp_hdboard_ne_rotS", "vp_hdboard_ne_rotE" ]
+        "bg": [ "vp_hdboard_ne", "vp_hdboard_ne_rotE", "vp_hdboard_ne_rotS", "vp_hdboard_ne_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdboard_nw",
-    "fg": [ "vp_hdboard_nw", "vp_hdboard_nw_rotW", "vp_hdboard_nw_rotS", "vp_hdboard_nw_rotE" ],
+    "fg": [ "vp_hdboard_nw", "vp_hdboard_nw_rotE", "vp_hdboard_nw_rotS", "vp_hdboard_nw_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -202,13 +197,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hdboard_nw", "vp_hdboard_nw_rotW", "vp_hdboard_nw_rotS", "vp_hdboard_nw_rotE" ]
+        "bg": [ "vp_hdboard_nw", "vp_hdboard_nw_rotE", "vp_hdboard_nw_rotS", "vp_hdboard_nw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdboard_se",
-    "fg": [ "vp_hdboard_se", "vp_hdboard_se_rotW", "vp_hdboard_nw", "vp_hdboard_se_rotE" ],
+    "fg": [ "vp_hdboard_se", "vp_hdboard_se_rotE", "vp_hdboard_nw", "vp_hdboard_se_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -216,13 +211,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hdboard_se", "vp_hdboard_se_rotW", "vp_hdboard_nw", "vp_hdboard_se_rotE" ]
+        "bg": [ "vp_hdboard_se", "vp_hdboard_se_rotE", "vp_hdboard_nw", "vp_hdboard_se_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdboard_sw",
-    "fg": [ "vp_hdboard_sw", "vp_hdboard_sw_rotW", "vp_hdboard_ne", "vp_hdboard_sw_rotE" ],
+    "fg": [ "vp_hdboard_sw", "vp_hdboard_sw_rotE", "vp_hdboard_ne", "vp_hdboard_sw_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -230,7 +225,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hdboard_sw", "vp_hdboard_sw_rotW", "vp_hdboard_ne", "vp_hdboard_sw_rotE" ]
+        "bg": [ "vp_hdboard_sw", "vp_hdboard_sw_rotE", "vp_hdboard_ne", "vp_hdboard_sw_rotW" ]
       }
     ]
   },
@@ -238,32 +233,8 @@
     "id": "vp_hdboard_vertical_left",
     "fg": [
       "vp_hdboard_vertical_left",
-      "vp_hdboard_vertical_rotW_rotE",
-      "vp_hdboard_vertical_right",
-      "vp_hdboard_vertical_left_rotE"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_hdboard_vertical_left",
-          "vp_hdboard_vertical_rotW_rotE",
-          "vp_hdboard_vertical_right",
-          "vp_hdboard_vertical_left_rotE"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_hdboard_vertical_right",
-    "fg": [
-      "vp_hdboard_vertical_right",
       "vp_hdboard_vertical_left_rotE",
-      "vp_hdboard_vertical_left",
+      "vp_hdboard_vertical_right",
       "vp_hdboard_vertical_rotW_rotE"
     ],
     "rotates": true,
@@ -274,10 +245,34 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_hdboard_vertical_right",
-          "vp_hdboard_vertical_left_rotE",
           "vp_hdboard_vertical_left",
+          "vp_hdboard_vertical_left_rotE",
+          "vp_hdboard_vertical_right",
           "vp_hdboard_vertical_rotW_rotE"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_hdboard_vertical_right",
+    "fg": [
+      "vp_hdboard_vertical_right",
+      "vp_hdboard_vertical_rotW_rotE",
+      "vp_hdboard_vertical_left",
+      "vp_hdboard_vertical_left_rotE"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_hdboard_vertical_right",
+          "vp_hdboard_vertical_rotW_rotE",
+          "vp_hdboard_vertical_left",
+          "vp_hdboard_vertical_left_rotE"
         ]
       }
     ]
@@ -286,9 +281,9 @@
     "id": [ "vp_hdboard_horizontal", "vp_hdboard_horizontal_2" ],
     "fg": [
       "vp_hdboard_horizontal_front",
-      "vp_hdboard_horizontal_front_rotW",
+      "vp_hdboard_horizontal_front_rotE",
       "vp_hdboard_horizontal_front_rotS",
-      "vp_hdboard_horizontal_front_rotE"
+      "vp_hdboard_horizontal_front_rotW"
     ],
     "rotates": true,
     "bg": [  ],
@@ -299,9 +294,9 @@
     "id": "vp_hdboard_horizontal_front",
     "fg": [
       "vp_hdboard_horizontal_front",
-      "vp_hdboard_horizontal_front_rotW",
+      "vp_hdboard_horizontal_front_rotE",
       "vp_hdboard_horizontal_front_rotS",
-      "vp_hdboard_horizontal_front_rotE"
+      "vp_hdboard_horizontal_front_rotW"
     ],
     "rotates": true,
     "bg": [  ],
@@ -312,9 +307,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_hdboard_horizontal_front",
-          "vp_hdboard_horizontal_front_rotW",
+          "vp_hdboard_horizontal_front_rotE",
           "vp_hdboard_horizontal_front_rotS",
-          "vp_hdboard_horizontal_front_rotE"
+          "vp_hdboard_horizontal_front_rotW"
         ]
       }
     ]
@@ -323,9 +318,9 @@
     "id": "vp_hdboard_horizontal_rear",
     "fg": [
       "vp_hdboard_horizontal_rear",
-      "vp_hdboard_horizontal_rear_rotW",
+      "vp_hdboard_horizontal_rear_rotE",
       "vp_hdhalfboard_horizontal_front",
-      "vp_hdboard_horizontal_rear_rotE"
+      "vp_hdboard_horizontal_rear_rotW"
     ],
     "rotates": true,
     "bg": [  ],
@@ -336,9 +331,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_hdboard_horizontal_rear",
-          "vp_hdboard_horizontal_rear_rotW",
+          "vp_hdboard_horizontal_rear_rotE",
           "vp_hdhalfboard_horizontal_front",
-          "vp_hdboard_horizontal_rear_rotE"
+          "vp_hdboard_horizontal_rear_rotW"
         ]
       }
     ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/cloth/vp_clothboard_se_0.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/cloth/vp_clothboard_se_0.json
@@ -9,28 +9,28 @@
   },
   {
     "id": "vp_clothboard_se_edge",
-    "fg": [ "vp_clothboard_se_edge", "vp_clothboard_se_edge_rotW", "vp_clothboard_se_edge_rotS", "vp_clothboard_se_edge_rotE" ],
+    "fg": [ "vp_clothboard_se_edge", "vp_clothboard_se_edge_rotE", "vp_clothboard_se_edge_rotS", "vp_clothboard_se_edge_rotW" ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_clothboard_se_edge", "vp_clothboard_se_edge_rotW", "vp_clothboard_se_edge_rotS", "vp_clothboard_se_edge_rotE" ]
+        "bg": [ "vp_clothboard_se_edge", "vp_clothboard_se_edge_rotE", "vp_clothboard_se_edge_rotS", "vp_clothboard_se_edge_rotW" ]
       }
     ],
     "bg": [  ]
   },
   {
     "id": "vp_clothboard_sw_edge",
-    "fg": [ "vp_clothboard_sw_edge", "vp_clothboard_sw_edge_rotW", "vp_clothboard_sw_edge_rotS", "vp_clothboard_sw_edge_rotE" ],
+    "fg": [ "vp_clothboard_sw_edge", "vp_clothboard_sw_edge_rotE", "vp_clothboard_sw_edge_rotS", "vp_clothboard_sw_edge_rotW" ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_clothboard_sw_edge", "vp_clothboard_sw_edge_rotW", "vp_clothboard_sw_edge_rotS", "vp_clothboard_sw_edge_rotE" ]
+        "bg": [ "vp_clothboard_sw_edge", "vp_clothboard_sw_edge_rotE", "vp_clothboard_sw_edge_rotS", "vp_clothboard_sw_edge_rotW" ]
       }
     ],
     "bg": [  ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/cloth/vp_clothboard_vertical_0.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/cloth/vp_clothboard_vertical_0.json
@@ -11,9 +11,9 @@
     "id": [ "vp_clothboard_vertical_left", "vp_clothboard_wheel_left" ],
     "fg": [
       "vp_clothboard_vertical_left",
-      "vp_clothboard_vertical_right_rotW",
+      "vp_clothboard_vertical_right_rotE",
       "vp_clothboard_vertical_right",
-      "vp_clothboard_vertical_left_rotE"
+      "vp_clothboard_vertical_left_rotW"
     ],
     "rotates": true,
     "multitile": true,
@@ -23,9 +23,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_clothboard_vertical_left",
-          "vp_clothboard_vertical_right_rotW",
+          "vp_clothboard_vertical_right_rotE",
           "vp_clothboard_vertical_right",
-          "vp_clothboard_vertical_left_rotE"
+          "vp_clothboard_vertical_left_rotW"
         ]
       }
     ],
@@ -35,9 +35,9 @@
     "id": [ "vp_clothboard_vertical_right", "vp_clothboard_wheel_right" ],
     "fg": [
       "vp_clothboard_vertical_right",
-      "vp_clothboard_vertical_left_rotW",
+      "vp_clothboard_vertical_left_rotE",
       "vp_clothboard_vertical_left",
-      "vp_clothboard_vertical_right_rotE"
+      "vp_clothboard_vertical_right_rotW"
     ],
     "rotates": true,
     "multitile": true,
@@ -47,9 +47,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_clothboard_vertical_right",
-          "vp_clothboard_vertical_left_rotW",
+          "vp_clothboard_vertical_left_rotE",
           "vp_clothboard_vertical_left",
-          "vp_clothboard_vertical_right_rotE"
+          "vp_clothboard_vertical_right_rotW"
         ]
       }
     ],

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/stowboards/stowboards.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/stowboards/stowboards.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "vp_stowboard_ne",
-    "fg": [ "vp_stowboard_ne", "vp_stowboard_ne_rotW", "vp_stowboard_ne_rotS", "vp_stowboard_ne_rotE" ],
+    "fg": [ "vp_stowboard_ne", "vp_stowboard_ne_rotE", "vp_stowboard_ne_rotS", "vp_stowboard_ne_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -9,13 +9,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_stowboard_ne", "vp_stowboard_ne_rotW", "vp_stowboard_ne_rotS", "vp_stowboard_ne_rotE" ]
+        "bg": [ "vp_stowboard_ne", "vp_stowboard_ne_rotE", "vp_stowboard_ne_rotS", "vp_stowboard_ne_rotW" ]
       }
     ]
   },
   {
     "id": "vp_stowboard_nw",
-    "fg": [ "vp_stowboard_nw", "vp_stowboard_nw_rotW", "vp_stowboard_nw_rotS", "vp_stowboard_nw_rotE" ],
+    "fg": [ "vp_stowboard_nw", "vp_stowboard_nw_rotE", "vp_stowboard_nw_rotS", "vp_stowboard_nw_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -23,13 +23,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_stowboard_nw", "vp_stowboard_nw_rotW", "vp_stowboard_nw_rotS", "vp_stowboard_nw_rotE" ]
+        "bg": [ "vp_stowboard_nw", "vp_stowboard_nw_rotE", "vp_stowboard_nw_rotS", "vp_stowboard_nw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_stowboard_se",
-    "fg": [ "vp_stowboard_se", "vp_stowboard_se_rotW", "vp_stowboard_nw", "vp_stowboard_se_rotE" ],
+    "fg": [ "vp_stowboard_se", "vp_stowboard_se_rotE", "vp_stowboard_nw", "vp_stowboard_se_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -37,13 +37,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_stowboard_se", "vp_stowboard_se_rotW", "vp_stowboard_nw", "vp_stowboard_se_rotE" ]
+        "bg": [ "vp_stowboard_se", "vp_stowboard_se_rotE", "vp_stowboard_nw", "vp_stowboard_se_rotW" ]
       }
     ]
   },
   {
     "id": "vp_stowboard_sw",
-    "fg": [ "vp_stowboard_sw", "vp_stowboard_sw_rotW", "vp_stowboard_ne", "vp_stowboard_sw_rotE" ],
+    "fg": [ "vp_stowboard_sw", "vp_stowboard_sw_rotE", "vp_stowboard_ne", "vp_stowboard_sw_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -51,7 +51,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_stowboard_sw", "vp_stowboard_sw_rotW", "vp_stowboard_ne", "vp_stowboard_sw_rotE" ]
+        "bg": [ "vp_stowboard_sw", "vp_stowboard_sw_rotE", "vp_stowboard_ne", "vp_stowboard_sw_rotW" ]
       }
     ]
   },
@@ -59,32 +59,8 @@
     "id": "vp_stowboard_vertical_left",
     "fg": [
       "vp_stowboard_vertical_left",
-      "vp_stowboard_vertical_left_rotW_right_rotE",
-      "vp_stowboard_vertical_right",
-      "vp_stowboard_vertical_left_rotE_right_rotW"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_stowboard_vertical_left",
-          "vp_stowboard_vertical_left_rotW_right_rotE",
-          "vp_stowboard_vertical_right",
-          "vp_stowboard_vertical_left_rotE_right_rotW"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_stowboard_vertical_right",
-    "fg": [
-      "vp_stowboard_vertical_right",
       "vp_stowboard_vertical_left_rotE_right_rotW",
-      "vp_stowboard_vertical_left",
+      "vp_stowboard_vertical_right",
       "vp_stowboard_vertical_left_rotW_right_rotE"
     ],
     "rotates": true,
@@ -95,10 +71,34 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_stowboard_vertical_right",
-          "vp_stowboard_vertical_left_rotE_right_rotW",
           "vp_stowboard_vertical_left",
+          "vp_stowboard_vertical_left_rotE_right_rotW",
+          "vp_stowboard_vertical_right",
           "vp_stowboard_vertical_left_rotW_right_rotE"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_stowboard_vertical_right",
+    "fg": [
+      "vp_stowboard_vertical_right",
+      "vp_stowboard_vertical_left_rotW_right_rotE",
+      "vp_stowboard_vertical_left",
+      "vp_stowboard_vertical_left_rotE_right_rotW"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_stowboard_vertical_right",
+          "vp_stowboard_vertical_left_rotW_right_rotE",
+          "vp_stowboard_vertical_left",
+          "vp_stowboard_vertical_left_rotE_right_rotW"
         ]
       }
     ]
@@ -115,32 +115,8 @@
     "id": "vp_stowboard_horizontal_front",
     "fg": [
       "vp_stowboard_horizontal_front",
-      "vp_stowboard_horizontal_front_rotW",
-      "vp_stowboard_horizontal_front_rotS",
-      "vp_stowboard_horizontal_front_rotE"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_stowboard_horizontal_front",
-          "vp_stowboard_horizontal_front_rotW",
-          "vp_stowboard_horizontal_front_rotS",
-          "vp_stowboard_horizontal_front_rotE"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_stowboard_horizontal_rear",
-    "fg": [
-      "vp_stowboard_horizontal_rear",
       "vp_stowboard_horizontal_front_rotE",
-      "vp_stowboard_horizontal_front",
+      "vp_stowboard_horizontal_front_rotS",
       "vp_stowboard_horizontal_front_rotW"
     ],
     "rotates": true,
@@ -151,10 +127,34 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_stowboard_horizontal_rear",
-          "vp_stowboard_horizontal_front_rotE",
           "vp_stowboard_horizontal_front",
+          "vp_stowboard_horizontal_front_rotE",
+          "vp_stowboard_horizontal_front_rotS",
           "vp_stowboard_horizontal_front_rotW"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_stowboard_horizontal_rear",
+    "fg": [
+      "vp_stowboard_horizontal_rear",
+      "vp_stowboard_horizontal_front_rotW",
+      "vp_stowboard_horizontal_front",
+      "vp_stowboard_horizontal_front_rotE"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_stowboard_horizontal_rear",
+          "vp_stowboard_horizontal_front_rotW",
+          "vp_stowboard_horizontal_front",
+          "vp_stowboard_horizontal_front_rotE"
         ]
       }
     ]
@@ -169,7 +169,7 @@
   },
   {
     "id": "vp_hdstowboard_ne",
-    "fg": [ "vp_hdstowboard_ne", "vp_hdstowboard_ne_rotW", "vp_hdstowboard_ne_rotS", "vp_hdstowboard_ne_rotE" ],
+    "fg": [ "vp_hdstowboard_ne", "vp_hdstowboard_ne_rotE", "vp_hdstowboard_ne_rotS", "vp_hdstowboard_ne_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -177,13 +177,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hdstowboard_ne", "vp_hdstowboard_ne_rotW", "vp_hdstowboard_ne_rotS", "vp_hdstowboard_ne_rotE" ]
+        "bg": [ "vp_hdstowboard_ne", "vp_hdstowboard_ne_rotE", "vp_hdstowboard_ne_rotS", "vp_hdstowboard_ne_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdstowboard_nw",
-    "fg": [ "vp_hdstowboard_nw", "vp_hdstowboard_nw_rotW", "vp_hdstowboard_nw_rotS", "vp_hdstowboard_nw_rotE" ],
+    "fg": [ "vp_hdstowboard_nw", "vp_hdstowboard_nw_rotE", "vp_hdstowboard_nw_rotS", "vp_hdstowboard_nw_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -191,13 +191,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hdstowboard_nw", "vp_hdstowboard_nw_rotW", "vp_hdstowboard_nw_rotS", "vp_hdstowboard_nw_rotE" ]
+        "bg": [ "vp_hdstowboard_nw", "vp_hdstowboard_nw_rotE", "vp_hdstowboard_nw_rotS", "vp_hdstowboard_nw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdstowboard_se",
-    "fg": [ "vp_hdstowboard_se", "vp_hdstowboard_se_rotW", "vp_hdstowboard_nw", "vp_hdstowboard_se_rotE" ],
+    "fg": [ "vp_hdstowboard_se", "vp_hdstowboard_se_rotE", "vp_hdstowboard_nw", "vp_hdstowboard_se_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -205,13 +205,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hdstowboard_se", "vp_hdstowboard_se_rotW", "vp_hdstowboard_nw", "vp_hdstowboard_se_rotE" ]
+        "bg": [ "vp_hdstowboard_se", "vp_hdstowboard_se_rotE", "vp_hdstowboard_nw", "vp_hdstowboard_se_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdstowboard_sw",
-    "fg": [ "vp_hdstowboard_sw", "vp_hdstowboard_sw_rotW", "vp_hdstowboard_ne", "vp_hdstowboard_sw_rotE" ],
+    "fg": [ "vp_hdstowboard_sw", "vp_hdstowboard_sw_rotE", "vp_hdstowboard_ne", "vp_hdstowboard_sw_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -219,7 +219,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hdstowboard_sw", "vp_hdstowboard_sw_rotW", "vp_hdstowboard_ne", "vp_hdstowboard_sw_rotE" ]
+        "bg": [ "vp_hdstowboard_sw", "vp_hdstowboard_sw_rotE", "vp_hdstowboard_ne", "vp_hdstowboard_sw_rotW" ]
       }
     ]
   },
@@ -227,32 +227,8 @@
     "id": "vp_hdstowboard_vertical_left",
     "fg": [
       "vp_hdstowboard_vertical_left",
-      "vp_hdstowboard_vertical_left_rotW_right_rotE",
-      "vp_hdstowboard_vertical_right",
-      "vp_hdstowboard_vertical_left_rotE_right_rotW"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_hdstowboard_vertical_left",
-          "vp_hdstowboard_vertical_left_rotW_right_rotE",
-          "vp_hdstowboard_vertical_right",
-          "vp_hdstowboard_vertical_left_rotE_right_rotW"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_hdstowboard_vertical_right",
-    "fg": [
-      "vp_hdstowboard_vertical_right",
       "vp_hdstowboard_vertical_left_rotE_right_rotW",
-      "vp_hdstowboard_vertical_left",
+      "vp_hdstowboard_vertical_right",
       "vp_hdstowboard_vertical_left_rotW_right_rotE"
     ],
     "rotates": true,
@@ -263,10 +239,34 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_hdstowboard_vertical_right",
-          "vp_hdstowboard_vertical_left_rotE_right_rotW",
           "vp_hdstowboard_vertical_left",
+          "vp_hdstowboard_vertical_left_rotE_right_rotW",
+          "vp_hdstowboard_vertical_right",
           "vp_hdstowboard_vertical_left_rotW_right_rotE"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_hdstowboard_vertical_right",
+    "fg": [
+      "vp_hdstowboard_vertical_right",
+      "vp_hdstowboard_vertical_left_rotW_right_rotE",
+      "vp_hdstowboard_vertical_left",
+      "vp_hdstowboard_vertical_left_rotE_right_rotW"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_hdstowboard_vertical_right",
+          "vp_hdstowboard_vertical_left_rotW_right_rotE",
+          "vp_hdstowboard_vertical_left",
+          "vp_hdstowboard_vertical_left_rotE_right_rotW"
         ]
       }
     ]
@@ -283,32 +283,8 @@
     "id": "vp_hdstowboard_horizontal_front",
     "fg": [
       "vp_hdstowboard_horizontal_front",
-      "vp_hdstowboard_horizontal_front_rotW",
-      "vp_hdstowboard_horizontal_front_rotS",
-      "vp_hdstowboard_horizontal_front_rotE"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_hdstowboard_horizontal_front",
-          "vp_hdstowboard_horizontal_front_rotW",
-          "vp_hdstowboard_horizontal_front_rotS",
-          "vp_hdstowboard_horizontal_front_rotE"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_hdstowboard_horizontal_rear",
-    "fg": [
-      "vp_hdstowboard_horizontal_rear",
       "vp_hdstowboard_horizontal_front_rotE",
-      "vp_hdstowboard_horizontal_front",
+      "vp_hdstowboard_horizontal_front_rotS",
       "vp_hdstowboard_horizontal_front_rotW"
     ],
     "rotates": true,
@@ -319,10 +295,34 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_hdstowboard_horizontal_rear",
-          "vp_hdstowboard_horizontal_front_rotE",
           "vp_hdstowboard_horizontal_front",
+          "vp_hdstowboard_horizontal_front_rotE",
+          "vp_hdstowboard_horizontal_front_rotS",
           "vp_hdstowboard_horizontal_front_rotW"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_hdstowboard_horizontal_rear",
+    "fg": [
+      "vp_hdstowboard_horizontal_rear",
+      "vp_hdstowboard_horizontal_front_rotW",
+      "vp_hdstowboard_horizontal_front",
+      "vp_hdstowboard_horizontal_front_rotE"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_hdstowboard_horizontal_rear",
+          "vp_hdstowboard_horizontal_front_rotW",
+          "vp_hdstowboard_horizontal_front",
+          "vp_hdstowboard_horizontal_front_rotE"
         ]
       }
     ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/vp_halfboard.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/vp_halfboard.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "vp_halfboard_ne",
-    "fg": [ "vp_halfboard_ne", "vp_halfboard_ne_rotW", "vp_halfboard_ne_rotS", "vp_halfboard_ne_rotE" ],
+    "fg": [ "vp_halfboard_ne", "vp_halfboard_ne_rotE", "vp_halfboard_ne_rotS", "vp_halfboard_ne_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -9,13 +9,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_halfboard_ne", "vp_halfboard_ne_rotW", "vp_halfboard_ne_rotS", "vp_halfboard_ne_rotE" ]
+        "bg": [ "vp_halfboard_ne", "vp_halfboard_ne_rotE", "vp_halfboard_ne_rotS", "vp_halfboard_ne_rotW" ]
       }
     ]
   },
   {
     "id": "vp_halfboard_nw",
-    "fg": [ "vp_halfboard_nw", "vp_halfboard_nw_rotW", "vp_halfboard_nw_rotS", "vp_halfboard_nw_rotE" ],
+    "fg": [ "vp_halfboard_nw", "vp_halfboard_nw_rotE", "vp_halfboard_nw_rotS", "vp_halfboard_nw_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -23,13 +23,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_halfboard_nw", "vp_halfboard_nw_rotW", "vp_halfboard_nw_rotS", "vp_halfboard_nw_rotE" ]
+        "bg": [ "vp_halfboard_nw", "vp_halfboard_nw_rotE", "vp_halfboard_nw_rotS", "vp_halfboard_nw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_halfboard_se",
-    "fg": [ "vp_halfboard_se", "vp_halfboard_se_rotW", "vp_halfboard_se_rotS", "vp_halfboard_se_rotE" ],
+    "fg": [ "vp_halfboard_se", "vp_halfboard_se_rotE", "vp_halfboard_se_rotS", "vp_halfboard_se_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -37,13 +37,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_halfboard_se", "vp_halfboard_se_rotW", "vp_halfboard_se_rotS", "vp_halfboard_se_rotE" ]
+        "bg": [ "vp_halfboard_se", "vp_halfboard_se_rotE", "vp_halfboard_se_rotS", "vp_halfboard_se_rotW" ]
       }
     ]
   },
   {
     "id": "vp_halfboard_sw",
-    "fg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotW", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotE" ],
+    "fg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotE", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -51,7 +51,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotW", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotE" ]
+        "bg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotE", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotW" ]
       }
     ]
   },
@@ -59,56 +59,8 @@
     "id": "vp_halfboard_vertical_left",
     "fg": [
       "vp_halfboard_vertical_left",
-      "vp_halfboard_vertical_left_rotW_right_rotE",
-      "vp_halfboard_vertical_right",
-      "vp_halfboard_vertical_left_rotE_right_rotW"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_halfboard_vertical_left",
-          "vp_halfboard_vertical_left_rotW_right_rotE",
-          "vp_halfboard_vertical_right",
-          "vp_halfboard_vertical_left_rotE_right_rotW"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_halfboard_vertical_2_left",
-    "fg": [
-      "vp_halfboard_vertical_2_left",
-      "vp_halfboard_vertical_2_left_rotW",
-      "vp_halfboard_vertical_2_right",
-      "vp_halfboard_vertical_2_left_rotE"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_halfboard_vertical_2_left",
-          "vp_halfboard_vertical_2_left_rotW",
-          "vp_halfboard_vertical_2_right",
-          "vp_halfboard_vertical_2_left_rotE"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_halfboard_vertical_right",
-    "fg": [
-      "vp_halfboard_vertical_right",
       "vp_halfboard_vertical_left_rotE_right_rotW",
-      "vp_halfboard_vertical_left",
+      "vp_halfboard_vertical_right",
       "vp_halfboard_vertical_left_rotW_right_rotE"
     ],
     "rotates": true,
@@ -119,10 +71,58 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_halfboard_vertical_right",
-          "vp_halfboard_vertical_left_rotE_right_rotW",
           "vp_halfboard_vertical_left",
+          "vp_halfboard_vertical_left_rotE_right_rotW",
+          "vp_halfboard_vertical_right",
           "vp_halfboard_vertical_left_rotW_right_rotE"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_halfboard_vertical_2_left",
+    "fg": [
+      "vp_halfboard_vertical_2_left",
+      "vp_halfboard_vertical_2_left_rotE",
+      "vp_halfboard_vertical_2_right",
+      "vp_halfboard_vertical_2_left_rotW"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_halfboard_vertical_2_left",
+          "vp_halfboard_vertical_2_left_rotE",
+          "vp_halfboard_vertical_2_right",
+          "vp_halfboard_vertical_2_left_rotW"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_halfboard_vertical_right",
+    "fg": [
+      "vp_halfboard_vertical_right",
+      "vp_halfboard_vertical_left_rotW_right_rotE",
+      "vp_halfboard_vertical_left",
+      "vp_halfboard_vertical_left_rotE_right_rotW"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_halfboard_vertical_right",
+          "vp_halfboard_vertical_left_rotW_right_rotE",
+          "vp_halfboard_vertical_left",
+          "vp_halfboard_vertical_left_rotE_right_rotW"
         ]
       }
     ]
@@ -131,9 +131,9 @@
     "id": "vp_halfboard_vertical_2_right",
     "fg": [
       "vp_halfboard_vertical_2_right",
-      "vp_halfboard_vertical_2_right_rotW",
+      "vp_halfboard_vertical_2_right_rotE",
       "vp_halfboard_vertical_2_left",
-      "vp_halfboard_vertical_2_right_rotE"
+      "vp_halfboard_vertical_2_right_rotW"
     ],
     "rotates": true,
     "bg": [  ],
@@ -144,9 +144,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_halfboard_vertical_2_right",
-          "vp_halfboard_vertical_2_right_rotW",
+          "vp_halfboard_vertical_2_right_rotE",
           "vp_halfboard_vertical_2_left",
-          "vp_halfboard_vertical_2_right_rotE"
+          "vp_halfboard_vertical_2_right_rotW"
         ]
       }
     ]
@@ -155,9 +155,9 @@
     "id": "vp_halfboard_vertical_t_left",
     "fg": [
       "vp_halfboard_vertical_t_left_rotN",
-      "vp_halfboard_vertical_t_left_rotW",
+      "vp_halfboard_vertical_t_left_rotE",
       "vp_halfboard_vertical_t_left_rotS",
-      "vp_halfboard_vertical_t_left_rotE"
+      "vp_halfboard_vertical_t_left_rotW"
     ],
     "rotates": true,
     "bg": [  ],
@@ -168,9 +168,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_halfboard_vertical_t_left_rotN",
-          "vp_halfboard_vertical_t_left_rotW",
+          "vp_halfboard_vertical_t_left_rotE",
           "vp_halfboard_vertical_t_left_rotS",
-          "vp_halfboard_vertical_t_left_rotE"
+          "vp_halfboard_vertical_t_left_rotW"
         ]
       }
     ]
@@ -179,9 +179,9 @@
     "id": "vp_halfboard_vertical_t_right",
     "fg": [
       "vp_halfboard_vertical_t_right_rotN",
-      "vp_halfboard_vertical_t_right_rotW",
+      "vp_halfboard_vertical_t_right_rotE",
       "vp_halfboard_vertical_t_right_rotS",
-      "vp_halfboard_vertical_t_right_rotE"
+      "vp_halfboard_vertical_t_right_rotW"
     ],
     "rotates": true,
     "bg": [  ],
@@ -192,9 +192,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_halfboard_vertical_t_right_rotN",
-          "vp_halfboard_vertical_t_right_rotW",
+          "vp_halfboard_vertical_t_right_rotE",
           "vp_halfboard_vertical_t_right_rotS",
-          "vp_halfboard_vertical_t_right_rotE"
+          "vp_halfboard_vertical_t_right_rotW"
         ]
       }
     ]
@@ -211,9 +211,9 @@
     "id": "vp_halfboard_horizontal_front",
     "fg": [
       "vp_halfboard_horizontal_front",
-      "vp_halfboard_horizontal_front_rotW",
+      "vp_halfboard_horizontal_front_rotE",
       "vp_halfboard_horizontal_front_rotS",
-      "vp_halfboard_horizontal_front_rotE"
+      "vp_halfboard_horizontal_front_rotW"
     ],
     "rotates": true,
     "bg": [  ],
@@ -224,9 +224,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_halfboard_horizontal_front",
-          "vp_halfboard_horizontal_front_rotW",
+          "vp_halfboard_horizontal_front_rotE",
           "vp_halfboard_horizontal_front_rotS",
-          "vp_halfboard_horizontal_front_rotE"
+          "vp_halfboard_horizontal_front_rotW"
         ]
       }
     ]
@@ -235,9 +235,9 @@
     "id": "vp_halfboard_horizontal_2_front",
     "fg": [
       "vp_halfboard_horizontal_2_front",
-      "vp_halfboard_horizontal_2_front_rotW",
+      "vp_halfboard_horizontal_2_front_rotE",
       "vp_halfboard_horizontal_2_front_rotS",
-      "vp_halfboard_horizontal_2_front_rotE"
+      "vp_halfboard_horizontal_2_front_rotW"
     ],
     "rotates": true,
     "bg": [  ],
@@ -248,9 +248,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_halfboard_horizontal_2_front",
-          "vp_halfboard_horizontal_2_front_rotW",
+          "vp_halfboard_horizontal_2_front_rotE",
           "vp_halfboard_horizontal_2_front_rotS",
-          "vp_halfboard_horizontal_2_front_rotE"
+          "vp_halfboard_horizontal_2_front_rotW"
         ]
       }
     ]
@@ -259,9 +259,9 @@
     "id": "vp_halfboard_horizontal_rear",
     "fg": [
       "vp_halfboard_horizontal_rear",
-      "vp_halfboard_horizontal_rear_rotW",
+      "vp_halfboard_horizontal_rear_rotE",
       "vp_halfboard_horizontal_rear_rotS",
-      "vp_halfboard_horizontal_rear_rotE"
+      "vp_halfboard_horizontal_rear_rotW"
     ],
     "rotates": true,
     "bg": [  ],
@@ -272,9 +272,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_halfboard_horizontal_rear",
-          "vp_halfboard_horizontal_rear_rotW",
+          "vp_halfboard_horizontal_rear_rotE",
           "vp_halfboard_horizontal_rear_rotS",
-          "vp_halfboard_horizontal_rear_rotE"
+          "vp_halfboard_horizontal_rear_rotW"
         ]
       }
     ]
@@ -283,9 +283,9 @@
     "id": "vp_halfboard_horizontal_2_rear",
     "fg": [
       "vp_halfboard_horizontal_2_rear",
-      "vp_halfboard_horizontal_2_rear_rotW",
+      "vp_halfboard_horizontal_2_rear_rotE",
       "vp_halfboard_horizontal_2_rear_rotS",
-      "vp_halfboard_horizontal_2_rear_rotE"
+      "vp_halfboard_horizontal_2_rear_rotW"
     ],
     "rotates": true,
     "bg": [  ],
@@ -296,9 +296,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_halfboard_horizontal_2_rear",
-          "vp_halfboard_horizontal_2_rear_rotW",
+          "vp_halfboard_horizontal_2_rear_rotE",
           "vp_halfboard_horizontal_2_rear_rotS",
-          "vp_halfboard_horizontal_2_rear_rotE"
+          "vp_halfboard_horizontal_2_rear_rotW"
         ]
       }
     ]
@@ -313,7 +313,7 @@
   },
   {
     "id": "vp_halfboard_cover",
-    "fg": [ "vp_halfboard_cover", "vp_halfboard_cover_rotW", "vp_halfboard_cover_rotS", "vp_halfboard_cover_rotE" ],
+    "fg": [ "vp_halfboard_cover", "vp_halfboard_cover_rotE", "vp_halfboard_cover_rotS", "vp_halfboard_cover_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -321,7 +321,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_halfboard_cover", "vp_halfboard_cover_rotW", "vp_halfboard_cover_rotS", "vp_halfboard_cover_rotE" ]
+        "bg": [ "vp_halfboard_cover", "vp_halfboard_cover_rotE", "vp_halfboard_cover_rotS", "vp_halfboard_cover_rotW" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/vp_hdhalfboard.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/vp_hdhalfboard.json
@@ -1,7 +1,7 @@
 [
   {
-    "id": ["vp_hdhalfboard_ne", "vp_counterweight_ne"],
-    "fg": [ "vp_hdhalfboard_ne", "vp_hdhalfboard_ne_rotW", "vp_hdhalfboard_ne_rotS", "vp_hdhalfboard_ne_rotE" ],
+    "id": [ "vp_hdhalfboard_ne", "vp_counterweight_ne" ],
+    "fg": [ "vp_hdhalfboard_ne", "vp_hdhalfboard_ne_rotE", "vp_hdhalfboard_ne_rotS", "vp_hdhalfboard_ne_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -9,13 +9,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hdhalfboard_ne", "vp_hdhalfboard_ne_rotW", "vp_hdhalfboard_ne_rotS", "vp_hdhalfboard_ne_rotE" ]
+        "bg": [ "vp_hdhalfboard_ne", "vp_hdhalfboard_ne_rotE", "vp_hdhalfboard_ne_rotS", "vp_hdhalfboard_ne_rotW" ]
       }
     ]
   },
   {
-    "id": ["vp_hdhalfboard_nw", "vp_counterweight_nw"],
-    "fg": [ "vp_hdhalfboard_nw", "vp_hdhalfboard_nw_rotW", "vp_hdhalfboard_nw_rotS", "vp_hdhalfboard_nw_rotE" ],
+    "id": [ "vp_hdhalfboard_nw", "vp_counterweight_nw" ],
+    "fg": [ "vp_hdhalfboard_nw", "vp_hdhalfboard_nw_rotE", "vp_hdhalfboard_nw_rotS", "vp_hdhalfboard_nw_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -23,13 +23,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hdhalfboard_nw", "vp_hdhalfboard_nw_rotW", "vp_hdhalfboard_nw_rotS", "vp_hdhalfboard_nw_rotE" ]
+        "bg": [ "vp_hdhalfboard_nw", "vp_hdhalfboard_nw_rotE", "vp_hdhalfboard_nw_rotS", "vp_hdhalfboard_nw_rotW" ]
       }
     ]
   },
   {
-    "id": ["vp_hdhalfboard_se", "vp_counterweight_se"],
-    "fg": [ "vp_hdhalfboard_se", "vp_hdhalfboard_se_rotW", "vp_hdhalfboard_se_rotS", "vp_hdhalfboard_se_rotE" ],
+    "id": [ "vp_hdhalfboard_se", "vp_counterweight_se" ],
+    "fg": [ "vp_hdhalfboard_se", "vp_hdhalfboard_se_rotE", "vp_hdhalfboard_se_rotS", "vp_hdhalfboard_se_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -37,13 +37,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hdhalfboard_se", "vp_hdhalfboard_se_rotW", "vp_hdhalfboard_se_rotS", "vp_hdhalfboard_se_rotE" ]
+        "bg": [ "vp_hdhalfboard_se", "vp_hdhalfboard_se_rotE", "vp_hdhalfboard_se_rotS", "vp_hdhalfboard_se_rotW" ]
       }
     ]
   },
   {
-    "id": ["vp_hdhalfboard_sw", "vp_counterweight_sw"],
-    "fg": [ "vp_hdhalfboard_sw", "vp_hdhalfboard_sw_rotW", "vp_hdhalfboard_sw_rotS", "vp_hdhalfboard_sw_rotE" ],
+    "id": [ "vp_hdhalfboard_sw", "vp_counterweight_sw" ],
+    "fg": [ "vp_hdhalfboard_sw", "vp_hdhalfboard_sw_rotE", "vp_hdhalfboard_sw_rotS", "vp_hdhalfboard_sw_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -51,12 +51,12 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hdhalfboard_sw", "vp_hdhalfboard_sw_rotW", "vp_hdhalfboard_sw_rotS", "vp_hdhalfboard_sw_rotE" ]
+        "bg": [ "vp_hdhalfboard_sw", "vp_hdhalfboard_sw_rotE", "vp_hdhalfboard_sw_rotS", "vp_hdhalfboard_sw_rotW" ]
       }
     ]
   },
   {
-    "id": ["vp_hdhalfboard_vertical_left", "vp_counterweight_vertical_left"],
+    "id": [ "vp_hdhalfboard_vertical_left", "vp_counterweight_vertical_left" ],
     "fg": [ "vp_hdhalfboard_vertical_left" ],
     "//": [
       "vp_hdhalfboard_vertical_left_rotW_right_rotE",
@@ -69,7 +69,7 @@
     "additional_tiles": [ { "id": "broken", "fg": [ "3987_vp_cargo_space_2" ], "bg": [ "vp_hdhalfboard_vertical_left" ] } ]
   },
   {
-    "id": ["vp_hdhalfboard_vertical_right", "vp_counterweight_vertical_right"],
+    "id": [ "vp_hdhalfboard_vertical_right", "vp_counterweight_vertical_right" ],
     "fg": [ "vp_hdhalfboard_vertical_right" ],
     "//": [
       "vp_hdhalfboard_vertical_left_rotE_right_rotW",
@@ -85,56 +85,8 @@
     "id": [ "vp_hdhalfboard_horizontal" ],
     "fg": [
       "vp_hdhalfboard_horizontal_front",
-      "vp_hdhalfboard_horizontal_front_rotW",
-      "vp_hdhalfboard_horizontal_front_rotS",
-      "vp_hdhalfboard_horizontal_front_rotE"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_hdhalfboard_horizontal_front",
-          "vp_hdhalfboard_horizontal_front_rotW",
-          "vp_hdhalfboard_horizontal_front_rotS",
-          "vp_hdhalfboard_horizontal_front_rotE"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_hdhalfboard_horizontal_front",
-    "fg": [
-      "vp_hdhalfboard_horizontal_front",
-      "vp_hdhalfboard_horizontal_front_rotW",
-      "vp_hdhalfboard_horizontal_front_rotS",
-      "vp_hdhalfboard_horizontal_front_rotE"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_hdhalfboard_horizontal_front",
-          "vp_hdhalfboard_horizontal_front_rotW",
-          "vp_hdhalfboard_horizontal_front_rotS",
-          "vp_hdhalfboard_horizontal_front_rotE"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_hdhalfboard_horizontal_rear",
-    "fg": [
-      "vp_hdhalfboard_horizontal_rear",
       "vp_hdhalfboard_horizontal_front_rotE",
-      "vp_hdhalfboard_horizontal_front",
+      "vp_hdhalfboard_horizontal_front_rotS",
       "vp_hdhalfboard_horizontal_front_rotW"
     ],
     "rotates": true,
@@ -145,10 +97,58 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_hdhalfboard_horizontal_rear",
-          "vp_hdhalfboard_horizontal_front_rotE",
           "vp_hdhalfboard_horizontal_front",
+          "vp_hdhalfboard_horizontal_front_rotE",
+          "vp_hdhalfboard_horizontal_front_rotS",
           "vp_hdhalfboard_horizontal_front_rotW"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_hdhalfboard_horizontal_front",
+    "fg": [
+      "vp_hdhalfboard_horizontal_front",
+      "vp_hdhalfboard_horizontal_front_rotE",
+      "vp_hdhalfboard_horizontal_front_rotS",
+      "vp_hdhalfboard_horizontal_front_rotW"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_hdhalfboard_horizontal_front",
+          "vp_hdhalfboard_horizontal_front_rotE",
+          "vp_hdhalfboard_horizontal_front_rotS",
+          "vp_hdhalfboard_horizontal_front_rotW"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_hdhalfboard_horizontal_rear",
+    "fg": [
+      "vp_hdhalfboard_horizontal_rear",
+      "vp_hdhalfboard_horizontal_front_rotW",
+      "vp_hdhalfboard_horizontal_front",
+      "vp_hdhalfboard_horizontal_front_rotE"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_hdhalfboard_horizontal_rear",
+          "vp_hdhalfboard_horizontal_front_rotW",
+          "vp_hdhalfboard_horizontal_front",
+          "vp_hdhalfboard_horizontal_front_rotE"
         ]
       }
     ]
@@ -163,7 +163,7 @@
   },
   {
     "id": "vp_hdhalfboard_cover",
-    "fg": [ "vp_hdhalfboard_cover", "vp_hdhalfboard_cover_rotW", "vp_hdhalfboard_cover_rotS", "vp_hdhalfboard_cover_rotE" ],
+    "fg": [ "vp_hdhalfboard_cover", "vp_hdhalfboard_cover_rotE", "vp_hdhalfboard_cover_rotS", "vp_hdhalfboard_cover_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -171,7 +171,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hdhalfboard_cover", "vp_hdhalfboard_cover_rotW", "vp_hdhalfboard_cover_rotS", "vp_hdhalfboard_cover_rotE" ]
+        "bg": [ "vp_hdhalfboard_cover", "vp_hdhalfboard_cover_rotE", "vp_hdhalfboard_cover_rotS", "vp_hdhalfboard_cover_rotW" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/vp_xlhalfboard.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/vp_xlhalfboard.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "vp_xlhalfboard_ne",
-    "fg": [ "vp_xlhalfboard_ne", "vp_xlhalfboard_ne_rotW", "vp_xlhalfboard_ne_rotS", "vp_xlhalfboard_ne_rotE" ],
+    "fg": [ "vp_xlhalfboard_ne", "vp_xlhalfboard_ne_rotE", "vp_xlhalfboard_ne_rotS", "vp_xlhalfboard_ne_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -9,13 +9,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_xlhalfboard_ne", "vp_xlhalfboard_ne_rotW", "vp_xlhalfboard_ne_rotS", "vp_xlhalfboard_ne_rotE" ]
+        "bg": [ "vp_xlhalfboard_ne", "vp_xlhalfboard_ne_rotE", "vp_xlhalfboard_ne_rotS", "vp_xlhalfboard_ne_rotW" ]
       }
     ]
   },
   {
     "id": "vp_xlhalfboard_nw",
-    "fg": [ "vp_xlhalfboard_nw", "vp_xlhalfboard_nw_rotW", "vp_xlhalfboard_nw_rotS", "vp_xlhalfboard_nw_rotE" ],
+    "fg": [ "vp_xlhalfboard_nw", "vp_xlhalfboard_nw_rotE", "vp_xlhalfboard_nw_rotS", "vp_xlhalfboard_nw_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -23,7 +23,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_xlhalfboard_nw", "vp_xlhalfboard_nw_rotW", "vp_xlhalfboard_nw_rotS", "vp_xlhalfboard_nw_rotE" ]
+        "bg": [ "vp_xlhalfboard_nw", "vp_xlhalfboard_nw_rotE", "vp_xlhalfboard_nw_rotS", "vp_xlhalfboard_nw_rotW" ]
       }
     ]
   },
@@ -83,9 +83,9 @@
     "id": "vp_xlhalfboard_horizontal_front",
     "fg": [
       "vp_xlhalfboard_horizontal_front",
-      "vp_xlhalfboard_horizontal_front_rotW",
+      "vp_xlhalfboard_horizontal_front_rotE",
       "vp_xlhalfboard_horizontal_front_rotS",
-      "vp_xlhalfboard_horizontal_front_rotE"
+      "vp_xlhalfboard_horizontal_front_rotW"
     ],
     "rotates": true,
     "bg": [  ],
@@ -96,9 +96,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_xlhalfboard_horizontal_front",
-          "vp_xlhalfboard_horizontal_front_rotW",
+          "vp_xlhalfboard_horizontal_front_rotE",
           "vp_xlhalfboard_horizontal_front_rotS",
-          "vp_xlhalfboard_horizontal_front_rotE"
+          "vp_xlhalfboard_horizontal_front_rotW"
         ]
       }
     ]
@@ -121,7 +121,7 @@
   },
   {
     "id": "vp_xlhalfboard_cover",
-    "fg": [ "vp_xlhalfboard_cover", "vp_xlhalfboard_cover_rotW", "vp_xlhalfboard_cover_rotS", "vp_xlhalfboard_cover_rotE" ],
+    "fg": [ "vp_xlhalfboard_cover", "vp_xlhalfboard_cover_rotE", "vp_xlhalfboard_cover_rotS", "vp_xlhalfboard_cover_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -129,7 +129,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_xlhalfboard_cover", "vp_xlhalfboard_cover_rotW", "vp_xlhalfboard_cover_rotS", "vp_xlhalfboard_cover_rotE" ]
+        "bg": [ "vp_xlhalfboard_cover", "vp_xlhalfboard_cover_rotE", "vp_xlhalfboard_cover_rotS", "vp_xlhalfboard_cover_rotW" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/wood/board.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/boards/wood/board.json
@@ -3,80 +3,8 @@
     "id": "vp_woodboard_ne",
     "fg": [
       "vp_woodboard_ne_rotN_sw_rotS",
-      "vp_woodboard_ne_rotW_sw_rotE",
-      "vp_woodboard_sw_rotN_ne_rotS",
-      "vp_woodboard_sw_rotw_ne_rotE"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_woodboard_ne_rotN_sw_rotS",
-          "vp_woodboard_ne_rotW_sw_rotE",
-          "vp_woodboard_sw_rotN_ne_rotS",
-          "vp_woodboard_sw_rotw_ne_rotE"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_woodboard_nw",
-    "fg": [
-      "vp_woodboard_nw_rotN_se_rotS",
-      "vp_woodboard_nw_rotw_se_rotE",
-      "vp_woodboard_se_rotN_nw_rotS",
-      "vp_woodboard_se_rotW_nw_rotE"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_woodboard_nw_rotN_se_rotS",
-          "vp_woodboard_nw_rotw_se_rotE",
-          "vp_woodboard_se_rotN_nw_rotS",
-          "vp_woodboard_se_rotW_nw_rotE"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_woodboard_se",
-    "fg": [
-      "vp_woodboard_se_rotN_nw_rotS",
-      "vp_woodboard_se_rotW_nw_rotE",
-      "vp_woodboard_nw_rotN_se_rotS",
-      "vp_woodboard_nw_rotw_se_rotE"
-    ],
-    "rotates": true,
-    "bg": [  ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [
-          "vp_woodboard_se_rotN_nw_rotS",
-          "vp_woodboard_se_rotW_nw_rotE",
-          "vp_woodboard_nw_rotN_se_rotS",
-          "vp_woodboard_nw_rotw_se_rotE"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_woodboard_sw",
-    "fg": [
-      "vp_woodboard_sw_rotN_ne_rotS",
       "vp_woodboard_sw_rotw_ne_rotE",
-      "vp_woodboard_ne_rotN_sw_rotS",
+      "vp_woodboard_sw_rotN_ne_rotS",
       "vp_woodboard_ne_rotW_sw_rotE"
     ],
     "rotates": true,
@@ -87,21 +15,21 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_woodboard_sw_rotN_ne_rotS",
-          "vp_woodboard_sw_rotw_ne_rotE",
           "vp_woodboard_ne_rotN_sw_rotS",
+          "vp_woodboard_sw_rotw_ne_rotE",
+          "vp_woodboard_sw_rotN_ne_rotS",
           "vp_woodboard_ne_rotW_sw_rotE"
         ]
       }
     ]
   },
   {
-    "id": "vp_woodboard_vertical_left",
+    "id": "vp_woodboard_nw",
     "fg": [
-      "vp_woodboard_vertical_left_rotN_right_rotS",
-      "vp_woodboard_horizontal_rear_rotN_front_rotS",
-      "vp_woodboard_vertical_right_rotN_left_rotS",
-      "vp_woodboard_horizontal_front_rotN_rear_rotS"
+      "vp_woodboard_nw_rotN_se_rotS",
+      "vp_woodboard_se_rotW_nw_rotE",
+      "vp_woodboard_se_rotN_nw_rotS",
+      "vp_woodboard_nw_rotw_se_rotE"
     ],
     "rotates": true,
     "bg": [  ],
@@ -111,20 +39,68 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_woodboard_vertical_left_rotN_right_rotS",
-          "vp_woodboard_horizontal_rear_rotN_front_rotS",
-          "vp_woodboard_vertical_right_rotN_left_rotS",
-          "vp_woodboard_horizontal_front_rotN_rear_rotS"
+          "vp_woodboard_nw_rotN_se_rotS",
+          "vp_woodboard_se_rotW_nw_rotE",
+          "vp_woodboard_se_rotN_nw_rotS",
+          "vp_woodboard_nw_rotw_se_rotE"
         ]
       }
     ]
   },
   {
-    "id": "vp_woodboard_vertical_right",
+    "id": "vp_woodboard_se",
     "fg": [
-      "vp_woodboard_vertical_right_rotN_left_rotS",
-      "vp_woodboard_horizontal_front_rotN_rear_rotS",
+      "vp_woodboard_se_rotN_nw_rotS",
+      "vp_woodboard_nw_rotw_se_rotE",
+      "vp_woodboard_nw_rotN_se_rotS",
+      "vp_woodboard_se_rotW_nw_rotE"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_woodboard_se_rotN_nw_rotS",
+          "vp_woodboard_nw_rotw_se_rotE",
+          "vp_woodboard_nw_rotN_se_rotS",
+          "vp_woodboard_se_rotW_nw_rotE"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_woodboard_sw",
+    "fg": [
+      "vp_woodboard_sw_rotN_ne_rotS",
+      "vp_woodboard_ne_rotW_sw_rotE",
+      "vp_woodboard_ne_rotN_sw_rotS",
+      "vp_woodboard_sw_rotw_ne_rotE"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_woodboard_sw_rotN_ne_rotS",
+          "vp_woodboard_ne_rotW_sw_rotE",
+          "vp_woodboard_ne_rotN_sw_rotS",
+          "vp_woodboard_sw_rotw_ne_rotE"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_woodboard_vertical_left",
+    "fg": [
       "vp_woodboard_vertical_left_rotN_right_rotS",
+      "vp_woodboard_horizontal_front_rotN_rear_rotS",
+      "vp_woodboard_vertical_right_rotN_left_rotS",
       "vp_woodboard_horizontal_rear_rotN_front_rotS"
     ],
     "rotates": true,
@@ -135,21 +111,21 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_woodboard_vertical_right_rotN_left_rotS",
-          "vp_woodboard_horizontal_front_rotN_rear_rotS",
           "vp_woodboard_vertical_left_rotN_right_rotS",
+          "vp_woodboard_horizontal_front_rotN_rear_rotS",
+          "vp_woodboard_vertical_right_rotN_left_rotS",
           "vp_woodboard_horizontal_rear_rotN_front_rotS"
         ]
       }
     ]
   },
   {
-    "id": [ "vp_woodboard_horizontal", "vp_woodboard_vertical", "vp_woodboard_horizontal_front" ],
+    "id": "vp_woodboard_vertical_right",
     "fg": [
-      "vp_woodboard_horizontal_front_rotN_rear_rotS",
-      "vp_woodboard_horizontal_front_rotW_rear_rotE",
+      "vp_woodboard_vertical_right_rotN_left_rotS",
       "vp_woodboard_horizontal_rear_rotN_front_rotS",
-      "vp_woodboard_horizontal_rear_rotW_front_rotE"
+      "vp_woodboard_vertical_left_rotN_right_rotS",
+      "vp_woodboard_horizontal_front_rotN_rear_rotS"
     ],
     "rotates": true,
     "bg": [  ],
@@ -159,20 +135,20 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_woodboard_horizontal_front_rotN_rear_rotS",
-          "vp_woodboard_horizontal_front_rotW_rear_rotE",
+          "vp_woodboard_vertical_right_rotN_left_rotS",
           "vp_woodboard_horizontal_rear_rotN_front_rotS",
-          "vp_woodboard_horizontal_rear_rotW_front_rotE"
+          "vp_woodboard_vertical_left_rotN_right_rotS",
+          "vp_woodboard_horizontal_front_rotN_rear_rotS"
         ]
       }
     ]
   },
   {
-    "id": "vp_woodboard_horizontal_rear",
+    "id": [ "vp_woodboard_horizontal", "vp_woodboard_vertical", "vp_woodboard_horizontal_front" ],
     "fg": [
-      "vp_woodboard_horizontal_rear_rotN_front_rotS",
-      "vp_woodboard_horizontal_rear_rotW_front_rotE",
       "vp_woodboard_horizontal_front_rotN_rear_rotS",
+      "vp_woodboard_horizontal_rear_rotW_front_rotE",
+      "vp_woodboard_horizontal_rear_rotN_front_rotS",
       "vp_woodboard_horizontal_front_rotW_rear_rotE"
     ],
     "rotates": true,
@@ -183,10 +159,34 @@
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
-          "vp_woodboard_horizontal_rear_rotN_front_rotS",
-          "vp_woodboard_horizontal_rear_rotW_front_rotE",
           "vp_woodboard_horizontal_front_rotN_rear_rotS",
+          "vp_woodboard_horizontal_rear_rotW_front_rotE",
+          "vp_woodboard_horizontal_rear_rotN_front_rotS",
           "vp_woodboard_horizontal_front_rotW_rear_rotE"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_woodboard_horizontal_rear",
+    "fg": [
+      "vp_woodboard_horizontal_rear_rotN_front_rotS",
+      "vp_woodboard_horizontal_front_rotW_rear_rotE",
+      "vp_woodboard_horizontal_front_rotN_rear_rotS",
+      "vp_woodboard_horizontal_rear_rotW_front_rotE"
+    ],
+    "rotates": true,
+    "bg": [  ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [
+          "vp_woodboard_horizontal_rear_rotN_front_rotS",
+          "vp_woodboard_horizontal_front_rotW_rear_rotE",
+          "vp_woodboard_horizontal_front_rotN_rear_rotS",
+          "vp_woodboard_horizontal_rear_rotW_front_rotE"
         ]
       }
     ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/cargo/baskets.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/cargo/baskets.json
@@ -11,9 +11,9 @@
     "id": "vp_basketsm_bike_rear",
     "fg": [
       "vp_basketsm_bike_rear_rotN",
-      "vp_basketsm_bike_rear_rotW",
+      "vp_basketsm_bike_rear_rotE",
       "vp_basketsm_bike_rear_rotS",
-      "vp_basketsm_bike_rear_rotE"
+      "vp_basketsm_bike_rear_rotW"
     ],
     "rotates": true,
     "bg": [  ],
@@ -23,9 +23,9 @@
         "id": "broken",
         "fg": [
           "broken_vp_basketsm_bike_rear_rotN",
-          "broken_vp_basketsm_bike_rear_rotW",
+          "broken_vp_basketsm_bike_rear_rotE",
           "broken_vp_basketsm_bike_rear_rotS",
-          "broken_vp_basketsm_bike_rear_rotE"
+          "broken_vp_basketsm_bike_rear_rotW"
         ]
       }
     ]
@@ -40,7 +40,7 @@
   },
   {
     "id": "vp_basketlg_cart",
-    "fg": [ "vp_basketlg_cart_rotN", "vp_basketlg_cart_rotW", "vp_basketlg_cart_rotS", "vp_basketlg_cart_rotE" ],
+    "fg": [ "vp_basketlg_cart_rotN", "vp_basketlg_cart_rotE", "vp_basketlg_cart_rotS", "vp_basketlg_cart_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -48,7 +48,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_basketlg_cart_rotN", "vp_basketlg_cart_rotW", "vp_basketlg_cart_rotS", "vp_basketlg_cart_rotE" ]
+        "bg": [ "vp_basketlg_cart_rotN", "vp_basketlg_cart_rotE", "vp_basketlg_cart_rotS", "vp_basketlg_cart_rotW" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/cargo/trunk.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/cargo/trunk.json
@@ -17,7 +17,7 @@
   },
   {
     "id": "vp_box_wheelbarrow",
-    "fg": [ "vp_box_wheelbarrow_rotN", "vp_box_wheelbarrow_rotW", "vp_box_wheelbarrow_rotS", "vp_box_wheelbarrow_rotE" ],
+    "fg": [ "vp_box_wheelbarrow_rotN", "vp_box_wheelbarrow_rotE", "vp_box_wheelbarrow_rotS", "vp_box_wheelbarrow_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -25,7 +25,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_box_wheelbarrow_rotN", "vp_box_wheelbarrow_rotW", "vp_box_wheelbarrow_rotS", "vp_box_wheelbarrow_rotE" ]
+        "bg": [ "vp_box_wheelbarrow_rotN", "vp_box_wheelbarrow_rotE", "vp_box_wheelbarrow_rotS", "vp_box_wheelbarrow_rotW" ]
       }
     ]
   },

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/doors/vp_door.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/doors/vp_door.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "vp_door_internal" ],
-    "fg": [ "vp_door_internal_rotN", "vp_door_internal_rotW", "vp_door_internal_rotS", "vp_door_internal_rotE" ],
+    "fg": [ "vp_door_internal_rotN", "vp_door_internal_rotE", "vp_door_internal_rotS", "vp_door_internal_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
@@ -10,16 +10,16 @@
         "id": "open",
         "fg": [
           "vp_door_internal_rotN_open",
-          "vp_door_internal_rotW_open",
+          "vp_door_internal_rotE_open",
           "vp_door_internal_rotS_open",
-          "vp_door_internal_rotE_open"
+          "vp_door_internal_rotW_open"
         ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_door_internal_rotN", "vp_door_internal_rotW", "vp_door_internal_rotS", "vp_door_internal_rotE" ]
+        "bg": [ "vp_door_internal_rotN", "vp_door_internal_rotE", "vp_door_internal_rotS", "vp_door_internal_rotW" ]
       }
     ]
   },
@@ -36,26 +36,26 @@
   },
   {
     "id": [ "vp_door_front" ],
-    "fg": [ "vp_door_front", "vp_door_front_rotW", "vp_door_front_rotS", "vp_door_front_rotE" ],
+    "fg": [ "vp_door_front", "vp_door_front_rotE", "vp_door_front_rotS", "vp_door_front_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotW", "vp_door_front_open_rotS", "vp_door_front_open_rotE" ],
+        "fg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotE", "vp_door_front_open_rotS", "vp_door_front_open_rotW" ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_door_front", "vp_door_front_rotW", "vp_door_front_rotS", "vp_door_front_rotE" ]
+        "bg": [ "vp_door_front", "vp_door_front_rotE", "vp_door_front_rotS", "vp_door_front_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_door_rear" ],
-    "fg": [ "vp_door_rear_edge", "vp_door_rear_edge_rotW", "vp_door_rear_edge_rotS", "vp_door_rear_edge_rotE" ],
+    "fg": [ "vp_door_rear_edge", "vp_door_rear_edge_rotE", "vp_door_rear_edge_rotS", "vp_door_rear_edge_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
@@ -64,22 +64,22 @@
         "id": "open",
         "fg": [
           "vp_door_rear_edge_open_rotN",
-          "vp_door_rear_edge_open_rotW",
+          "vp_door_rear_edge_open_rotE",
           "vp_door_rear_edge_open_rotS",
-          "vp_door_rear_edge_open_rotE"
+          "vp_door_rear_edge_open_rotW"
         ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_door_rear_edge", "vp_door_rear_edge_rotW", "vp_door_rear_edge_rotS", "vp_door_rear_edge_rotE" ]
+        "bg": [ "vp_door_rear_edge", "vp_door_rear_edge_rotE", "vp_door_rear_edge_rotS", "vp_door_rear_edge_rotW" ]
       }
     ]
   },
   {
     "id": "vp_door_shutter",
-    "fg": [ "vp_door_shutter", "vp_door_shutter_rotW", "vp_door_shutter_rotS", "vp_door_shutter_rotE" ],
+    "fg": [ "vp_door_shutter", "vp_door_shutter_rotE", "vp_door_shutter_rotS", "vp_door_shutter_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
@@ -88,127 +88,137 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_door_shutter", "vp_door_shutter_rotW", "vp_door_shutter_rotS", "vp_door_shutter_rotE" ]
+        "bg": [ "vp_door_shutter", "vp_door_shutter_rotE", "vp_door_shutter_rotS", "vp_door_shutter_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_hatch_opaque_left", "vp_hatch_opaque_wheel_left" ],
-    "fg": [ "vp_hatch_opaque_left", "vp_hatch_opaque_left_rotE", "vp_hatch_opaque_left_rotS", "vp_hatch_opaque_left_rotW" ],
+    "fg": [ "vp_hatch_opaque_left", "vp_hatch_opaque_left_rotW", "vp_hatch_opaque_left_rotS", "vp_hatch_opaque_left_rotE" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_opaque_left_open", "vp_hatch_opaque_left_open_rotE", "vp_hatch_opaque_left_open_rotS", "vp_hatch_opaque_left_open_rotW" ],
+        "fg": [
+          "vp_hatch_opaque_left_open",
+          "vp_hatch_opaque_left_open_rotW",
+          "vp_hatch_opaque_left_open_rotS",
+          "vp_hatch_opaque_left_open_rotE"
+        ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hatch_opaque_left", "vp_hatch_opaque_left_rotE", "vp_hatch_opaque_left_rotS", "vp_hatch_opaque_left_rotW" ]
+        "bg": [ "vp_hatch_opaque_left", "vp_hatch_opaque_left_rotW", "vp_hatch_opaque_left_rotS", "vp_hatch_opaque_left_rotE" ]
       }
     ]
   },
   {
     "id": [ "vp_hatch_opaque_right", "vp_hatch_opaque_wheel_right" ],
-    "fg": [ "vp_hatch_opaque_left_rotS", "vp_hatch_opaque_left_rotW", "vp_hatch_opaque_left", "vp_hatch_opaque_left_rotE" ],
+    "fg": [ "vp_hatch_opaque_left_rotS", "vp_hatch_opaque_left_rotE", "vp_hatch_opaque_left", "vp_hatch_opaque_left_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_opaque_left_open_rotS", "vp_hatch_opaque_left_open_rotW", "vp_hatch_opaque_left_open", "vp_hatch_opaque_left_open_rotE" ],
+        "fg": [
+          "vp_hatch_opaque_left_open_rotS",
+          "vp_hatch_opaque_left_open_rotE",
+          "vp_hatch_opaque_left_open",
+          "vp_hatch_opaque_left_open_rotW"
+        ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hatch_opaque_left_rotS", "vp_hatch_opaque_left_rotW", "vp_hatch_opaque_left", "vp_hatch_opaque_left_rotE" ]
+        "bg": [ "vp_hatch_opaque_left_rotS", "vp_hatch_opaque_left_rotE", "vp_hatch_opaque_left", "vp_hatch_opaque_left_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_hddoor_trunk", "vp_hatch", "vp_hatch_opaque", "vp_hdhatch", "vp_hdhatch_opaque" ],
-    "fg": [ "vp_hddoor_trunk", "vp_hddoor_trunk_rotW", "vp_hddoor_trunk_rotS", "vp_hddoor_trunk_rotE" ],
+    "fg": [ "vp_hddoor_trunk", "vp_hddoor_trunk_rotE", "vp_hddoor_trunk_rotS", "vp_hddoor_trunk_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hddoor_trunk_open", "vp_hddoor_trunk_open_rotW", "vp_hddoor_trunk_open_rotS", "vp_hddoor_trunk_open_rotE" ],
+        "fg": [ "vp_hddoor_trunk_open", "vp_hddoor_trunk_open_rotE", "vp_hddoor_trunk_open_rotS", "vp_hddoor_trunk_open_rotW" ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hddoor_trunk", "vp_hddoor_trunk_rotW", "vp_hddoor_trunk_rotS", "vp_hddoor_trunk_rotE" ]
+        "bg": [ "vp_hddoor_trunk", "vp_hddoor_trunk_rotE", "vp_hddoor_trunk_rotS", "vp_hddoor_trunk_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_hddoor_left" ],
-    "fg": [ "vp_hddoor_L_rotN", "vp_hddoor_L_rotW", "vp_hddoor_L_rotS", "vp_hddoor_L_rotE" ],
+    "fg": [ "vp_hddoor_L_rotN", "vp_hddoor_L_rotE", "vp_hddoor_L_rotS", "vp_hddoor_L_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hddoor_left_open_rotN", "vp_hddoor_left_open_rotW", "vp_hddoor_left_open_rotS", "vp_hddoor_left_open_rotE" ],
+        "fg": [ "vp_hddoor_left_open_rotN", "vp_hddoor_left_open_rotE", "vp_hddoor_left_open_rotS", "vp_hddoor_left_open_rotW" ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hddoor_L_rotN", "vp_hddoor_L_rotW", "vp_hddoor_L_rotS", "vp_hddoor_L_rotE" ]
+        "bg": [ "vp_hddoor_L_rotN", "vp_hddoor_L_rotE", "vp_hddoor_L_rotS", "vp_hddoor_L_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_hddoor_right" ],
-    "fg": [ "vp_hddoor_R_rotN", "vp_hddoor_R_rotW", "vp_hddoor_R_rotS", "vp_hddoor_R_rotE" ],
+    "fg": [ "vp_hddoor_R_rotN", "vp_hddoor_R_rotE", "vp_hddoor_R_rotS", "vp_hddoor_R_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hddoor_right_open_rotN", "vp_hddoor_right_open_rotW", "vp_hddoor_right_open_rotS", "vp_hddoor_right_open_rotE" ],
+        "fg": [ "vp_hddoor_right_open_rotN", "vp_hddoor_right_open_rotE", "vp_hddoor_right_open_rotS", "vp_hddoor_right_open_rotW" ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hddoor_R_rotN", "vp_hddoor_R_rotW", "vp_hddoor_R_rotS", "vp_hddoor_R_rotE" ]
+        "bg": [ "vp_hddoor_R_rotN", "vp_hddoor_R_rotE", "vp_hddoor_R_rotS", "vp_hddoor_R_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_hddoor", "vp_hddoor_front" ],
-    "fg": [ "vp_hddoor_rear_rotS", "vp_hddoor_front_rotW", "vp_hddoor_front_rotS", "vp_hddoor_front_rotE" ],
+    "fg": [ "vp_hddoor_rear_rotS", "vp_hddoor_front_rotE", "vp_hddoor_front_rotS", "vp_hddoor_front_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotW", "vp_door_front_open_rotS", "vp_door_front_open_rotE" ],
+        "fg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotE", "vp_door_front_open_rotS", "vp_door_front_open_rotW" ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hddoor_rear_rotS", "vp_hddoor_front_rotW", "vp_hddoor_front_rotS", "vp_hddoor_front_rotE" ]
+        "bg": [ "vp_hddoor_rear_rotS", "vp_hddoor_front_rotE", "vp_hddoor_front_rotS", "vp_hddoor_front_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_hddoor_rear" ],
-    "fg": [ "vp_hddoor_rear_rotN", "vp_hddoor_rear_rotW", "vp_hddoor_rear_rotS", "vp_hddoor_rear_rotE" ],
+    "fg": [ "vp_hddoor_rear_rotN", "vp_hddoor_rear_rotE", "vp_hddoor_rear_rotS", "vp_hddoor_rear_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
@@ -217,22 +227,22 @@
         "id": "open",
         "fg": [
           "vp_door_rear_edge_open_rotN",
-          "vp_door_rear_edge_open_rotW",
+          "vp_door_rear_edge_open_rotE",
           "vp_door_rear_edge_open_rotS",
-          "vp_door_rear_edge_open_rotE"
+          "vp_door_rear_edge_open_rotW"
         ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_hddoor_rear_rotN", "vp_hddoor_rear_rotW", "vp_hddoor_rear_rotS", "vp_hddoor_rear_rotE" ]
+        "bg": [ "vp_hddoor_rear_rotN", "vp_hddoor_rear_rotE", "vp_hddoor_rear_rotS", "vp_hddoor_rear_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_door_opaque_left" ],
-    "fg": [ "vp_door_opaque_left_rotN", "vp_door_opaque_left_rotW", "vp_door_opaque_left_rotS", "vp_door_opaque_left_rotE" ],
+    "fg": [ "vp_door_opaque_left_rotN", "vp_door_opaque_left_rotE", "vp_door_opaque_left_rotS", "vp_door_opaque_left_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
@@ -241,22 +251,27 @@
         "id": "open",
         "fg": [
           "vp_door_opaque_left_open_rotN",
-          "vp_door_opaque_left_open_rotW",
+          "vp_door_opaque_left_open_rotE",
           "vp_door_opaque_left_open_rotS",
-          "vp_door_opaque_left_open_rotE"
+          "vp_door_opaque_left_open_rotW"
         ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_door_opaque_left_rotN", "vp_door_opaque_left_rotW", "vp_door_opaque_left_rotS", "vp_door_opaque_left_rotE" ]
+        "bg": [ "vp_door_opaque_left_rotN", "vp_door_opaque_left_rotE", "vp_door_opaque_left_rotS", "vp_door_opaque_left_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_door_opaque_full_left" ],
-    "fg": [ "vp_door_opaque_full_left", "vp_door_opaque_full_left_rotW", "vp_door_opaque_full_left_rotS", "vp_door_opaque_full_left_rotE" ],
+    "fg": [
+      "vp_door_opaque_full_left",
+      "vp_door_opaque_full_left_rotE",
+      "vp_door_opaque_full_left_rotS",
+      "vp_door_opaque_full_left_rotW"
+    ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
@@ -265,22 +280,27 @@
         "id": "open",
         "fg": [
           "vp_door_opaque_full_left_open",
-          "vp_door_opaque_full_left_open_rotW",
+          "vp_door_opaque_full_left_open_rotE",
           "vp_door_opaque_full_left_open_rotS",
-          "vp_door_opaque_full_left_open_rotE"
+          "vp_door_opaque_full_left_open_rotW"
         ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_door_opaque_full_left", "vp_door_opaque_full_left_rotW", "vp_door_opaque_full_left_rotS", "vp_door_opaque_full_left_rotE" ]
+        "bg": [
+          "vp_door_opaque_full_left",
+          "vp_door_opaque_full_left_rotE",
+          "vp_door_opaque_full_left_rotS",
+          "vp_door_opaque_full_left_rotW"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_door_opaque_right" ],
-    "fg": [ "vp_door_opaque_right_rotN", "vp_door_opaque_right_rotW", "vp_door_opaque_right_rotS", "vp_door_opaque_right_rotE" ],
+    "fg": [ "vp_door_opaque_right_rotN", "vp_door_opaque_right_rotE", "vp_door_opaque_right_rotS", "vp_door_opaque_right_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
@@ -289,22 +309,27 @@
         "id": "open",
         "fg": [
           "vp_door_opaque_right_open_rotN",
-          "vp_door_opaque_right_open_rotW",
+          "vp_door_opaque_right_open_rotE",
           "vp_door_opaque_right_open_rotS",
-          "vp_door_opaque_right_open_rotE"
+          "vp_door_opaque_right_open_rotW"
         ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_door_opaque_right_rotN", "vp_door_opaque_right_rotW", "vp_door_opaque_right_rotS", "vp_door_opaque_right_rotE" ]
+        "bg": [ "vp_door_opaque_right_rotN", "vp_door_opaque_right_rotE", "vp_door_opaque_right_rotS", "vp_door_opaque_right_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_door_opaque_full_right" ],
-    "fg": [ "vp_door_opaque_full_right", "vp_door_opaque_full_right_rotW", "vp_door_opaque_full_right_rotS", "vp_door_opaque_full_right_rotE" ],
+    "fg": [
+      "vp_door_opaque_full_right",
+      "vp_door_opaque_full_right_rotE",
+      "vp_door_opaque_full_right_rotS",
+      "vp_door_opaque_full_right_rotW"
+    ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
@@ -313,41 +338,46 @@
         "id": "open",
         "fg": [
           "vp_door_opaque_full_right_open",
-          "vp_door_opaque_full_right_open_rotW",
+          "vp_door_opaque_full_right_open_rotE",
           "vp_door_opaque_full_right_open_rotS",
-          "vp_door_opaque_full_right_open_rotE"
+          "vp_door_opaque_full_right_open_rotW"
         ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_door_opaque_full_right", "vp_door_opaque_full_right_rotW", "vp_door_opaque_full_right_rotS", "vp_door_opaque_full_right_rotE" ]
+        "bg": [
+          "vp_door_opaque_full_right",
+          "vp_door_opaque_full_right_rotE",
+          "vp_door_opaque_full_right_rotS",
+          "vp_door_opaque_full_right_rotW"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_door_opaque", "vp_door_opaque_front" ],
-    "fg": [ "vp_door_opaque_front_rotN", "vp_door_opaque_front_rotW", "vp_door_opaque_front_rotS", "vp_door_opaque_front_rotE" ],
+    "fg": [ "vp_door_opaque_front_rotN", "vp_door_opaque_front_rotE", "vp_door_opaque_front_rotS", "vp_door_opaque_front_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotW", "vp_door_front_open_rotS", "vp_door_front_open_rotE" ],
+        "fg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotE", "vp_door_front_open_rotS", "vp_door_front_open_rotW" ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_door_opaque_front_rotN", "vp_door_opaque_front_rotW", "vp_door_opaque_front_rotS", "vp_door_opaque_front_rotE" ]
+        "bg": [ "vp_door_opaque_front_rotN", "vp_door_opaque_front_rotE", "vp_door_opaque_front_rotS", "vp_door_opaque_front_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_door_opaque_rear" ],
-    "fg": [ "vp_door_opaque_rear_rotN", "vp_door_opaque_rear_rotW", "vp_door_opaque_rear_rotS", "vp_door_opaque_rear_rotE" ],
+    "fg": [ "vp_door_opaque_rear_rotN", "vp_door_opaque_rear_rotE", "vp_door_opaque_rear_rotS", "vp_door_opaque_rear_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
@@ -356,16 +386,16 @@
         "id": "open",
         "fg": [
           "vp_door_rear_edge_open_rotN",
-          "vp_door_rear_edge_open_rotW",
+          "vp_door_rear_edge_open_rotE",
           "vp_door_rear_edge_open_rotS",
-          "vp_door_rear_edge_open_rotE"
+          "vp_door_rear_edge_open_rotW"
         ],
         "bg": [  ]
       },
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_door_opaque_rear_rotN", "vp_door_opaque_rear_rotW", "vp_door_opaque_rear_rotS", "vp_door_opaque_rear_rotE" ]
+        "bg": [ "vp_door_opaque_rear_rotN", "vp_door_opaque_rear_rotE", "vp_door_opaque_rear_rotS", "vp_door_opaque_rear_rotW" ]
       }
     ]
   },
@@ -373,9 +403,9 @@
     "id": [ "vp_hddoor_opaque_left" ],
     "fg": [
       "vp_hddoor_opaque_left_rotN",
-      "vp_hddoor_opaque_left_rotW",
+      "vp_hddoor_opaque_left_rotE",
       "vp_hddoor_opaque_left_rotS",
-      "vp_hddoor_opaque_left_rotE"
+      "vp_hddoor_opaque_left_rotW"
     ],
     "bg": [  ],
     "rotates": true,
@@ -385,9 +415,9 @@
         "id": "open",
         "fg": [
           "vp_hddoor_opaque_left_open_rotN",
-          "vp_hddoor_opaque_left_open_rotW",
+          "vp_hddoor_opaque_left_open_rotE",
           "vp_hddoor_opaque_left_open_rotS",
-          "vp_hddoor_opaque_left_open_rotE"
+          "vp_hddoor_opaque_left_open_rotW"
         ],
         "bg": [  ]
       },
@@ -396,9 +426,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_hddoor_opaque_left_rotN",
-          "vp_hddoor_opaque_left_rotW",
+          "vp_hddoor_opaque_left_rotE",
           "vp_hddoor_opaque_left_rotS",
-          "vp_hddoor_opaque_left_rotE"
+          "vp_hddoor_opaque_left_rotW"
         ]
       }
     ]
@@ -407,9 +437,9 @@
     "id": [ "vp_hddoor_opaque_right" ],
     "fg": [
       "vp_hddoor_opaque_right_rotN",
-      "vp_hddoor_opaque_right_rotW",
+      "vp_hddoor_opaque_right_rotE",
       "vp_hddoor_opaque_right_rotS",
-      "vp_hddoor_opaque_right_rotE"
+      "vp_hddoor_opaque_right_rotW"
     ],
     "bg": [  ],
     "rotates": true,
@@ -419,9 +449,9 @@
         "id": "open",
         "fg": [
           "vp_hddoor_opaque_right_open_rotN",
-          "vp_hddoor_opaque_right_open_rotW",
+          "vp_hddoor_opaque_right_open_rotE",
           "vp_hddoor_opaque_right_open_rotS",
-          "vp_hddoor_opaque_right_open_rotE"
+          "vp_hddoor_opaque_right_open_rotW"
         ],
         "bg": [  ]
       },
@@ -430,9 +460,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_hddoor_opaque_right_rotN",
-          "vp_hddoor_opaque_right_rotW",
+          "vp_hddoor_opaque_right_rotE",
           "vp_hddoor_opaque_right_rotS",
-          "vp_hddoor_opaque_right_rotE"
+          "vp_hddoor_opaque_right_rotW"
         ]
       }
     ]
@@ -441,9 +471,9 @@
     "id": [ "vp_hddoor_opaque", "vp_hddoor_opaque_front" ],
     "fg": [
       "vp_hddoor_opaque_rear_rotS",
-      "vp_hddoor_opaque_front_rotW",
+      "vp_hddoor_opaque_front_rotE",
       "vp_hddoor_opaque_front_rotS",
-      "vp_hddoor_opaque_front_rotE"
+      "vp_hddoor_opaque_front_rotW"
     ],
     "bg": [  ],
     "rotates": true,
@@ -451,7 +481,7 @@
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotW", "vp_door_front_open_rotS", "vp_door_front_open_rotE" ],
+        "fg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotE", "vp_door_front_open_rotS", "vp_door_front_open_rotW" ],
         "bg": [  ]
       },
       {
@@ -459,9 +489,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_hddoor_opaque_rear_rotS",
-          "vp_hddoor_opaque_front_rotW",
+          "vp_hddoor_opaque_front_rotE",
           "vp_hddoor_opaque_front_rotS",
-          "vp_hddoor_opaque_front_rotE"
+          "vp_hddoor_opaque_front_rotW"
         ]
       }
     ]
@@ -470,9 +500,9 @@
     "id": [ "vp_hddoor_opaque_rear" ],
     "fg": [
       "vp_hddoor_opaque_rear_rotN",
-      "vp_hddoor_opaque_rear_rotW",
+      "vp_hddoor_opaque_rear_rotE",
       "vp_hddoor_opaque_rear_rotS",
-      "vp_hddoor_opaque_rear_rotE"
+      "vp_hddoor_opaque_rear_rotW"
     ],
     "bg": [  ],
     "rotates": true,
@@ -482,9 +512,9 @@
         "id": "open",
         "fg": [
           "vp_door_rear_edge_open_rotN",
-          "vp_door_rear_edge_open_rotW",
+          "vp_door_rear_edge_open_rotE",
           "vp_door_rear_edge_open_rotS",
-          "vp_door_rear_edge_open_rotE"
+          "vp_door_rear_edge_open_rotW"
         ],
         "bg": [  ]
       },
@@ -493,9 +523,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_hddoor_opaque_rear_rotN",
-          "vp_hddoor_opaque_rear_rotW",
+          "vp_hddoor_opaque_rear_rotE",
           "vp_hddoor_opaque_rear_rotS",
-          "vp_hddoor_opaque_rear_rotE"
+          "vp_hddoor_opaque_rear_rotW"
         ]
       }
     ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/frames/frame_wood_deck/vp_frame_wood_deck.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/frames/frame_wood_deck/vp_frame_wood_deck.json
@@ -1,16 +1,15 @@
 [
   {
     "id": [ "vp_frame_wood_deck_cover", "vp_wheel_skateboard" ],
-    "fg": [ "vp_frame_wood_deck_north", "vp_frame_wood_deck_west", "vp_frame_wood_deck_south", "vp_frame_wood_deck_east" ],
+    "fg": [ "vp_frame_wood_deck_north", "vp_frame_wood_deck_east", "vp_frame_wood_deck_south", "vp_frame_wood_deck_west" ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_frame_wood_deck_north", "vp_frame_wood_deck_west", "vp_frame_wood_deck_south", "vp_frame_wood_deck_east" ]
+        "bg": [ "vp_frame_wood_deck_north", "vp_frame_wood_deck_east", "vp_frame_wood_deck_south", "vp_frame_wood_deck_west" ]
       }
     ]
   }
 ]
-

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/motorcycle/motorcycle_saddle.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/motorcycle/motorcycle_saddle.json
@@ -1,13 +1,13 @@
 [
   {
     "id": "vp_saddle_motor",
-    "fg": [ "saddle_motor_rotN", "saddle_motor_rotW", "saddle_motor_rotS", "saddle_motor_rotE" ],
+    "fg": [ "saddle_motor_rotN", "saddle_motor_rotE", "saddle_motor_rotS", "saddle_motor_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
-        "bg": [ "saddle_motor_rotN", "saddle_motor_rotW", "saddle_motor_rotS", "saddle_motor_rotE" ]
+        "bg": [ "saddle_motor_rotN", "saddle_motor_rotE", "saddle_motor_rotS", "saddle_motor_rotW" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/motorcycle/motorcycle_wheels.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/motorcycle/motorcycle_wheels.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "vp_wheel_motorbike", "vp_wheel_motorbike_steerable", "vp_wheel_motorbike_or", "vp_wheel_motorbike_or_steerable" ],
-    "fg": [ "vp_wheel_motor_rotN", "vp_wheel_motor_rotW", "vp_wheel_motor_rotS", "vp_wheel_motor_rotE" ],
+    "fg": [ "vp_wheel_motor_rotN", "vp_wheel_motor_rotE", "vp_wheel_motor_rotS", "vp_wheel_motor_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
-        "bg": [ "vp_wheel_motor_rotN", "vp_wheel_motor_rotW", "vp_wheel_motor_rotS", "vp_wheel_motor_rotE" ]
+        "bg": [ "vp_wheel_motor_rotN", "vp_wheel_motor_rotE", "vp_wheel_motor_rotS", "vp_wheel_motor_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_wheel_motorbike_rear", "vp_wheel_motorbike_or_rear" ],
-    "fg": [ "vp_wheel_motor_rear_rotN", "vp_wheel_motor_rear_rotW", "vp_wheel_motor_rear_rotS", "vp_wheel_motor_rear_rotE" ],
+    "fg": [ "vp_wheel_motor_rear_rotN", "vp_wheel_motor_rear_rotE", "vp_wheel_motor_rear_rotS", "vp_wheel_motor_rear_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
-        "bg": [ "vp_wheel_motor_rear_rotN", "vp_wheel_motor_rear_rotW", "vp_wheel_motor_rear_rotS", "vp_wheel_motor_rear_rotE" ]
+        "bg": [ "vp_wheel_motor_rear_rotN", "vp_wheel_motor_rear_rotE", "vp_wheel_motor_rear_rotS", "vp_wheel_motor_rear_rotW" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/msx_tempfix.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/msx_tempfix.json
@@ -3,9 +3,9 @@
     "id": [ "vp_halfboard_cover_right", "vp_halfboard_cover_left" ],
     "fg": [
       "vp_halfboard_horizontal_front",
-      "vp_halfboard_horizontal_front_rotW",
+      "vp_halfboard_horizontal_front_rotE",
       "vp_halfboard_horizontal_front_rotS",
-      "vp_halfboard_horizontal_front_rotE"
+      "vp_halfboard_horizontal_front_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -13,35 +13,35 @@
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
         "bg": [
-      "vp_halfboard_horizontal_front",
-      "vp_halfboard_horizontal_front_rotW",
-      "vp_halfboard_horizontal_front_rotS",
-      "vp_halfboard_horizontal_front_rotE"
-    ]
+          "vp_halfboard_horizontal_front",
+          "vp_halfboard_horizontal_front_rotE",
+          "vp_halfboard_horizontal_front_rotS",
+          "vp_halfboard_horizontal_front_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_halfboard_hatch_wheel_left",
-    "fg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotW", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotE" ],
+    "fg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotE", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
-        "bg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotW", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotE" ]
+        "bg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotE", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_halfboard_hatch_wheel_right",
-    "fg": [ "vp_halfboard_se", "vp_halfboard_se_rotW", "vp_halfboard_se_rotS", "vp_halfboard_se_rotE" ],
+    "fg": [ "vp_halfboard_se", "vp_halfboard_se_rotE", "vp_halfboard_se_rotS", "vp_halfboard_se_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
-        "bg": [ "vp_halfboard_se", "vp_halfboard_se_rotW", "vp_halfboard_se_rotS", "vp_halfboard_se_rotE" ]
+        "bg": [ "vp_halfboard_se", "vp_halfboard_se_rotE", "vp_halfboard_se_rotS", "vp_halfboard_se_rotW" ]
       }
     ]
   },
@@ -49,9 +49,9 @@
     "id": "vp_halfboard_wheel_left",
     "fg": [
       "vp_halfboard_vertical_left",
-      "vp_halfboard_vertical_left_rotW_right_rotE",
+      "vp_halfboard_vertical_left_rotE_right_rotW",
       "vp_halfboard_vertical_right",
-      "vp_halfboard_vertical_left_rotE_right_rotW"
+      "vp_halfboard_vertical_left_rotW_right_rotE"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -59,11 +59,11 @@
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
         "bg": [
-      "vp_halfboard_vertical_left",
-      "vp_halfboard_vertical_left_rotW_right_rotE",
-      "vp_halfboard_vertical_right",
-      "vp_halfboard_vertical_left_rotE_right_rotW"
-    ]
+          "vp_halfboard_vertical_left",
+          "vp_halfboard_vertical_left_rotE_right_rotW",
+          "vp_halfboard_vertical_right",
+          "vp_halfboard_vertical_left_rotW_right_rotE"
+        ]
       }
     ]
   },
@@ -71,9 +71,9 @@
     "id": "vp_halfboard_wheel_right",
     "fg": [
       "vp_halfboard_vertical_right",
-      "vp_halfboard_vertical_left_rotE_right_rotW",
+      "vp_halfboard_vertical_left_rotW_right_rotE",
       "vp_halfboard_vertical_left",
-      "vp_halfboard_vertical_left_rotW_right_rotE"
+      "vp_halfboard_vertical_left_rotE_right_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -81,136 +81,170 @@
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
         "bg": [
-      "vp_halfboard_vertical_right",
-      "vp_halfboard_vertical_left_rotE_right_rotW",
-      "vp_halfboard_vertical_left",
-      "vp_halfboard_vertical_left_rotW_right_rotE"
-    ]
+          "vp_halfboard_vertical_right",
+          "vp_halfboard_vertical_left_rotW_right_rotE",
+          "vp_halfboard_vertical_left",
+          "vp_halfboard_vertical_left_rotE_right_rotW"
+        ]
       }
     ]
   },
   {
-    "id": [ "vp_board_wheel_left", "vp_board_nw_edge" ], 
-    "fg": [ "vp_board_vertical_left", "vp_board_vertical_left_rotW_right_rotE", "vp_board_vertical_right", "vp_board_vertical_left_rotE_right_rotW" ],
+    "id": [ "vp_board_wheel_left", "vp_board_nw_edge" ],
+    "fg": [
+      "vp_board_vertical_left",
+      "vp_board_vertical_left_rotE_right_rotW",
+      "vp_board_vertical_right",
+      "vp_board_vertical_left_rotW_right_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
-        "bg": [ "vp_board_vertical_left", "vp_board_vertical_left_rotW_right_rotE", "vp_board_vertical_right", "vp_board_vertical_left_rotE_right_rotW" ]
+        "bg": [
+          "vp_board_vertical_left",
+          "vp_board_vertical_left_rotE_right_rotW",
+          "vp_board_vertical_right",
+          "vp_board_vertical_left_rotW_right_rotE"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_board_wheel_right", "vp_board_ne_edge" ],
-    "fg": [ "vp_board_vertical_right", "vp_board_vertical_left_rotE_right_rotW", "vp_board_vertical_left", "vp_board_vertical_left_rotW_right_rotE" ],
+    "fg": [
+      "vp_board_vertical_right",
+      "vp_board_vertical_left_rotW_right_rotE",
+      "vp_board_vertical_left",
+      "vp_board_vertical_left_rotE_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
-        "bg": [ "vp_board_vertical_right", "vp_board_vertical_left_rotE_right_rotW", "vp_board_vertical_left", "vp_board_vertical_left_rotW_right_rotE" ]
+        "bg": [
+          "vp_board_vertical_right",
+          "vp_board_vertical_left_rotW_right_rotE",
+          "vp_board_vertical_left",
+          "vp_board_vertical_left_rotE_right_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_stowboard_wheel_left",
-    "fg": [ "vp_stowboard_vertical_left", "vp_stowboard_vertical_left_rotW_right_rotE", "vp_stowboard_vertical_right", "vp_stowboard_vertical_left_rotE_right_rotW" ],
+    "fg": [
+      "vp_stowboard_vertical_left",
+      "vp_stowboard_vertical_left_rotE_right_rotW",
+      "vp_stowboard_vertical_right",
+      "vp_stowboard_vertical_left_rotW_right_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
-        "bg": [ "vp_stowboard_vertical_left", "vp_stowboard_vertical_left_rotW_right_rotE", "vp_stowboard_vertical_right", "vp_stowboard_vertical_left_rotE_right_rotW" ]
+        "bg": [
+          "vp_stowboard_vertical_left",
+          "vp_stowboard_vertical_left_rotE_right_rotW",
+          "vp_stowboard_vertical_right",
+          "vp_stowboard_vertical_left_rotW_right_rotE"
+        ]
       }
     ]
   },
   {
     "id": "vp_stowboard_wheel_right",
-    "fg": [ "vp_stowboard_vertical_right", "vp_stowboard_vertical_left_rotE_right_rotW", "vp_stowboard_vertical_left", "vp_stowboard_vertical_left_rotW_right_rotE" ],
+    "fg": [
+      "vp_stowboard_vertical_right",
+      "vp_stowboard_vertical_left_rotW_right_rotE",
+      "vp_stowboard_vertical_left",
+      "vp_stowboard_vertical_left_rotE_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
-        "bg": [ "vp_stowboard_vertical_right", "vp_stowboard_vertical_left_rotE_right_rotW", "vp_stowboard_vertical_left", "vp_stowboard_vertical_left_rotW_right_rotE" ]
+        "bg": [
+          "vp_stowboard_vertical_right",
+          "vp_stowboard_vertical_left_rotW_right_rotE",
+          "vp_stowboard_vertical_left",
+          "vp_stowboard_vertical_left_rotE_right_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_windshield_wheel_left",
-    "fg": [ "vp_windshield_nw", "vp_windshield_nw_rotW", "vp_windshield_nw_rotS", "vp_windshield_nw_rotE" ],
+    "fg": [ "vp_windshield_nw", "vp_windshield_nw_rotE", "vp_windshield_nw_rotS", "vp_windshield_nw_rotW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_right",
-        "bg": [ "vp_windshield_nw", "vp_windshield_nw_rotW", "vp_windshield_nw_rotS", "vp_windshield_nw_rotE" ]
+        "bg": [ "vp_windshield_nw", "vp_windshield_nw_rotE", "vp_windshield_nw_rotS", "vp_windshield_nw_rotW" ]
       }
     ],
     "multitile": true
   },
   {
     "id": "vp_windshield_wheel_right",
-    "fg": [ "vp_windshield_ne", "vp_windshield_ne_rotW", "vp_windshield_ne_rotS", "vp_windshield_ne_rotE" ],
+    "fg": [ "vp_windshield_ne", "vp_windshield_ne_rotE", "vp_windshield_ne_rotS", "vp_windshield_ne_rotW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_left",
-        "bg": [ "vp_windshield_ne", "vp_windshield_ne_rotW", "vp_windshield_ne_rotS", "vp_windshield_ne_rotE" ]
+        "bg": [ "vp_windshield_ne", "vp_windshield_ne_rotE", "vp_windshield_ne_rotS", "vp_windshield_ne_rotW" ]
       }
     ],
     "multitile": true
   },
   {
     "id": "vp_windshield_full_wheel_left",
-    "fg": [ "vp_windshield_left", "vp_windshield_left_rotW", "vp_windshield_left_rotS", "vp_windshield_left_rotE" ],
+    "fg": [ "vp_windshield_left", "vp_windshield_left_rotE", "vp_windshield_left_rotS", "vp_windshield_left_rotW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_left",
-        "bg": ["vp_windshield_left", "vp_windshield_left_rotW", "vp_windshield_left_rotS", "vp_windshield_left_rotE"
-        ]
+        "bg": [ "vp_windshield_left", "vp_windshield_left_rotE", "vp_windshield_left_rotS", "vp_windshield_left_rotW" ]
       }
     ],
     "multitile": true
   },
   {
     "id": "vp_windshield_full_wheel_right",
-    "fg": [ "vp_windshield_right", "vp_windshield_right_rotW", "vp_windshield_right_rotS", "vp_windshield_right_rotE" ],
+    "fg": [ "vp_windshield_right", "vp_windshield_right_rotE", "vp_windshield_right_rotS", "vp_windshield_right_rotW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_right",
-        "bg": [
-         "vp_windshield_right", "vp_windshield_right_rotW", "vp_windshield_right_rotS", "vp_windshield_right_rotE"
-        ]
+        "bg": [ "vp_windshield_right", "vp_windshield_right_rotE", "vp_windshield_right_rotS", "vp_windshield_right_rotW" ]
       }
     ],
     "multitile": true
   },
   {
     "id": "vp_windshield_vertical_2_left",
-    "fg": [ "vp_windshield_left", "vp_windshield_left_rotW", "vp_windshield_left_rotS", "vp_windshield_left_rotE" ],
+    "fg": [ "vp_windshield_left", "vp_windshield_left_rotE", "vp_windshield_left_rotS", "vp_windshield_left_rotW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_left",
-        "bg": ["vp_windshield_left", "vp_windshield_left_rotW", "vp_windshield_left_rotS", "vp_windshield_left_rotE"
-        ]
+        "bg": [ "vp_windshield_left", "vp_windshield_left_rotE", "vp_windshield_left_rotS", "vp_windshield_left_rotW" ]
       }
     ],
     "multitile": true
   },
   {
     "id": "vp_windshield_vertical_2_right",
-    "fg": [ "vp_windshield_right", "vp_windshield_right_rotW", "vp_windshield_right_rotS", "vp_windshield_right_rotE" ],
+    "fg": [ "vp_windshield_right", "vp_windshield_right_rotE", "vp_windshield_right_rotS", "vp_windshield_right_rotW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_right",
-        "bg": [
-         "vp_windshield_right", "vp_windshield_right_rotW", "vp_windshield_right_rotS", "vp_windshield_right_rotE"
-        ]
+        "bg": [ "vp_windshield_right", "vp_windshield_right_rotE", "vp_windshield_right_rotS", "vp_windshield_right_rotW" ]
       }
     ],
     "multitile": true

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/nose_plate/nose_plate.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/nose_plate/nose_plate.json
@@ -1,14 +1,14 @@
 [
   {
     "id": "vp_nose_plate",
-    "fg": [ "vp_nose_plate_north", "vp_nose_plate_west", "vp_nose_plate_south", "vp_nose_plate_east" ],
+    "fg": [ "vp_nose_plate_north", "vp_nose_plate_east", "vp_nose_plate_south", "vp_nose_plate_west" ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_nose_plate_north", "vp_nose_plate_west", "vp_nose_plate_south", "vp_nose_plate_east" ]
+        "bg": [ "vp_nose_plate_north", "vp_nose_plate_east", "vp_nose_plate_south", "vp_nose_plate_west" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/other/lights.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/other/lights.json
@@ -17,10 +17,16 @@
   },
   {
     "id": [ "vp_floodlight", "vp_directed_floodlight" ],
-    "fg": [ "vp_floodlight_rotN", "vp_floodlight_rotW", "vp_floodlight_rotS", "vp_floodlight_rotE" ],
+    "fg": [ "vp_floodlight_rotN", "vp_floodlight_rotE", "vp_floodlight_rotS", "vp_floodlight_rotW" ],
     "bg": [  ],
     "rotates": true,
     "multitile": true,
-    "additional_tiles": [ { "id": "broken", "fg": [ "3987_vp_cargo_space_2" ], "bg": [ "vp_floodlight_rotN", "vp_floodlight_rotW", "vp_floodlight_rotS", "vp_floodlight_rotE" ] } ]
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": [ "3987_vp_cargo_space_2" ],
+        "bg": [ "vp_floodlight_rotN", "vp_floodlight_rotE", "vp_floodlight_rotS", "vp_floodlight_rotW" ]
+      }
+    ]
   }
 ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/rams/rams.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/rams/rams.json
@@ -1,44 +1,43 @@
 [
   {
     "id": "vp_ram_spiked",
-    "fg": [ "vp_ram_spiked", "vp_ram_spiked_left", "vp_ram_spiked_down", "vp_ram_spiked_right" ],
+    "fg": [ "vp_ram_spiked", "vp_ram_spiked_right", "vp_ram_spiked_down", "vp_ram_spiked_left" ],
     "bg": "",
     "rotates": true
   },
   {
     "id": "vp_ram_wood",
-    "fg": [ "vp_ram_wood", "vp_ram_wood_left", "vp_ram_wood_down", "vp_ram_wood_right" ],
+    "fg": [ "vp_ram_wood", "vp_ram_wood_right", "vp_ram_wood_down", "vp_ram_wood_left" ],
     "bg": "",
     "rotates": true
   },
   {
     "id": "vp_spike_wood",
-    "fg": [ "vp_spike_wood", "vp_spike_wood_left", "vp_spike_wood_down", "vp_spike_wood_right" ],
+    "fg": [ "vp_spike_wood", "vp_spike_wood_right", "vp_spike_wood_down", "vp_spike_wood_left" ],
     "bg": "",
     "rotates": true
   },
   {
     "id": "vp_ram_military",
-    "fg": [ "vp_ram_military", "vp_ram_military_left", "vp_ram_military_down", "vp_ram_military_right" ],
+    "fg": [ "vp_ram_military", "vp_ram_military_right", "vp_ram_military_down", "vp_ram_military_left" ],
     "bg": "",
     "rotates": true
   },
   {
     "id": "vp_ram_steel",
-    "fg": [ "vp_ram_steel", "vp_ram_steel_left", "vp_ram_steel_down", "vp_ram_steel_right" ],
+    "fg": [ "vp_ram_steel", "vp_ram_steel_right", "vp_ram_steel_down", "vp_ram_steel_left" ],
     "bg": "",
     "rotates": true
   },
   {
     "id": "vp_ram_hardsteel",
-    "fg": [ "vp_ram_hardsteel", "vp_ram_hardsteel_left", "vp_ram_hardsteel_down", "vp_ram_hardsteel_right" ],
+    "fg": [ "vp_ram_hardsteel", "vp_ram_hardsteel_right", "vp_ram_hardsteel_down", "vp_ram_hardsteel_left" ],
     "bg": "",
     "rotates": true
-  }
-,
+  },
   {
     "id": "vp_ram_alloy",
-    "fg": [ "vp_ram_alloy", "vp_ram_alloy_left", "vp_ram_alloy_down", "vp_ram_alloy_right" ],
+    "fg": [ "vp_ram_alloy", "vp_ram_alloy_right", "vp_ram_alloy_down", "vp_ram_alloy_left" ],
     "bg": "",
     "rotates": true
   }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/seats/seats.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/seats/seats.json
@@ -3,13 +3,13 @@
     "id": [ "vp_folding_seat", "vp_reclining_seat", "vp_seat" ],
     "rotates": true,
     "bg": [  ],
-    "fg": [ "vp_seat_up", "vp_seat_left", "vp_seat_down", "vp_seat_right" ],
+    "fg": [ "vp_seat_up", "vp_seat_right", "vp_seat_down", "vp_seat_left" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_seat_up", "vp_seat_left", "vp_seat_down", "vp_seat_right" ]
+        "bg": [ "vp_seat_up", "vp_seat_right", "vp_seat_down", "vp_seat_left" ]
       }
     ]
   },
@@ -17,13 +17,13 @@
     "id": [ "vp_seat_leather", "vp_reclining_seat_leather" ],
     "rotates": true,
     "bg": [  ],
-    "fg": [ "vp_seat_leather_up", "vp_seat_leather_left", "vp_seat_leather_down", "vp_seat_leather_right" ],
+    "fg": [ "vp_seat_leather_up", "vp_seat_leather_right", "vp_seat_leather_down", "vp_seat_leather_left" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_seat_leather_up", "vp_seat_leather_left", "vp_seat_leather_down", "vp_seat_leather_right" ]
+        "bg": [ "vp_seat_leather_up", "vp_seat_leather_right", "vp_seat_leather_down", "vp_seat_leather_left" ]
       }
     ]
   },
@@ -31,13 +31,13 @@
     "id": [ "vp_seat_wood" ],
     "rotates": true,
     "bg": [ "vp_wooden_aisle_vertical", "vp_wooden_aisle_horizontal" ],
-    "fg": [ "vp_seat_wood_rotN", "vp_seat_wood_rotN", "vp_seat_wood_rotS", "vp_seat_wood_rotS" ],
+    "fg": [ "vp_seat_wood_rotN", "vp_seat_wood_rotS", "vp_seat_wood_rotS", "vp_seat_wood_rotN" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_seat_wood_rotN", "vp_seat_wood_rotN", "vp_seat_wood_rotS", "vp_seat_wood_rotS" ]
+        "bg": [ "vp_seat_wood_rotN", "vp_seat_wood_rotS", "vp_seat_wood_rotS", "vp_seat_wood_rotN" ]
       }
     ]
   },
@@ -45,19 +45,19 @@
     "id": [ "vp_seat_wood_flimsy" ],
     "rotates": true,
     "bg": [ "vp_wooden_aisle_vertical", "vp_wooden_aisle_horizontal" ],
-    "fg": [ "vp_seat_wood_flimsy_rotN", "vp_seat_wood_flimsy_rotN", "vp_seat_wood_flimsy_rotS", "vp_seat_wood_flimsy_rotS" ],
+    "fg": [ "vp_seat_wood_flimsy_rotN", "vp_seat_wood_flimsy_rotS", "vp_seat_wood_flimsy_rotS", "vp_seat_wood_flimsy_rotN" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_seat_wood_flimsy_rotN", "vp_seat_wood_flimsy_rotN", "vp_seat_wood_flimsy_rotS", "vp_seat_wood_flimsy_rotS" ]
+        "bg": [ "vp_seat_wood_flimsy_rotN", "vp_seat_wood_flimsy_rotS", "vp_seat_wood_flimsy_rotS", "vp_seat_wood_flimsy_rotN" ]
       }
     ]
   },
   {
     "id": "vp_seat_back",
-    "fg": [ "vp_seat_back_up", "vp_seat_back_west", "vp_seat_back_down", "vp_seat_back_east" ],
+    "fg": [ "vp_seat_back_up", "vp_seat_back_east", "vp_seat_back_down", "vp_seat_back_west" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -65,13 +65,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_seat_back_up", "vp_seat_back_west", "vp_seat_back_down", "vp_seat_back_east" ]
+        "bg": [ "vp_seat_back_up", "vp_seat_back_east", "vp_seat_back_down", "vp_seat_back_west" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_right",
-    "fg": [ "vp_seat_back_right_up", "vp_seat_back_right_west", "vp_seat_back_right_down", "vp_seat_back_right_east" ],
+    "fg": [ "vp_seat_back_right_up", "vp_seat_back_right_east", "vp_seat_back_right_down", "vp_seat_back_right_west" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -79,13 +79,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_seat_back_right_up", "vp_seat_back_right_west", "vp_seat_back_right_down", "vp_seat_back_right_east" ]
+        "bg": [ "vp_seat_back_right_up", "vp_seat_back_right_east", "vp_seat_back_right_down", "vp_seat_back_right_west" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_left",
-    "fg": [ "vp_seat_back_left_up", "vp_seat_back_left_west", "vp_seat_back_left_down", "vp_seat_back_left_east" ],
+    "fg": [ "vp_seat_back_left_up", "vp_seat_back_left_east", "vp_seat_back_left_down", "vp_seat_back_left_west" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -93,13 +93,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_seat_back_left_up", "vp_seat_back_left_west", "vp_seat_back_left_down", "vp_seat_back_left_east" ]
+        "bg": [ "vp_seat_back_left_up", "vp_seat_back_left_east", "vp_seat_back_left_down", "vp_seat_back_left_west" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_leather",
-    "fg": [ "vp_seat_back_leather_up", "vp_seat_back_leather_west", "vp_seat_back_leather_down", "vp_seat_back_leather_east" ],
+    "fg": [ "vp_seat_back_leather_up", "vp_seat_back_leather_east", "vp_seat_back_leather_down", "vp_seat_back_leather_west" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -107,7 +107,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_seat_back_leather_up", "vp_seat_back_leather_west", "vp_seat_back_leather_down", "vp_seat_back_leather_east" ]
+        "bg": [ "vp_seat_back_leather_up", "vp_seat_back_leather_east", "vp_seat_back_leather_down", "vp_seat_back_leather_west" ]
       }
     ]
   },
@@ -115,9 +115,9 @@
     "id": "vp_seat_back_leather_right",
     "fg": [
       "vp_seat_back_leather_right_up",
-      "vp_seat_back_leather_right_west",
+      "vp_seat_back_leather_right_east",
       "vp_seat_back_leather_right_down",
-      "vp_seat_back_leather_right_east"
+      "vp_seat_back_leather_right_west"
     ],
     "rotates": true,
     "bg": [  ],
@@ -128,9 +128,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_seat_back_leather_right_up",
-          "vp_seat_back_leather_right_west",
+          "vp_seat_back_leather_right_east",
           "vp_seat_back_leather_right_down",
-          "vp_seat_back_leather_right_east"
+          "vp_seat_back_leather_right_west"
         ]
       }
     ]
@@ -139,9 +139,9 @@
     "id": "vp_seat_back_leather_left",
     "fg": [
       "vp_seat_back_leather_left_up",
-      "vp_seat_back_leather_left_west",
+      "vp_seat_back_leather_left_east",
       "vp_seat_back_leather_left_down",
-      "vp_seat_back_leather_left_east"
+      "vp_seat_back_leather_left_west"
     ],
     "rotates": true,
     "bg": [  ],
@@ -152,16 +152,16 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_seat_back_leather_left_up",
-          "vp_seat_back_leather_left_west",
+          "vp_seat_back_leather_left_east",
           "vp_seat_back_leather_left_down",
-          "vp_seat_back_leather_left_east"
+          "vp_seat_back_leather_left_west"
         ]
       }
     ]
   },
   {
     "id": "vp_seat_back_vertical",
-    "fg": [ "vp_seat_back_east", "vp_seat_back_up", "vp_seat_back_west", "vp_seat_back_down" ],
+    "fg": [ "vp_seat_back_east", "vp_seat_back_down", "vp_seat_back_west", "vp_seat_back_up" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -169,13 +169,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_seat_back_east", "vp_seat_back_up", "vp_seat_back_west", "vp_seat_back_down" ]
+        "bg": [ "vp_seat_back_east", "vp_seat_back_down", "vp_seat_back_west", "vp_seat_back_up" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_vertical_right",
-    "fg": [ "vp_seat_back_right_east", "vp_seat_back_right_up", "vp_seat_back_right_west", "vp_seat_back_right_down" ],
+    "fg": [ "vp_seat_back_right_east", "vp_seat_back_right_down", "vp_seat_back_right_west", "vp_seat_back_right_up" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -183,13 +183,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_seat_back_right_east", "vp_seat_back_right_up", "vp_seat_back_right_west", "vp_seat_back_right_down" ]
+        "bg": [ "vp_seat_back_right_east", "vp_seat_back_right_down", "vp_seat_back_right_west", "vp_seat_back_right_up" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_vertical_left",
-    "fg": [ "vp_seat_back_left_east", "vp_seat_back_left_up", "vp_seat_back_left_west", "vp_seat_back_left_down" ],
+    "fg": [ "vp_seat_back_left_east", "vp_seat_back_left_down", "vp_seat_back_left_west", "vp_seat_back_left_up" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -197,13 +197,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_seat_back_left_east", "vp_seat_back_left_up", "vp_seat_back_left_west", "vp_seat_back_left_down" ]
+        "bg": [ "vp_seat_back_left_east", "vp_seat_back_left_down", "vp_seat_back_left_west", "vp_seat_back_left_up" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_leather_vertical",
-    "fg": [ "vp_seat_back_leather_east", "vp_seat_back_leather_up", "vp_seat_back_leather_west", "vp_seat_back_leather_down" ],
+    "fg": [ "vp_seat_back_leather_east", "vp_seat_back_leather_down", "vp_seat_back_leather_west", "vp_seat_back_leather_up" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -211,7 +211,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_seat_back_leather_east", "vp_seat_back_leather_up", "vp_seat_back_leather_west", "vp_seat_back_leather_down" ]
+        "bg": [ "vp_seat_back_leather_east", "vp_seat_back_leather_down", "vp_seat_back_leather_west", "vp_seat_back_leather_up" ]
       }
     ]
   },
@@ -219,9 +219,9 @@
     "id": "vp_seat_back_leather_vertical_right",
     "fg": [
       "vp_seat_back_leather_right_east",
-      "vp_seat_back_leather_right_up",
+      "vp_seat_back_leather_right_down",
       "vp_seat_back_leather_right_west",
-      "vp_seat_back_leather_right_down"
+      "vp_seat_back_leather_right_up"
     ],
     "rotates": true,
     "bg": [  ],
@@ -232,9 +232,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_seat_back_leather_right_east",
-          "vp_seat_back_leather_right_up",
+          "vp_seat_back_leather_right_down",
           "vp_seat_back_leather_right_west",
-          "vp_seat_back_leather_right_down"
+          "vp_seat_back_leather_right_up"
         ]
       }
     ]
@@ -243,9 +243,9 @@
     "id": "vp_seat_back_leather_vertical_left",
     "fg": [
       "vp_seat_back_leather_left_east",
-      "vp_seat_back_leather_left_up",
+      "vp_seat_back_leather_left_down",
       "vp_seat_back_leather_left_west",
-      "vp_seat_back_leather_left_down"
+      "vp_seat_back_leather_left_up"
     ],
     "rotates": true,
     "bg": [  ],
@@ -256,9 +256,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_seat_back_leather_left_east",
-          "vp_seat_back_leather_left_up",
+          "vp_seat_back_leather_left_down",
           "vp_seat_back_leather_left_west",
-          "vp_seat_back_leather_left_down"
+          "vp_seat_back_leather_left_up"
         ]
       }
     ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/seats/swivel_chair/vp_seat_swivel_chair.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/seats/swivel_chair/vp_seat_swivel_chair.json
@@ -1,14 +1,14 @@
 [
   {
     "id": "vp_seat_swivel_chair",
-    "fg": [ "vp_seat_swivel_chair_north", "vp_seat_swivel_chair_west", "vp_seat_swivel_chair_south", "vp_seat_swivel_chair_east" ],
+    "fg": [ "vp_seat_swivel_chair_north", "vp_seat_swivel_chair_east", "vp_seat_swivel_chair_south", "vp_seat_swivel_chair_west" ],
     "rotates": true,
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_seat_swivel_chair_north", "vp_seat_swivel_chair_west", "vp_seat_swivel_chair_south", "vp_seat_swivel_chair_east" ]
+        "bg": [ "vp_seat_swivel_chair_north", "vp_seat_swivel_chair_east", "vp_seat_swivel_chair_south", "vp_seat_swivel_chair_west" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/seats/vp_saddle.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/seats/vp_saddle.json
@@ -1,14 +1,14 @@
 [
   {
     "id": [ "vp_saddle", "vp_saddle_pedal" ],
-    "fg": [ "saddle_pedal_rotN", "saddle_pedal_rotW", "saddle_pedal_rotS", "saddle_pedal_rotE" ],
+    "fg": [ "saddle_pedal_rotN", "saddle_pedal_rotE", "saddle_pedal_rotS", "saddle_pedal_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
-        "fg": [ "broken_saddle_pedal_rotN", "broken_saddle_pedal_rotW", "broken_saddle_pedal_rotS", "broken_saddle_pedal_rotE" ]
+        "fg": [ "broken_saddle_pedal_rotN", "broken_saddle_pedal_rotE", "broken_saddle_pedal_rotS", "broken_saddle_pedal_rotW" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/trashcan/integrated_trashcan.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/trashcan/integrated_trashcan.json
@@ -3,9 +3,9 @@
     "id": "vp_integrated_trashcan",
     "fg": [
       "vp_integrated_trashcan_north",
-      "vp_integrated_trashcan_west",
+      "vp_integrated_trashcan_east",
       "vp_integrated_trashcan_south",
-      "vp_integrated_trashcan_east"
+      "vp_integrated_trashcan_west"
     ],
     "rotates": true,
     "multitile": true,
@@ -15,9 +15,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_integrated_trashcan_north",
-          "vp_integrated_trashcan_west",
+          "vp_integrated_trashcan_east",
           "vp_integrated_trashcan_south",
-          "vp_integrated_trashcan_east"
+          "vp_integrated_trashcan_west"
         ]
       }
     ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/vp_seed_drill.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/vp_seed_drill.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "vp_seed_drill" ],
-    "fg": [ "vp_seed_drill_N", "vp_seed_drill_W", "vp_seed_drill_S", "vp_seed_drill_E" ],
+    "fg": [ "vp_seed_drill_N", "vp_seed_drill_E", "vp_seed_drill_S", "vp_seed_drill_W" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
-        "bg": [ "vp_seed_drill_N", "vp_seed_drill_W", "vp_seed_drill_S", "vp_seed_drill_E" ]
+        "bg": [ "vp_seed_drill_N", "vp_seed_drill_E", "vp_seed_drill_S", "vp_seed_drill_W" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/wheels/wheels.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/wheels/wheels.json
@@ -8,7 +8,7 @@
   },
   {
     "id": [ "vp_wheel_bicycle", "vp_wheel_bicycle_steerable" ],
-    "fg": [ "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotW", "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotE" ],
+    "fg": [ "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotW", "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -17,16 +17,16 @@
         "id": "broken",
         "fg": [
           "broken_vp_wheel_bicycle_rotN",
-          "broken_vp_wheel_bicycle_rotW",
+          "broken_vp_wheel_bicycle_rotE",
           "broken_vp_wheel_bicycle_rotS",
-          "broken_vp_wheel_bicycle_rotE"
+          "broken_vp_wheel_bicycle_rotW"
         ]
       }
     ]
   },
   {
     "id": [ "vp_wheel_bicycle_or" ],
-    "fg": [ "vp_wheel_bicycle_or_rotN", "vp_wheel_bicycle_or_rotW", "vp_wheel_bicycle_or_rotS", "vp_wheel_bicycle_or_rotE" ],
+    "fg": [ "vp_wheel_bicycle_or_rotN", "vp_wheel_bicycle_or_rotE", "vp_wheel_bicycle_or_rotS", "vp_wheel_bicycle_or_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -34,13 +34,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_wheel_bicycle_or_rotN", "vp_wheel_bicycle_or_rotW", "vp_wheel_bicycle_or_rotS", "vp_wheel_bicycle_or_rotE" ]
+        "bg": [ "vp_wheel_bicycle_or_rotN", "vp_wheel_bicycle_or_rotE", "vp_wheel_bicycle_or_rotS", "vp_wheel_bicycle_or_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_wheel_bicycle_or_rear" ],
-    "fg": [ "vp_wheel_bicycle_or_rotS", "vp_wheel_bicycle_or_rotE", "vp_wheel_bicycle_or_rotN", "vp_wheel_bicycle_or_rotW" ],
+    "fg": [ "vp_wheel_bicycle_or_rotS", "vp_wheel_bicycle_or_rotW", "vp_wheel_bicycle_or_rotN", "vp_wheel_bicycle_or_rotE" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -48,13 +48,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_wheel_bicycle_or_rotS", "vp_wheel_bicycle_or_rotE", "vp_wheel_bicycle_or_rotN", "vp_wheel_bicycle_or_rotW" ]
+        "bg": [ "vp_wheel_bicycle_or_rotS", "vp_wheel_bicycle_or_rotW", "vp_wheel_bicycle_or_rotN", "vp_wheel_bicycle_or_rotE" ]
       }
     ]
   },
   {
     "id": [ "vp_wheel_small", "vp_wheel_small_steerable" ],
-    "fg": [ "vp_wheel_small_rotN", "vp_wheel_small_rotW", "vp_wheel_small_rotS", "vp_wheel_small_rotE" ],
+    "fg": [ "vp_wheel_small_rotN", "vp_wheel_small_rotE", "vp_wheel_small_rotS", "vp_wheel_small_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -62,13 +62,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_wheel_small_rotN", "vp_wheel_small_rotW", "vp_wheel_small_rotS", "vp_wheel_small_rotE" ]
+        "bg": [ "vp_wheel_small_rotN", "vp_wheel_small_rotE", "vp_wheel_small_rotS", "vp_wheel_small_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_wheel_bicycle_rear" ],
-    "fg": [ "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotE", "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotW" ],
+    "fg": [ "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotW", "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotE" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -76,7 +76,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotE", "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotW" ]
+        "bg": [ "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotW", "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotE" ]
       }
     ]
   },
@@ -97,7 +97,7 @@
   },
   {
     "id": [ "vp_wheel_wood" ],
-    "fg": [ "vp_wheel_wood_rotN", "vp_wheel_wood_rotW", "vp_wheel_wood_rotS", "vp_wheel_wood_rotE" ],
+    "fg": [ "vp_wheel_wood_rotN", "vp_wheel_wood_rotE", "vp_wheel_wood_rotS", "vp_wheel_wood_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -105,13 +105,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_wheel_wood_rotN", "vp_wheel_wood_rotW", "vp_wheel_wood_rotS", "vp_wheel_wood_rotE" ]
+        "bg": [ "vp_wheel_wood_rotN", "vp_wheel_wood_rotE", "vp_wheel_wood_rotS", "vp_wheel_wood_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_wheel_wood_b" ],
-    "fg": [ "vp_wheel_wood_b_rotN", "vp_wheel_wood_b_rotW", "vp_wheel_wood_b_rotS", "vp_wheel_wood_b_rotE" ],
+    "fg": [ "vp_wheel_wood_b_rotN", "vp_wheel_wood_b_rotE", "vp_wheel_wood_b_rotS", "vp_wheel_wood_b_rotW" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -119,13 +119,13 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_wheel_wood_b_rotN", "vp_wheel_wood_b_rotW", "vp_wheel_wood_b_rotS", "vp_wheel_wood_b_rotE" ]
+        "bg": [ "vp_wheel_wood_b_rotN", "vp_wheel_wood_b_rotE", "vp_wheel_wood_b_rotS", "vp_wheel_wood_b_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_yoke_harness" ],
-    "fg": [ "vp_yoke_harness_up", "vp_yoke_harness_left", "vp_yoke_harness_down", "vp_yoke_harness_right" ],
+    "fg": [ "vp_yoke_harness_up", "vp_yoke_harness_right", "vp_yoke_harness_down", "vp_yoke_harness_left" ],
     "rotates": true,
     "bg": [  ],
     "multitile": true,
@@ -133,7 +133,7 @@
       {
         "id": "broken",
         "fg": [ "3987_vp_cargo_space_2" ],
-        "bg": [ "vp_yoke_harness_up", "vp_yoke_harness_left", "vp_yoke_harness_down", "vp_yoke_harness_right" ]
+        "bg": [ "vp_yoke_harness_up", "vp_yoke_harness_right", "vp_yoke_harness_down", "vp_yoke_harness_left" ]
       }
     ]
   }

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/windshields/reinforced/vp_windshield_reinforced.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/windshields/reinforced/vp_windshield_reinforced.json
@@ -8,9 +8,9 @@
     ],
     "fg": [
       "vp_reinforced_windshield_horizontal_front",
-      "vp_reinforced_windshield_horizontal_front_rotW",
+      "vp_reinforced_windshield_horizontal_front_rotE",
       "vp_reinforced_windshield_horizontal_front_rotS",
-      "vp_reinforced_windshield_horizontal_front_rotE"
+      "vp_reinforced_windshield_horizontal_front_rotW"
     ],
     "bg": [  ],
     "rotates": true,
@@ -21,9 +21,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_reinforced_windshield_horizontal_front",
-          "vp_reinforced_windshield_horizontal_front_rotW",
+          "vp_reinforced_windshield_horizontal_front_rotE",
           "vp_reinforced_windshield_horizontal_front_rotS",
-          "vp_reinforced_windshield_horizontal_front_rotE"
+          "vp_reinforced_windshield_horizontal_front_rotW"
         ]
       }
     ]
@@ -48,9 +48,9 @@
     "id": "vp_reinforced_windshield_nw",
     "fg": [
       "vp_windshield_reinforced_nw",
-      "vp_windshield_reinforced_nw_rotW",
+      "vp_windshield_reinforced_nw_rotE",
       "vp_windshield_reinforced_se",
-      "vp_windshield_reinforced_nw_rotE"
+      "vp_windshield_reinforced_nw_rotW"
     ],
     "bg": [  ],
     "rotates": true,
@@ -61,9 +61,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_windshield_reinforced_nw",
-          "vp_windshield_reinforced_nw_rotW",
+          "vp_windshield_reinforced_nw_rotE",
           "vp_windshield_reinforced_se",
-          "vp_windshield_reinforced_nw_rotE"
+          "vp_windshield_reinforced_nw_rotW"
         ]
       }
     ]
@@ -72,9 +72,9 @@
     "id": "vp_reinforced_windshield_ne",
     "fg": [
       "vp_windshield_reinforced_ne",
-      "vp_windshield_reinforced_ne_rotW",
+      "vp_windshield_reinforced_ne_rotE",
       "vp_windshield_reinforced_sw",
-      "vp_windshield_reinforced_ne_rotE"
+      "vp_windshield_reinforced_ne_rotW"
     ],
     "bg": [  ],
     "rotates": true,
@@ -85,9 +85,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_windshield_reinforced_ne",
-          "vp_windshield_reinforced_ne_rotW",
+          "vp_windshield_reinforced_ne_rotE",
           "vp_windshield_reinforced_sw",
-          "vp_windshield_reinforced_ne_rotE"
+          "vp_windshield_reinforced_ne_rotW"
         ]
       }
     ]
@@ -144,9 +144,9 @@
     "id": "vp_reinforced_windshield_full_horizontal_front",
     "fg": [
       "vp_reinforced_windshield_full_horizontal_front",
-      "vp_reinforced_windshield_full_horizontal_front_rotW",
+      "vp_reinforced_windshield_full_horizontal_front_rotE",
       "vp_reinforced_windshield_full_horizontal_front_rotS",
-      "vp_reinforced_windshield_full_horizontal_front_rotE"
+      "vp_reinforced_windshield_full_horizontal_front_rotW"
     ],
     "bg": [  ],
     "rotates": true,
@@ -157,9 +157,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_reinforced_windshield_full_horizontal_front",
-          "vp_reinforced_windshield_full_horizontal_front_rotW",
+          "vp_reinforced_windshield_full_horizontal_front_rotE",
           "vp_reinforced_windshield_full_horizontal_front_rotS",
-          "vp_reinforced_windshield_full_horizontal_front_rotE"
+          "vp_reinforced_windshield_full_horizontal_front_rotW"
         ]
       }
     ]
@@ -168,9 +168,9 @@
     "id": "vp_reinforced_windshield_full_nw",
     "fg": [
       "vp_reinforced_windshield_full_nw",
-      "vp_reinforced_windshield_full_nw_rotW",
+      "vp_reinforced_windshield_full_nw_rotE",
       "vp_reinforced_windshield_full_nw_rotS",
-      "vp_reinforced_windshield_full_nw_rotE"
+      "vp_reinforced_windshield_full_nw_rotW"
     ],
     "bg": [  ],
     "rotates": true,
@@ -181,9 +181,9 @@
         "fg": [ "3987_vp_cargo_space_2" ],
         "bg": [
           "vp_reinforced_windshield_full_nw",
-          "vp_reinforced_windshield_full_nw_rotW",
+          "vp_reinforced_windshield_full_nw_rotE",
           "vp_reinforced_windshield_full_nw_rotS",
-          "vp_reinforced_windshield_full_nw_rotE"
+          "vp_reinforced_windshield_full_nw_rotW"
         ]
       }
     ]

--- a/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/windshields/vp_windshield.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/vehicle/windshields/vp_windshield.json
@@ -3,9 +3,9 @@
     "id": [ "vp_windshield", "vp_windshield_horizontal", "vp_windshield_horizontal_front", "vp_windshield_front_edge" ],
     "fg": [
       "vp_windshield_horizontal",
-      "vp_windshield_horizontal_rotW",
+      "vp_windshield_horizontal_rotE",
       "vp_windshield_horizontal_rotS",
-      "vp_windshield_horizontal_rotE"
+      "vp_windshield_horizontal_rotW"
     ],
     "bg": [  ],
     "additional_tiles": [
@@ -14,9 +14,9 @@
         "fg": "crack_glass_center",
         "bg": [
           "vp_windshield_horizontal",
-          "vp_windshield_horizontal_rotW",
+          "vp_windshield_horizontal_rotE",
           "vp_windshield_horizontal_rotS",
-          "vp_windshield_horizontal_rotE"
+          "vp_windshield_horizontal_rotW"
         ]
       }
     ],
@@ -25,13 +25,13 @@
   },
   {
     "id": [ "vp_windshield_horizontal_rear" ],
-    "fg": [ "vp_windshield_rear", "vp_windshield_rear_rotW", "vp_windshield_rear_rotS", "vp_windshield_rear_rotE" ],
+    "fg": [ "vp_windshield_rear", "vp_windshield_rear_rotE", "vp_windshield_rear_rotS", "vp_windshield_rear_rotW" ],
     "bg": [  ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_center",
-        "bg": [ "vp_windshield_rear", "vp_windshield_rear_rotW", "vp_windshield_rear_rotS", "vp_windshield_rear_rotE" ]
+        "bg": [ "vp_windshield_rear", "vp_windshield_rear_rotE", "vp_windshield_rear_rotS", "vp_windshield_rear_rotW" ]
       }
     ],
     "multitile": true,
@@ -41,9 +41,9 @@
     "id": [ "vp_windshield_horizontal_front_edge" ],
     "fg": [
       "vp_windshield_horizontal_front_edge_rotN",
-      "vp_windshield_horizontal_front_edge_rotW",
+      "vp_windshield_horizontal_front_edge_rotE",
       "vp_windshield_horizontal_front_edge_rotS",
-      "vp_windshield_horizontal_front_edge_rotE"
+      "vp_windshield_horizontal_front_edge_rotW"
     ],
     "bg": [  ],
     "additional_tiles": [
@@ -52,9 +52,9 @@
         "fg": "crack_glass_center",
         "bg": [
           "vp_windshield_horizontal_front_edge_rotN",
-          "vp_windshield_horizontal_front_edge_rotW",
+          "vp_windshield_horizontal_front_edge_rotE",
           "vp_windshield_horizontal_front_edge_rotS",
-          "vp_windshield_horizontal_front_edge_rotE"
+          "vp_windshield_horizontal_front_edge_rotW"
         ]
       }
     ],
@@ -65,9 +65,9 @@
     "id": [ "vp_windshield_horizontal_rear_edge" ],
     "fg": [
       "vp_windshield_rear_edge",
-      "vp_windshield_rear_edge_rotW",
+      "vp_windshield_rear_edge_rotE",
       "vp_windshield_rear_edge_rotS",
-      "vp_windshield_rear_edge_rotE"
+      "vp_windshield_rear_edge_rotW"
     ],
     "bg": [  ],
     "additional_tiles": [
@@ -76,9 +76,9 @@
         "fg": "crack_glass_center",
         "bg": [
           "vp_windshield_rear_edge",
-          "vp_windshield_rear_edge_rotW",
+          "vp_windshield_rear_edge_rotE",
           "vp_windshield_rear_edge_rotS",
-          "vp_windshield_rear_edge_rotE"
+          "vp_windshield_rear_edge_rotW"
         ]
       }
     ],
@@ -87,13 +87,13 @@
   },
   {
     "id": "vp_windshield_nw",
-    "fg": [ "vp_windshield_nw", "vp_windshield_nw_rotW", "vp_windshield_nw_rotS", "vp_windshield_nw_rotE" ],
+    "fg": [ "vp_windshield_nw", "vp_windshield_nw_rotE", "vp_windshield_nw_rotS", "vp_windshield_nw_rotW" ],
     "bg": [  ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_right",
-        "bg": [ "vp_windshield_nw", "vp_windshield_nw_rotW", "vp_windshield_nw_rotS", "vp_windshield_nw_rotE" ]
+        "bg": [ "vp_windshield_nw", "vp_windshield_nw_rotE", "vp_windshield_nw_rotS", "vp_windshield_nw_rotW" ]
       }
     ],
     "multitile": true,
@@ -101,13 +101,13 @@
   },
   {
     "id": "vp_windshield_ne",
-    "fg": [ "vp_windshield_ne", "vp_windshield_ne_rotW", "vp_windshield_ne_rotS", "vp_windshield_ne_rotE" ],
+    "fg": [ "vp_windshield_ne", "vp_windshield_ne_rotE", "vp_windshield_ne_rotS", "vp_windshield_ne_rotW" ],
     "bg": [  ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_left",
-        "bg": [ "vp_windshield_ne", "vp_windshield_ne_rotW", "vp_windshield_ne_rotS", "vp_windshield_ne_rotE" ]
+        "bg": [ "vp_windshield_ne", "vp_windshield_ne_rotE", "vp_windshield_ne_rotS", "vp_windshield_ne_rotW" ]
       }
     ],
     "multitile": true,
@@ -115,13 +115,13 @@
   },
   {
     "id": "vp_windshield_sw",
-    "fg": [ "vp_windshield_sw_rotN", "vp_windshield_sw_rotW", "vp_windshield_sw_rotS", "vp_windshield_sw_rotE" ],
+    "fg": [ "vp_windshield_sw_rotN", "vp_windshield_sw_rotE", "vp_windshield_sw_rotS", "vp_windshield_sw_rotW" ],
     "bg": [  ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_right",
-        "bg": [ "vp_windshield_sw_rotN", "vp_windshield_sw_rotW", "vp_windshield_sw_rotS", "vp_windshield_sw_rotE" ]
+        "bg": [ "vp_windshield_sw_rotN", "vp_windshield_sw_rotE", "vp_windshield_sw_rotS", "vp_windshield_sw_rotW" ]
       }
     ],
     "multitile": true,
@@ -129,13 +129,13 @@
   },
   {
     "id": "vp_windshield_se",
-    "fg": [ "vp_windshield_se_rotN", "vp_windshield_se_rotW", "vp_windshield_se_rotS", "vp_windshield_se_rotE" ],
+    "fg": [ "vp_windshield_se_rotN", "vp_windshield_se_rotE", "vp_windshield_se_rotS", "vp_windshield_se_rotW" ],
     "bg": [  ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_left",
-        "bg": [ "vp_windshield_se_rotN", "vp_windshield_se_rotW", "vp_windshield_se_rotS", "vp_windshield_se_rotE" ]
+        "bg": [ "vp_windshield_se_rotN", "vp_windshield_se_rotE", "vp_windshield_se_rotS", "vp_windshield_se_rotW" ]
       }
     ],
     "multitile": true,
@@ -145,9 +145,9 @@
     "id": "vp_windshield_nw_edge",
     "fg": [
       "vp_windshield_nw_edge_rotN",
-      "vp_windshield_nw_edge_rotW",
+      "vp_windshield_nw_edge_rotE",
       "vp_windshield_nw_edge_rotS",
-      "vp_windshield_nw_edge_rotE"
+      "vp_windshield_nw_edge_rotW"
     ],
     "bg": [  ],
     "additional_tiles": [
@@ -156,9 +156,9 @@
         "fg": "crack_glass_right",
         "bg": [
           "vp_windshield_nw_edge_rotN",
-          "vp_windshield_nw_edge_rotW",
+          "vp_windshield_nw_edge_rotE",
           "vp_windshield_nw_edge_rotS",
-          "vp_windshield_nw_edge_rotE"
+          "vp_windshield_nw_edge_rotW"
         ]
       }
     ],
@@ -170,9 +170,9 @@
     "bg": [  ],
     "fg": [
       "vp_windshield_ne_edge_rotN",
-      "vp_windshield_ne_edge_rotW",
+      "vp_windshield_ne_edge_rotE",
       "vp_windshield_ne_edge_rotS",
-      "vp_windshield_ne_edge_rotE"
+      "vp_windshield_ne_edge_rotW"
     ],
     "additional_tiles": [
       {
@@ -180,9 +180,9 @@
         "fg": "crack_glass_left",
         "bg": [
           "vp_windshield_ne_edge_rotN",
-          "vp_windshield_ne_edge_rotW",
+          "vp_windshield_ne_edge_rotE",
           "vp_windshield_ne_edge_rotS",
-          "vp_windshield_ne_edge_rotE"
+          "vp_windshield_ne_edge_rotW"
         ]
       }
     ],
@@ -191,15 +191,13 @@
   },
   {
     "id": "vp_windshield_sw_edge",
-    "fg": [ "vp_windshield_sw_edge", "vp_windshield_sw_edge_rotW", "vp_windshield_sw_edge_rotS", "vp_windshield_sw_edge_rotE" ],
+    "fg": [ "vp_windshield_sw_edge", "vp_windshield_sw_edge_rotE", "vp_windshield_sw_edge_rotS", "vp_windshield_sw_edge_rotW" ],
     "bg": [  ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_right",
-        "bg": [
-          "vp_windshield_sw_edge", "vp_windshield_sw_edge_rotW", "vp_windshield_sw_edge_rotS", "vp_windshield_sw_edge_rotE"
-        ]
+        "bg": [ "vp_windshield_sw_edge", "vp_windshield_sw_edge_rotE", "vp_windshield_sw_edge_rotS", "vp_windshield_sw_edge_rotW" ]
       }
     ],
     "multitile": true,
@@ -207,15 +205,13 @@
   },
   {
     "id": "vp_windshield_se_edge",
-    "fg": [ "vp_windshield_se_edge", "vp_windshield_se_edge_rotW", "vp_windshield_se_edge_rotS", "vp_windshield_se_edge_rotE" ],
+    "fg": [ "vp_windshield_se_edge", "vp_windshield_se_edge_rotE", "vp_windshield_se_edge_rotS", "vp_windshield_se_edge_rotW" ],
     "bg": [  ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_left",
-        "bg": [
-          "vp_windshield_se_edge", "vp_windshield_se_edge_rotW", "vp_windshield_se_edge_rotS", "vp_windshield_se_edge_rotE"
-        ]
+        "bg": [ "vp_windshield_se_edge", "vp_windshield_se_edge_rotE", "vp_windshield_se_edge_rotS", "vp_windshield_se_edge_rotW" ]
       }
     ],
     "multitile": true,
@@ -223,14 +219,13 @@
   },
   {
     "id": [ "vp_windshield_vertical_left", "vp_windshield_left" ],
-    "fg": [ "vp_windshield_left", "vp_windshield_left_rotW", "vp_windshield_left_rotS", "vp_windshield_left_rotE" ],
+    "fg": [ "vp_windshield_left", "vp_windshield_left_rotE", "vp_windshield_left_rotS", "vp_windshield_left_rotW" ],
     "bg": [  ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_left",
-        "bg": ["vp_windshield_left", "vp_windshield_left_rotW", "vp_windshield_left_rotS", "vp_windshield_left_rotE"
-        ]
+        "bg": [ "vp_windshield_left", "vp_windshield_left_rotE", "vp_windshield_left_rotS", "vp_windshield_left_rotW" ]
       }
     ],
     "multitile": true,
@@ -238,15 +233,13 @@
   },
   {
     "id": [ "vp_windshield_vertical_right", "vp_windshield_right" ],
-    "fg": [ "vp_windshield_right", "vp_windshield_right_rotW", "vp_windshield_right_rotS", "vp_windshield_right_rotE" ],
+    "fg": [ "vp_windshield_right", "vp_windshield_right_rotE", "vp_windshield_right_rotS", "vp_windshield_right_rotW" ],
     "bg": [  ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_right",
-        "bg": [
-         "vp_windshield_right", "vp_windshield_right_rotW", "vp_windshield_right_rotS", "vp_windshield_right_rotE"
-        ]
+        "bg": [ "vp_windshield_right", "vp_windshield_right_rotE", "vp_windshield_right_rotS", "vp_windshield_right_rotW" ]
       }
     ],
     "multitile": true,


### PR DESCRIPTION
#### Summary
Part of the tile rotation update PRs. Updates tile definitions to account for the fixes in https://github.com/CleverRaven/Cataclysm-DDA/pull/86335 and https://github.com/CleverRaven/Cataclysm-DDA/pull/86574

#### Content of the change
The dependent PR changed the tile drawing code to rotate tiles in the correct direction (clockwise instead of counter clockwise) and it will select tiles in an order opposite than it used to.
Every tile definition that defines all four rotations had to have indexes 1 and 3 swapped so the engine will select the correct tile to draw. 


#### Testing
Composed locally checked around for any obviously broken tiles. Attached is a save with a lot of testing material placed down in-game and on the overmap.
[Debug.tar.gz](https://github.com/user-attachments/files/26925717/Debug.tar.gz)


#### Additional information
Depends on https://github.com/CleverRaven/Cataclysm-DDA/pull/86574 being merged.