### PR TITLE
[Ultica] Rotation Fixes

### DIFF
--- a/gfx/UltimateCataclysm/pngs_centered_64x64/f_LIXA_electrical_conduit/f_LIXA_electrical_conduit.json
+++ b/gfx/UltimateCataclysm/pngs_centered_64x64/f_LIXA_electrical_conduit/f_LIXA_electrical_conduit.json
@@ -3,25 +3,16 @@
   "multitile": true,
   "fg": "f_LIXA_electrical_conduit_edge_ns",
   "additional_tiles": [
-    {
-      "id": "edge",
-      "fg": [
-        "f_LIXA_electrical_conduit_edge_ns",
-        "f_LIXA_electrical_conduit_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_LIXA_electrical_conduit_edge_ns", "f_LIXA_electrical_conduit_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_LIXA_electrical_conduit_end_piece_n",
-        "f_LIXA_electrical_conduit_end_piece_w",
+        "f_LIXA_electrical_conduit_end_piece_e",
         "f_LIXA_electrical_conduit_end_piece_s",
-        "f_LIXA_electrical_conduit_end_piece_e"
+        "f_LIXA_electrical_conduit_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "f_LIXA_electrical_conduit_edge_ns"
-    }
+    { "id": "unconnected", "fg": "f_LIXA_electrical_conduit_edge_ns" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_centered_64x64/f_electrical_conduit/f_electrical_conduit.json
+++ b/gfx/UltimateCataclysm/pngs_centered_64x64/f_electrical_conduit/f_electrical_conduit.json
@@ -4,28 +4,16 @@
   "fg": "f_electrical_conduit_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "edge",
-      "fg": [
-        "f_electrical_conduit_edge_ns",
-        "f_electrical_conduit_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_electrical_conduit_edge_ns", "f_electrical_conduit_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_electrical_conduit_end_piece_n",
-        "f_electrical_conduit_end_piece_w",
+        "f_electrical_conduit_end_piece_e",
         "f_electrical_conduit_end_piece_s",
-        "f_electrical_conduit_end_piece_e"
+        "f_electrical_conduit_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_electrical_conduit_unconnected",
-        "f_electrical_conduit_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_electrical_conduit_unconnected", "f_electrical_conduit_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_centered_64x64/vehicles/vp_wing_mirror.json
+++ b/gfx/UltimateCataclysm/pngs_centered_64x64/vehicles/vp_wing_mirror.json
@@ -1,19 +1,19 @@
 [
   {
     "id": "vp_wing_mirror",
-    "fg": [ "vp_wing_mirror_rotN", "vp_wing_mirror_rotW", "vp_wing_mirror_rotS", "vp_wing_mirror_rotE" ],
+    "fg": [ "vp_wing_mirror_rotN", "vp_wing_mirror_rotE", "vp_wing_mirror_rotS", "vp_wing_mirror_rotW" ],
     "rotates": true,
     "bg": ""
   },
   {
     "id": "vp_wing_mirror_left",
-    "fg": [ "vp_wing_mirror_left_rotN", "vp_wing_mirror_left_rotW", "vp_wing_mirror_left_rotS", "vp_wing_mirror_left_rotE" ],
+    "fg": [ "vp_wing_mirror_left_rotN", "vp_wing_mirror_left_rotE", "vp_wing_mirror_left_rotS", "vp_wing_mirror_left_rotW" ],
     "rotates": true,
     "bg": ""
   },
   {
     "id": "vp_wing_mirror_right",
-    "fg": [ "vp_wing_mirror_right_rotN", "vp_wing_mirror_right_rotW", "vp_wing_mirror_right_rotS", "vp_wing_mirror_right_rotE" ],
+    "fg": [ "vp_wing_mirror_right_rotN", "vp_wing_mirror_right_rotE", "vp_wing_mirror_right_rotS", "vp_wing_mirror_right_rotW" ],
     "rotates": true,
     "bg": ""
   }

--- a/gfx/UltimateCataclysm/pngs_filler_32x32/f_metal_bench/f_metal_bench.json
+++ b/gfx/UltimateCataclysm/pngs_filler_32x32/f_metal_bench/f_metal_bench.json
@@ -4,53 +4,28 @@
   "fg": "f_metal_bench_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_metal_bench_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_metal_bench_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_metal_bench_corner_nw",
-        "f_metal_bench_corner_sw",
-        "f_metal_bench_corner_se",
-        "f_metal_bench_corner_ne"
-      ]
+      "fg": [ "f_metal_bench_corner_nw", "f_metal_bench_corner_ne", "f_metal_bench_corner_se", "f_metal_bench_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "f_metal_bench_t_connection_n",
-        "f_metal_bench_t_connection_w",
+        "f_metal_bench_t_connection_e",
         "f_metal_bench_t_connection_s",
-        "f_metal_bench_t_connection_e"
+        "f_metal_bench_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_metal_bench_edge_ns",
-        "f_metal_bench_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_metal_bench_edge_ns", "f_metal_bench_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_metal_bench_end_piece_n",
-        "f_metal_bench_end_piece_w",
-        "f_metal_bench_end_piece_s",
-        "f_metal_bench_end_piece_e"
-      ]
+      "fg": [ "f_metal_bench_end_piece_n", "f_metal_bench_end_piece_e", "f_metal_bench_end_piece_s", "f_metal_bench_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_metal_bench_unconnected", "f_metal_bench_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_metal_bench_unconnected", "f_metal_bench_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_fillerhoder_32x32/MShockXotto+/vehicle/rams/rams.json
+++ b/gfx/UltimateCataclysm/pngs_fillerhoder_32x32/MShockXotto+/vehicle/rams/rams.json
@@ -1,23 +1,22 @@
 [
   {
     "id": "vp_ram_wood",
-    "fg": [ "vp_ram_wood", "vp_ram_wood_left", "vp_ram_wood_down", "vp_ram_wood_right" ],
+    "fg": "vp_ram_wood",
     "rotates": true
   },
   {
     "id": "vp_ram_military_front",
-    "fg": [ "vp_ram_military", "vp_ram_military_left", "vp_ram_military_down", "vp_ram_military_right" ],
+    "fg": "vp_ram_military",
     "rotates": true
   },
   {
     "id": "vp_ram_hardsteel_front",
-    "fg": [ "vp_ram_hardsteel", "vp_ram_hardsteel_left", "vp_ram_hardsteel_down", "vp_ram_hardsteel_right" ],
+    "fg": "vp_ram_hardsteel",
     "rotates": true
-  }
-,
+  },
   {
     "id": "vp_ram_alloy_front",
-    "fg": [ "vp_ram_alloy", "vp_ram_alloy_left", "vp_ram_alloy_down", "vp_ram_alloy_right" ],
+    "fg": "vp_ram_alloy",
     "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/boards/board.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/boards/board.json
@@ -1,145 +1,215 @@
 [
   {
     "id": "vp_board_ne",
-    "fg": [ "vp_board_ne", "vp_board_ne_rotW", "vp_board_ne_rotS", "vp_board_ne_rotE" ],
+    "fg": [ "vp_board_ne", "vp_board_ne_rotE", "vp_board_ne_rotS", "vp_board_ne_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_ne", "vp_board_ne_rotW", "vp_board_ne_rotS", "vp_board_ne_rotE" ]
+        "bg": [ "vp_board_ne", "vp_board_ne_rotE", "vp_board_ne_rotS", "vp_board_ne_rotE" ]
       }
     ]
   },
   {
     "id": "vp_board_nw",
-    "fg": [ "vp_board_ne_rotW", "vp_board_nw_rotW", "vp_board_nw_rotS", "vp_board_ne" ],
+    "fg": [ "vp_board_ne_rotW", "vp_board_ne", "vp_board_nw_rotS", "vp_board_nw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_ne_rotW", "vp_board_nw_rotW", "vp_board_nw_rotS", "vp_board_ne" ]
+        "bg": [ "vp_board_ne_rotW", "vp_board_ne", "vp_board_nw_rotS", "vp_board_nw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_board_se",
-    "fg": [ "vp_board_se", "vp_board_ne", "vp_board_ne_rotW", "vp_board_nw_rotW" ],
+    "fg": [ "vp_board_se", "vp_board_nw_rotW", "vp_board_ne_rotW", "vp_board_ne" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_se", "vp_board_ne", "vp_board_ne_rotW", "vp_board_nw_rotW" ]
+        "bg": [ "vp_board_se", "vp_board_nw_rotW", "vp_board_ne_rotW", "vp_board_ne" ]
       }
     ]
   },
   {
     "id": "vp_board_sw",
-    "fg": [ "vp_board_sw", "vp_board_ne_rotE", "vp_board_ne", "vp_board_ne_rotW" ],
+    "fg": [ "vp_board_sw", "vp_board_ne_rotW", "vp_board_ne", "vp_board_ne_rotE" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_sw", "vp_board_ne_rotE", "vp_board_ne", "vp_board_ne_rotW" ]
+        "bg": [ "vp_board_sw", "vp_board_ne_rotW", "vp_board_ne", "vp_board_ne_rotE" ]
       }
     ]
   },
   {
     "id": "vp_board_vertical_left",
-    "fg": [ "vp_board_horizontal_front_rotW", "vp_board_vertical_left_rotW_right_rotE", "vp_board_horizontal_front_rotE", "vp_board_horizontal_rear_rotS" ],
+    "fg": [
+      "vp_board_horizontal_front_rotW",
+      "vp_board_horizontal_rear_rotS",
+      "vp_board_horizontal_front_rotE",
+      "vp_board_vertical_left_rotW_right_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_horizontal_front_rotW", "vp_board_vertical_left_rotW_right_rotE", "vp_board_horizontal_front_rotE", "vp_board_horizontal_rear_rotS" ]
+        "bg": [
+          "vp_board_horizontal_front_rotW",
+          "vp_board_horizontal_rear_rotS",
+          "vp_board_horizontal_front_rotE",
+          "vp_board_vertical_left_rotW_right_rotE"
+        ]
       }
     ]
   },
   {
     "id": "vp_board_vertical_right",
-    "fg": [ "vp_board_horizontal_front_rotE", "vp_board_horizontal_rear_rotS", "vp_board_horizontal_front_rotW", "vp_board_vertical_left_rotW_right_rotE" ],
+    "fg": [
+      "vp_board_horizontal_front_rotE",
+      "vp_board_vertical_left_rotW_right_rotE",
+      "vp_board_horizontal_front_rotW",
+      "vp_board_horizontal_rear_rotS"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_horizontal_front_rotE", "vp_board_horizontal_rear_rotS", "vp_board_horizontal_front_rotW", "vp_board_vertical_left_rotW_right_rotE" ]
+        "bg": [
+          "vp_board_horizontal_front_rotE",
+          "vp_board_vertical_left_rotW_right_rotE",
+          "vp_board_horizontal_front_rotW",
+          "vp_board_horizontal_rear_rotS"
+        ]
       }
     ]
   },
   {
     "id": "vp_board_wheel_left",
-    "fg": [ "vp_board_horizontal_front_rotW", "vp_board_wheel_left_rotW_right_rotE", "vp_board_horizontal_front_rotE", "vp_board_horizontal_rear_rotS" ],
+    "fg": [
+      "vp_board_horizontal_front_rotW",
+      "vp_board_horizontal_rear_rotS",
+      "vp_board_horizontal_front_rotE",
+      "vp_board_wheel_left_rotW_right_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_horizontal_front_rotW", "vp_board_wheel_left_rotW_right_rotE", "vp_board_horizontal_front_rotE", "vp_board_horizontal_rear_rotS" ]
+        "bg": [
+          "vp_board_horizontal_front_rotW",
+          "vp_board_horizontal_rear_rotS",
+          "vp_board_horizontal_front_rotE",
+          "vp_board_wheel_left_rotW_right_rotE"
+        ]
       }
     ]
   },
   {
     "id": "vp_board_wheel_right",
-    "fg": [ "vp_board_horizontal_front_rotE", "vp_board_horizontal_rear_rotS", "vp_board_horizontal_front_rotW", "vp_board_wheel_left_rotW_right_rotE" ],
+    "fg": [
+      "vp_board_horizontal_front_rotE",
+      "vp_board_wheel_left_rotW_right_rotE",
+      "vp_board_horizontal_front_rotW",
+      "vp_board_horizontal_rear_rotS"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_horizontal_front_rotE", "vp_board_horizontal_rear_rotS", "vp_board_horizontal_front_rotW", "vp_board_wheel_left_rotW_right_rotE" ]
+        "bg": [
+          "vp_board_horizontal_front_rotE",
+          "vp_board_wheel_left_rotW_right_rotE",
+          "vp_board_horizontal_front_rotW",
+          "vp_board_horizontal_rear_rotS"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_board", "vp_board_horizontal", "vp_board_horizontal_2" ],
-    "fg": [ "vp_board_horizontal_front", "vp_board_horizontal_rotW", "vp_board_horizontal_front", "vp_board_vertical_rotNS" ],
+    "fg": [ "vp_board_horizontal_front", "vp_board_vertical_rotNS", "vp_board_horizontal_front", "vp_board_horizontal_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_horizontal_front", "vp_board_horizontal_rotW", "vp_board_horizontal_front", "vp_board_vertical_rotNS" ]
+        "bg": [ "vp_board_horizontal_front", "vp_board_vertical_rotNS", "vp_board_horizontal_front", "vp_board_horizontal_rotW" ]
       }
     ]
   },
   {
     "id": "vp_board_horizontal_front",
-    "fg": [ "vp_board_horizontal_front", "vp_board_horizontal_front_rotW", "vp_board_horizontal_front_rotS", "vp_board_horizontal_front_rotE" ],
+    "fg": [
+      "vp_board_horizontal_front",
+      "vp_board_horizontal_front_rotE",
+      "vp_board_horizontal_front_rotS",
+      "vp_board_horizontal_front_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_horizontal_rear_rotS", "vp_board_horizontal_front_rotW", "vp_board_horizontal_front_rotS", "vp_board_horizontal_front_rotE" ]
+        "bg": [
+          "vp_board_horizontal_rear_rotS",
+          "vp_board_horizontal_front_rotE",
+          "vp_board_horizontal_front_rotS",
+          "vp_board_horizontal_front_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_board_horizontal_rear",
-    "fg": [ "vp_board_horizontal_rear", "vp_board_horizontal_front_rotE", "vp_board_horizontal_rear_rotS", "vp_board_horizontal_front_rotW" ],
+    "fg": [
+      "vp_board_horizontal_rear",
+      "vp_board_horizontal_front_rotW",
+      "vp_board_horizontal_rear_rotS",
+      "vp_board_horizontal_front_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_horizontal_rear", "vp_board_horizontal_front_rotE", "vp_board_horizontal_rear_rotS", "vp_board_horizontal_front_rotW" ]
+        "bg": [
+          "vp_board_horizontal_rear",
+          "vp_board_horizontal_front_rotW",
+          "vp_board_horizontal_rear_rotS",
+          "vp_board_horizontal_front_rotE"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_board_vertical", "vp_board_vertical_2" ],
-    "fg": [ "vp_board_vertical_rotNS", "vp_board_horizontal_rear_rotS", "vp_board_vertical_rotNS", "vp_board_horizontal_rear_rotS" ],
+    "fg": [
+      "vp_board_vertical_rotNS",
+      "vp_board_horizontal_rear_rotS",
+      "vp_board_vertical_rotNS",
+      "vp_board_horizontal_rear_rotS"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_vertical_rotNS", "vp_board_horizontal_rear_rotS", "vp_board_vertical_rotNS", "vp_board_horizontal_rear_rotS" ]
+        "bg": [
+          "vp_board_vertical_rotNS",
+          "vp_board_horizontal_rear_rotS",
+          "vp_board_vertical_rotNS",
+          "vp_board_horizontal_rear_rotS"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/boards/edges/board_edges.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/boards/edges/board_edges.json
@@ -1,25 +1,25 @@
 [
   {
     "id": "vp_board_ne_edge",
-    "fg": [ "vp_board_ne", "vp_board_ne_edge_rotW", "vp_board_ne_rotS", "vp_board_ne_edge_rotE" ],
+    "fg": [ "vp_board_ne", "vp_board_ne_edge_rotE", "vp_board_ne_rotS", "vp_board_ne_edge_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_ne", "vp_board_ne_edge_rotW", "vp_board_ne_rotS", "vp_board_ne_edge_rotE" ]
+        "bg": [ "vp_board_ne", "vp_board_ne_edge_rotE", "vp_board_ne_rotS", "vp_board_ne_edge_rotW" ]
       }
     ]
   },
   {
     "id": "vp_board_nw_edge",
-    "fg": [ "vp_board_ne_rotW", "vp_board_nw_edge_rotW", "vp_board_nw_rotS", "vp_board_nw_edge_rotE" ],
+    "fg": [ "vp_board_ne_rotW", "vp_board_nw_edge_rotE", "vp_board_nw_rotS", "vp_board_nw_edge_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_board_ne_rotW", "vp_board_nw_edge_rotW", "vp_board_nw_rotS", "vp_board_nw_edge_rotE" ]
+        "bg": [ "vp_board_ne_rotW", "vp_board_nw_edge_rotE", "vp_board_nw_rotS", "vp_board_nw_edge_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/clothboard/clothboard.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/clothboard/clothboard.json
@@ -1,145 +1,225 @@
 [
   {
     "id": "vp_clothboard_ne",
-    "fg": [ "vp_clothboard_ne", "vp_clothboard_nw", "vp_clothboard_ne_rotS", "vp_clothboard_ne_rotE" ],
+    "fg": [ "vp_clothboard_ne", "vp_clothboard_ne_rotE", "vp_clothboard_ne_rotS", "vp_clothboard_nw" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_ne", "vp_clothboard_nw", "vp_clothboard_ne_rotS", "vp_clothboard_ne_rotE" ]
+        "bg": [ "vp_clothboard_ne", "vp_clothboard_ne_rotE", "vp_clothboard_ne_rotS", "vp_clothboard_nw" ]
       }
     ]
   },
   {
     "id": "vp_clothboard_nw",
-    "fg": [ "vp_clothboard_nw", "vp_clothboard_nw_rotW", "vp_clothboard_nw_rotS", "vp_clothboard_ne" ],
+    "fg": [ "vp_clothboard_nw", "vp_clothboard_ne", "vp_clothboard_nw_rotS", "vp_clothboard_nw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_nw", "vp_clothboard_nw_rotW", "vp_clothboard_nw_rotS", "vp_clothboard_ne" ]
+        "bg": [ "vp_clothboard_nw", "vp_clothboard_ne", "vp_clothboard_nw_rotS", "vp_clothboard_nw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_clothboard_se",
-    "fg": [ "vp_clothboard_se", "vp_clothboard_se_rotW", "vp_clothboard_nw", "vp_clothboard_se_rotE" ],
+    "fg": [ "vp_clothboard_se", "vp_clothboard_se_rotE", "vp_clothboard_nw", "vp_clothboard_se_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_se", "vp_clothboard_se_rotW", "vp_clothboard_nw", "vp_clothboard_se_rotE" ]
+        "bg": [ "vp_clothboard_se", "vp_clothboard_se_rotE", "vp_clothboard_nw", "vp_clothboard_se_rotW" ]
       }
     ]
   },
   {
     "id": "vp_clothboard_sw",
-    "fg": [ "vp_clothboard_sw", "vp_clothboard_sw_rotW", "vp_clothboard_ne", "vp_clothboard_sw_rotE" ],
+    "fg": [ "vp_clothboard_sw", "vp_clothboard_sw_rotE", "vp_clothboard_ne", "vp_clothboard_sw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_sw", "vp_clothboard_sw_rotW", "vp_clothboard_ne", "vp_clothboard_sw_rotE" ]
+        "bg": [ "vp_clothboard_sw", "vp_clothboard_sw_rotE", "vp_clothboard_ne", "vp_clothboard_sw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_clothboard_vertical_left",
-    "fg": [ "vp_clothboard_horizontal_front_rotW", "vp_clothboard_vertical_left_rotW_right_rotE", "vp_clothboard_horizontal_front_rotE", "vp_clothboard_horizontal_rear_rotS" ],
+    "fg": [
+      "vp_clothboard_horizontal_front_rotW",
+      "vp_clothboard_horizontal_rear_rotS",
+      "vp_clothboard_horizontal_front_rotE",
+      "vp_clothboard_vertical_left_rotW_right_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_horizontal_front_rotW", "vp_clothboard_vertical_left_rotW_right_rotE", "vp_clothboard_horizontal_front_rotE", "vp_clothboard_horizontal_rear_rotS" ]
+        "bg": [
+          "vp_clothboard_horizontal_front_rotW",
+          "vp_clothboard_horizontal_rear_rotS",
+          "vp_clothboard_horizontal_front_rotE",
+          "vp_clothboard_vertical_left_rotW_right_rotE"
+        ]
       }
     ]
   },
   {
     "id": "vp_clothboard_vertical_right",
-    "fg": [ "vp_clothboard_horizontal_front_rotE", "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_horizontal_front_rotW", "vp_clothboard_vertical_left_rotW_right_rotE" ],
+    "fg": [
+      "vp_clothboard_horizontal_front_rotE",
+      "vp_clothboard_vertical_left_rotW_right_rotE",
+      "vp_clothboard_horizontal_front_rotW",
+      "vp_clothboard_horizontal_rear_rotS"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_horizontal_front_rotE", "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_horizontal_front_rotW", "vp_clothboard_vertical_left_rotW_right_rotE" ]
+        "bg": [
+          "vp_clothboard_horizontal_front_rotE",
+          "vp_clothboard_vertical_left_rotW_right_rotE",
+          "vp_clothboard_horizontal_front_rotW",
+          "vp_clothboard_horizontal_rear_rotS"
+        ]
       }
     ]
   },
   {
     "id": "vp_clothboard_wheel_left",
-    "fg": [ "vp_clothboard_horizontal_front_rotW", "vp_clothboard_wheel_left_rotW_right_rotE", "vp_clothboard_horizontal_front_rotE", "vp_clothboard_horizontal_rear_rotS" ],
+    "fg": [
+      "vp_clothboard_horizontal_front_rotW",
+      "vp_clothboard_horizontal_rear_rotS",
+      "vp_clothboard_horizontal_front_rotE",
+      "vp_clothboard_wheel_left_rotW_right_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_horizontal_front_rotW", "vp_clothboard_wheel_left_rotW_right_rotE", "vp_clothboard_horizontal_front_rotE", "vp_clothboard_horizontal_rear_rotS" ]
+        "bg": [
+          "vp_clothboard_horizontal_front_rotW",
+          "vp_clothboard_horizontal_rear_rotS",
+          "vp_clothboard_horizontal_front_rotE",
+          "vp_clothboard_wheel_left_rotW_right_rotE"
+        ]
       }
     ]
   },
   {
     "id": "vp_clothboard_wheel_right",
-    "fg": [ "vp_clothboard_horizontal_front_rotE", "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_horizontal_front_rotW", "vp_clothboard_wheel_left_rotW_right_rotE" ],
+    "fg": [
+      "vp_clothboard_horizontal_front_rotE",
+      "vp_clothboard_wheel_left_rotW_right_rotE",
+      "vp_clothboard_horizontal_front_rotW",
+      "vp_clothboard_horizontal_rear_rotS"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_horizontal_front_rotE", "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_horizontal_front_rotW", "vp_clothboard_wheel_left_rotW_right_rotE" ]
+        "bg": [
+          "vp_clothboard_horizontal_front_rotE",
+          "vp_clothboard_wheel_left_rotW_right_rotE",
+          "vp_clothboard_horizontal_front_rotW",
+          "vp_clothboard_horizontal_rear_rotS"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_clothboard", "vp_clothboard_horizontal", "vp_clothboard_horizontal_2" ],
-    "fg": [ "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_vertical_rotNS", "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_vertical_rotNS" ],
+    "fg": [
+      "vp_clothboard_horizontal_rear_rotS",
+      "vp_clothboard_vertical_rotNS",
+      "vp_clothboard_horizontal_rear_rotS",
+      "vp_clothboard_vertical_rotNS"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_vertical_rotNS", "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_vertical_rotNS" ]
+        "bg": [
+          "vp_clothboard_horizontal_rear_rotS",
+          "vp_clothboard_vertical_rotNS",
+          "vp_clothboard_horizontal_rear_rotS",
+          "vp_clothboard_vertical_rotNS"
+        ]
       }
     ]
   },
   {
     "id": "vp_clothboard_horizontal_front",
-    "fg": [ "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_horizontal_front_rotW", "vp_clothboard_horizontal_front_rotS", "vp_clothboard_horizontal_front_rotE" ],
+    "fg": [
+      "vp_clothboard_horizontal_rear_rotS",
+      "vp_clothboard_horizontal_front_rotE",
+      "vp_clothboard_horizontal_front_rotS",
+      "vp_clothboard_horizontal_front_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_horizontal_front_rotW", "vp_clothboard_horizontal_front_rotS", "vp_clothboard_horizontal_front_rotE" ]
+        "bg": [
+          "vp_clothboard_horizontal_rear_rotS",
+          "vp_clothboard_horizontal_front_rotE",
+          "vp_clothboard_horizontal_front_rotS",
+          "vp_clothboard_horizontal_front_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_clothboard_horizontal_rear",
-    "fg": [ "vp_clothboard_horizontal_rear", "vp_clothboard_horizontal_front_rotE", "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_horizontal_front_rotW" ],
+    "fg": [
+      "vp_clothboard_horizontal_rear",
+      "vp_clothboard_horizontal_front_rotW",
+      "vp_clothboard_horizontal_rear_rotS",
+      "vp_clothboard_horizontal_front_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_horizontal_rear", "vp_clothboard_horizontal_front_rotE", "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_horizontal_front_rotW" ]
+        "bg": [
+          "vp_clothboard_horizontal_rear",
+          "vp_clothboard_horizontal_front_rotW",
+          "vp_clothboard_horizontal_rear_rotS",
+          "vp_clothboard_horizontal_front_rotE"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_clothboard_vertical", "vp_clothboard_vertical_2" ],
-    "fg": [ "vp_clothboard_vertical_rotNS", "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_vertical_rotNS", "vp_clothboard_horizontal_rear_rotS" ],
+    "fg": [
+      "vp_clothboard_vertical_rotNS",
+      "vp_clothboard_horizontal_rear_rotS",
+      "vp_clothboard_vertical_rotNS",
+      "vp_clothboard_horizontal_rear_rotS"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_vertical_rotNS", "vp_clothboard_horizontal_rear_rotS", "vp_clothboard_vertical_rotNS", "vp_clothboard_horizontal_rear_rotS" ]
+        "bg": [
+          "vp_clothboard_vertical_rotNS",
+          "vp_clothboard_horizontal_rear_rotS",
+          "vp_clothboard_vertical_rotNS",
+          "vp_clothboard_horizontal_rear_rotS"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/clothboard/edges/clothboard_edges.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/clothboard/edges/clothboard_edges.json
@@ -1,49 +1,49 @@
 [
   {
     "id": "vp_clothboard_ne_edge",
-    "fg": [ "vp_clothboard_ne", "vp_clothboard_ne_edge_rotW", "vp_clothboard_ne_rotS", "vp_clothboard_ne_edge_rotE" ],
+    "fg": [ "vp_clothboard_ne", "vp_clothboard_ne_edge_rotE", "vp_clothboard_ne_rotS", "vp_clothboard_ne_edge_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_ne", "vp_clothboard_ne_edge_rotW", "vp_clothboard_ne_rotS", "vp_clothboard_ne_edge_rotE" ]
+        "bg": [ "vp_clothboard_ne", "vp_clothboard_ne_edge_rotE", "vp_clothboard_ne_rotS", "vp_clothboard_ne_edge_rotW" ]
       }
     ]
   },
   {
     "id": "vp_clothboard_nw_edge",
-    "fg": [ "vp_clothboard_nw", "vp_clothboard_nw_edge_rotW", "vp_clothboard_nw_rotS", "vp_clothboard_nw_edge_rotE" ],
+    "fg": [ "vp_clothboard_nw", "vp_clothboard_nw_edge_rotE", "vp_clothboard_nw_rotS", "vp_clothboard_nw_edge_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_nw", "vp_clothboard_nw_edge_rotW", "vp_clothboard_nw_rotS", "vp_clothboard_nw_edge_rotE" ]
+        "bg": [ "vp_clothboard_nw", "vp_clothboard_nw_edge_rotE", "vp_clothboard_nw_rotS", "vp_clothboard_nw_edge_rotW" ]
       }
     ]
   },
   {
     "id": "vp_clothboard_se_edge",
-    "fg": [ "vp_clothboard_se", "vp_clothboard_se_edge_rotW", "vp_clothboard_nw", "vp_clothboard_se_edge_rotE" ],
+    "fg": [ "vp_clothboard_se", "vp_clothboard_se_edge_rotE", "vp_clothboard_nw", "vp_clothboard_se_edge_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_se", "vp_clothboard_se_edge_rotW", "vp_clothboard_nw", "vp_clothboard_se_edge_rotE" ]
+        "bg": [ "vp_clothboard_se", "vp_clothboard_se_edge_rotE", "vp_clothboard_nw", "vp_clothboard_se_edge_rotW" ]
       }
     ]
   },
   {
     "id": "vp_clothboard_sw_edge",
-    "fg": [ "vp_clothboard_sw", "vp_clothboard_sw_edge_rotW", "vp_clothboard_ne", "vp_clothboard_sw_edge_rotE" ],
+    "fg": [ "vp_clothboard_sw", "vp_clothboard_sw_edge_rotE", "vp_clothboard_ne", "vp_clothboard_sw_edge_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_clothboard_sw", "vp_clothboard_sw_edge_rotW", "vp_clothboard_ne", "vp_clothboard_sw_edge_rotE" ]
+        "bg": [ "vp_clothboard_sw", "vp_clothboard_sw_edge_rotE", "vp_clothboard_ne", "vp_clothboard_sw_edge_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/doors/vp_door_32x48.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/doors/vp_door_32x48.json
@@ -1,144 +1,152 @@
 [
   {
     "id": [ "vp_door_left", "vp_door_vertical_left" ],
-    "fg": [ "vp_door_L", "vp_door_L_rotW", "vp_door_L_rotS", "vp_door_L_rotE" ],
+    "fg": [ "vp_door_L", "vp_door_L_rotE", "vp_door_L_rotS", "vp_door_L_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_left_open_rotN", "vp_door_left_open_rotW", "vp_door_left_open_rotS", "vp_door_left_open_rotE" ]
+        "fg": [ "vp_door_left_open_rotN", "vp_door_left_open_rotE", "vp_door_left_open_rotS", "vp_door_left_open_rotW" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_door_left_open_rotN", "vp_door_left_open_rotW", "vp_door_left_open_rotS", "vp_door_left_open_rotE" ]
+        "bg": [ "vp_door_left_open_rotN", "vp_door_left_open_rotE", "vp_door_left_open_rotS", "vp_door_left_open_rotW" ]
       }
     ]
   },
   {
     "id": "vp_door_nw",
-    "fg": [ "vp_door_nw", "vp_door_nw_rotW", "vp_door_nw_rotS", "vp_door_nw_rotE" ],
+    "fg": [ "vp_door_nw", "vp_door_nw_rotE", "vp_door_nw_rotS", "vp_door_nw_rotW" ],
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "open",
-        "fg": [ "vp_door_nw_open", "vp_door_nw_open_rotW", "vp_door_nw_open_rotS", "vp_door_nw_open_rotE" ]
-      },
+      { "id": "open", "fg": [ "vp_door_nw_open", "vp_door_nw_open_rotE", "vp_door_nw_open_rotS", "vp_door_nw_open_rotW" ] },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_door_left_open_rotN", "vp_door_left_open_rotW", "vp_door_left_open_rotS", "vp_door_left_open_rotE" ]
+        "bg": [ "vp_door_left_open_rotN", "vp_door_left_open_rotE", "vp_door_left_open_rotS", "vp_door_left_open_rotW" ]
       }
     ]
   },
   {
     "id": "vp_door_front_left",
-    "fg": [ "vp_door_nw_mirrorless", "vp_door_nw_mirrorless_rotW", "vp_door_nw_mirrorless_rotS", "vp_door_nw_mirrorless_rotE" ],
+    "fg": [ "vp_door_nw_mirrorless", "vp_door_nw_mirrorless_rotE", "vp_door_nw_mirrorless_rotS", "vp_door_nw_mirrorless_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_nw_mirrorless_open", "vp_door_nw_mirrorless_open_rotW", "vp_door_nw_mirrorless_open_rotS", "vp_door_nw_mirrorless_open_rotE" ]
+        "fg": [
+          "vp_door_nw_mirrorless_open",
+          "vp_door_nw_mirrorless_open_rotE",
+          "vp_door_nw_mirrorless_open_rotS",
+          "vp_door_nw_mirrorless_open_rotW"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_door_nw_mirrorless_open", "vp_door_nw_mirrorless_open_rotW", "vp_door_nw_mirrorless_open_rotS", "vp_door_nw_mirrorless_open_rotE" ]
+        "bg": [
+          "vp_door_nw_mirrorless_open",
+          "vp_door_nw_mirrorless_open_rotE",
+          "vp_door_nw_mirrorless_open_rotS",
+          "vp_door_nw_mirrorless_open_rotW"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_door_sw", "vp_door_rear_left" ],
-    "fg": [ "vp_door_sw", "vp_door_sw_rotW", "vp_door_sw_rotS", "vp_door_sw_rotE" ],
+    "fg": [ "vp_door_sw", "vp_door_sw_rotE", "vp_door_sw_rotS", "vp_door_sw_rotW" ],
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "open",
-        "fg": [ "vp_door_sw_open", "vp_door_sw_open_rotW", "vp_door_sw_open_rotS", "vp_door_sw_open_rotE" ]
-      },
+      { "id": "open", "fg": [ "vp_door_sw_open", "vp_door_sw_open_rotE", "vp_door_sw_open_rotS", "vp_door_sw_open_rotW" ] },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_door_left_open_rotN", "vp_door_left_open_rotW", "vp_door_left_open_rotS", "vp_door_left_open_rotE" ]
+        "bg": [ "vp_door_left_open_rotN", "vp_door_left_open_rotE", "vp_door_left_open_rotS", "vp_door_left_open_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_door_right", "vp_door_vertical_right" ],
-    "fg": [ "vp_door_R", "vp_door_R_rotW", "vp_door_R_rotS", "vp_door_R_rotE" ],
+    "fg": [ "vp_door_R", "vp_door_R_rotE", "vp_door_R_rotS", "vp_door_R_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_right_open_rotN", "vp_door_right_open_rotW", "vp_door_right_open_rotS", "vp_door_right_open_rotE" ]
+        "fg": [ "vp_door_right_open_rotN", "vp_door_right_open_rotE", "vp_door_right_open_rotS", "vp_door_right_open_rotW" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_door_right_open_rotN", "vp_door_right_open_rotW", "vp_door_right_open_rotS", "vp_door_right_open_rotE" ]
+        "bg": [ "vp_door_right_open_rotN", "vp_door_right_open_rotE", "vp_door_right_open_rotS", "vp_door_right_open_rotW" ]
       }
     ]
   },
   {
     "id": "vp_door_ne",
-    "fg": [ "vp_door_ne", "vp_door_ne_rotW", "vp_door_ne_rotS", "vp_door_ne_rotE" ],
+    "fg": [ "vp_door_ne", "vp_door_ne_rotE", "vp_door_ne_rotS", "vp_door_ne_rotW" ],
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "open",
-        "fg": [ "vp_door_ne_open", "vp_door_ne_open_rotW", "vp_door_ne_open_rotS", "vp_door_ne_open_rotE" ]
-      },
+      { "id": "open", "fg": [ "vp_door_ne_open", "vp_door_ne_open_rotE", "vp_door_ne_open_rotS", "vp_door_ne_open_rotW" ] },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_door_right_open_rotN", "vp_door_right_open_rotW", "vp_door_right_open_rotS", "vp_door_right_open_rotE" ]
+        "bg": [ "vp_door_right_open_rotN", "vp_door_right_open_rotE", "vp_door_right_open_rotS", "vp_door_right_open_rotW" ]
       }
     ]
   },
   {
     "id": "vp_door_front_right",
-    "fg": [ "vp_door_ne_mirrorless", "vp_door_ne_mirrorless_rotW", "vp_door_ne_mirrorless_rotS", "vp_door_ne_mirrorless_rotE" ],
+    "fg": [ "vp_door_ne_mirrorless", "vp_door_ne_mirrorless_rotE", "vp_door_ne_mirrorless_rotS", "vp_door_ne_mirrorless_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_ne_mirrorless_open", "vp_door_ne_mirrorless_open_rotW", "vp_door_ne_mirrorless_open_rotS", "vp_door_ne_mirrorless_open_rotE" ]
+        "fg": [
+          "vp_door_ne_mirrorless_open",
+          "vp_door_ne_mirrorless_open_rotE",
+          "vp_door_ne_mirrorless_open_rotS",
+          "vp_door_ne_mirrorless_open_rotW"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_door_ne_mirrorless_open", "vp_door_ne_mirrorless_open_rotW", "vp_door_ne_mirrorless_open_rotS", "vp_door_ne_mirrorless_open_rotE" ]
+        "bg": [
+          "vp_door_ne_mirrorless_open",
+          "vp_door_ne_mirrorless_open_rotE",
+          "vp_door_ne_mirrorless_open_rotS",
+          "vp_door_ne_mirrorless_open_rotW"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_door_se", "vp_door_rear_right" ],
-    "fg": [ "vp_door_se", "vp_door_se_rotW", "vp_door_se_rotS", "vp_door_se_rotE" ],
+    "fg": [ "vp_door_se", "vp_door_se_rotE", "vp_door_se_rotS", "vp_door_se_rotW" ],
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "open",
-        "fg": [ "vp_door_se_open", "vp_door_se_open_rotW", "vp_door_se_open_rotS", "vp_door_se_open_rotE" ]
-      },
+      { "id": "open", "fg": [ "vp_door_se_open", "vp_door_se_open_rotE", "vp_door_se_open_rotS", "vp_door_se_open_rotW" ] },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_door_right_open_rotN", "vp_door_right_open_rotW", "vp_door_right_open_rotS", "vp_door_right_open_rotE" ]
+        "bg": [ "vp_door_right_open_rotN", "vp_door_right_open_rotE", "vp_door_right_open_rotS", "vp_door_right_open_rotW" ]
       }
     ]
   },
   {
     "id": "vp_door_opaque_left",
-    "fg": [ "vp_door_opaque_left_rotN", "vp_door_opaque_left_rotW", "vp_door_opaque_left_rotS", "vp_door_opaque_left_rotE" ],
+    "fg": [ "vp_door_opaque_left_rotN", "vp_door_opaque_left_rotE", "vp_door_opaque_left_rotS", "vp_door_opaque_left_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
         "fg": [
           "vp_door_opaque_left_open_rotN",
-          "vp_door_opaque_left_open_rotW",
+          "vp_door_opaque_left_open_rotE",
           "vp_door_opaque_left_open_rotS",
-          "vp_door_opaque_left_open_rotE"
+          "vp_door_opaque_left_open_rotW"
         ]
       },
       {
@@ -146,25 +154,25 @@
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
           "vp_door_opaque_left_open_rotN",
-          "vp_door_opaque_left_open_rotW",
+          "vp_door_opaque_left_open_rotE",
           "vp_door_opaque_left_open_rotS",
-          "vp_door_opaque_left_open_rotE"
+          "vp_door_opaque_left_open_rotW"
         ]
       }
     ]
   },
   {
     "id": "vp_door_opaque_right",
-    "fg": [ "vp_door_opaque_right_rotN", "vp_door_opaque_right_rotW", "vp_door_opaque_right_rotS", "vp_door_opaque_right_rotE" ],
+    "fg": [ "vp_door_opaque_right_rotN", "vp_door_opaque_right_rotE", "vp_door_opaque_right_rotS", "vp_door_opaque_right_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
         "fg": [
           "vp_door_opaque_right_open_rotN",
-          "vp_door_opaque_right_open_rotW",
+          "vp_door_opaque_right_open_rotE",
           "vp_door_opaque_right_open_rotS",
-          "vp_door_opaque_right_open_rotE"
+          "vp_door_opaque_right_open_rotW"
         ]
       },
       {
@@ -172,9 +180,9 @@
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
           "vp_door_opaque_right_open_rotN",
-          "vp_door_opaque_right_open_rotW",
+          "vp_door_opaque_right_open_rotE",
           "vp_door_opaque_right_open_rotS",
-          "vp_door_opaque_right_open_rotE"
+          "vp_door_opaque_right_open_rotW"
         ]
       }
     ]

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/halfboard/vp_halfboard.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/halfboard/vp_halfboard.json
@@ -1,49 +1,49 @@
 [
   {
     "id": "vp_halfboard_ne",
-    "fg": [ "vp_halfboard_ne", "vp_halfboard_ne_rotW", "vp_halfboard_ne_rotS", "vp_halfboard_ne_rotE" ],
+    "fg": [ "vp_halfboard_ne", "vp_halfboard_ne_rotE", "vp_halfboard_ne_rotS", "vp_halfboard_ne_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_halfboard_ne", "vp_halfboard_ne_rotW", "vp_halfboard_ne_rotS", "vp_halfboard_ne_rotE" ]
+        "bg": [ "vp_halfboard_ne", "vp_halfboard_ne_rotE", "vp_halfboard_ne_rotS", "vp_halfboard_ne_rotW" ]
       }
     ]
   },
   {
     "id": "vp_halfboard_nw",
-    "fg": [ "vp_halfboard_nw", "vp_halfboard_nw_rotW", "vp_halfboard_nw_rotS", "vp_halfboard_nw_rotE" ],
+    "fg": [ "vp_halfboard_nw", "vp_halfboard_nw_rotE", "vp_halfboard_nw_rotS", "vp_halfboard_nw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_halfboard_nw", "vp_halfboard_nw_rotW", "vp_halfboard_nw_rotS", "vp_halfboard_nw_rotE" ]
+        "bg": [ "vp_halfboard_nw", "vp_halfboard_nw_rotE", "vp_halfboard_nw_rotS", "vp_halfboard_nw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_halfboard_se",
-    "fg": [ "vp_halfboard_se", "vp_halfboard_se_rotW", "vp_halfboard_se_rotS", "vp_halfboard_se_rotE" ],
+    "fg": [ "vp_halfboard_se", "vp_halfboard_se_rotE", "vp_halfboard_se_rotS", "vp_halfboard_se_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_halfboard_se", "vp_halfboard_se_rotW", "vp_halfboard_se_rotS", "vp_halfboard_se_rotE" ]
+        "bg": [ "vp_halfboard_se", "vp_halfboard_se_rotE", "vp_halfboard_se_rotS", "vp_halfboard_se_rotW" ]
       }
     ]
   },
   {
     "id": "vp_halfboard_sw",
-    "fg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotW", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotE" ],
+    "fg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotE", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotW", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotE" ]
+        "bg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotE", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotW" ]
       }
     ]
   },
@@ -51,9 +51,9 @@
     "id": [ "vp_halfboard_vertical_left", "vp_halfboard_vertical_2_left" ],
     "fg": [
       "vp_halfboard_vertical_left",
-      "vp_halfboard_vertical_left_rotW_right_rotE",
+      "vp_halfboard_vertical_left_rotE_right_rotW",
       "vp_halfboard_vertical_right",
-      "vp_halfboard_vertical_left_rotE_right_rotW"
+      "vp_halfboard_vertical_left_rotW_right_rotE"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -61,11 +61,11 @@
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
-      "vp_halfboard_vertical_left",
-      "vp_halfboard_vertical_left_rotW_right_rotE",
-      "vp_halfboard_vertical_right",
-      "vp_halfboard_vertical_left_rotE_right_rotW"
-    ]
+          "vp_halfboard_vertical_left",
+          "vp_halfboard_vertical_left_rotE_right_rotW",
+          "vp_halfboard_vertical_right",
+          "vp_halfboard_vertical_left_rotW_right_rotE"
+        ]
       }
     ]
   },
@@ -73,9 +73,9 @@
     "id": [ "vp_halfboard_vertical_right", "vp_halfboard_vertical_2_right" ],
     "fg": [
       "vp_halfboard_vertical_right",
-      "vp_halfboard_vertical_left_rotE_right_rotW",
+      "vp_halfboard_vertical_left_rotW_right_rotE",
       "vp_halfboard_vertical_left",
-      "vp_halfboard_vertical_left_rotW_right_rotE"
+      "vp_halfboard_vertical_left_rotE_right_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -83,11 +83,11 @@
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
-      "vp_halfboard_vertical_right",
-      "vp_halfboard_vertical_left_rotE_right_rotW",
-      "vp_halfboard_vertical_left",
-      "vp_halfboard_vertical_left_rotW_right_rotE"
-    ]
+          "vp_halfboard_vertical_right",
+          "vp_halfboard_vertical_left_rotW_right_rotE",
+          "vp_halfboard_vertical_left",
+          "vp_halfboard_vertical_left_rotE_right_rotW"
+        ]
       }
     ]
   },
@@ -95,9 +95,9 @@
     "id": "vp_halfboard_vertical_t_left",
     "fg": [
       "vp_halfboard_vertical_t_left_rotN",
-      "vp_halfboard_vertical_t_left_rotW",
+      "vp_halfboard_vertical_t_left_rotE",
       "vp_halfboard_vertical_t_left_rotS",
-      "vp_halfboard_vertical_t_left_rotE"
+      "vp_halfboard_vertical_t_left_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -105,11 +105,11 @@
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
-      "vp_halfboard_vertical_t_left_rotN",
-      "vp_halfboard_vertical_t_left_rotW",
-      "vp_halfboard_vertical_t_left_rotS",
-      "vp_halfboard_vertical_t_left_rotE"
-    ]
+          "vp_halfboard_vertical_t_left_rotN",
+          "vp_halfboard_vertical_t_left_rotE",
+          "vp_halfboard_vertical_t_left_rotS",
+          "vp_halfboard_vertical_t_left_rotW"
+        ]
       }
     ]
   },
@@ -117,9 +117,9 @@
     "id": "vp_halfboard_vertical_t_right",
     "fg": [
       "vp_halfboard_vertical_t_right_rotN",
-      "vp_halfboard_vertical_t_right_rotW",
+      "vp_halfboard_vertical_t_right_rotE",
       "vp_halfboard_vertical_t_right_rotS",
-      "vp_halfboard_vertical_t_right_rotE"
+      "vp_halfboard_vertical_t_right_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -127,11 +127,11 @@
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
-      "vp_halfboard_vertical_t_right_rotN",
-      "vp_halfboard_vertical_t_right_rotW",
-      "vp_halfboard_vertical_t_right_rotS",
-      "vp_halfboard_vertical_t_right_rotE"
-    ]
+          "vp_halfboard_vertical_t_right_rotN",
+          "vp_halfboard_vertical_t_right_rotE",
+          "vp_halfboard_vertical_t_right_rotS",
+          "vp_halfboard_vertical_t_right_rotW"
+        ]
       }
     ]
   },
@@ -139,9 +139,9 @@
     "id": [ "vp_halfboard_horizontal", "vp_halfboard_horizontal_2" ],
     "fg": [
       "vp_halfboard_horizontal_rotN",
-      "vp_halfboard_horizontal_rotW",
+      "vp_halfboard_horizontal_rotE",
       "vp_halfboard_horizontal_rotS",
-      "vp_halfboard_horizontal_rotE"
+      "vp_halfboard_horizontal_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -149,11 +149,11 @@
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
-      "vp_halfboard_horizontal_rotN",
-      "vp_halfboard_horizontal_rotW",
-      "vp_halfboard_horizontal_rotS",
-      "vp_halfboard_horizontal_rotE"
-    ]
+          "vp_halfboard_horizontal_rotN",
+          "vp_halfboard_horizontal_rotE",
+          "vp_halfboard_horizontal_rotS",
+          "vp_halfboard_horizontal_rotW"
+        ]
       }
     ]
   },
@@ -161,9 +161,9 @@
     "id": [ "vp_halfboard_horizontal_front", "vp_halfboard_horizontal_2_front", "vp_halfboard_cover" ],
     "fg": [
       "vp_halfboard_horizontal_front",
-      "vp_halfboard_horizontal_front_rotW",
+      "vp_halfboard_horizontal_front_rotE",
       "vp_halfboard_horizontal_front_rotS",
-      "vp_halfboard_horizontal_front_rotE"
+      "vp_halfboard_horizontal_front_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -171,21 +171,21 @@
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
-      "vp_halfboard_horizontal_front",
-      "vp_halfboard_horizontal_front_rotW",
-      "vp_halfboard_horizontal_front_rotS",
-      "vp_halfboard_horizontal_front_rotE"
-    ]
+          "vp_halfboard_horizontal_front",
+          "vp_halfboard_horizontal_front_rotE",
+          "vp_halfboard_horizontal_front_rotS",
+          "vp_halfboard_horizontal_front_rotW"
+        ]
       }
     ]
   },
   {
-    "id": "vp_halfboard_horizontal_rear" ,
+    "id": "vp_halfboard_horizontal_rear",
     "fg": [
       "vp_halfboard_horizontal_rear",
-      "vp_halfboard_horizontal_rear_rotW",
+      "vp_halfboard_horizontal_rear_rotE",
       "vp_halfboard_horizontal_rear_rotS",
-      "vp_halfboard_horizontal_rear_rotE"
+      "vp_halfboard_horizontal_rear_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -193,11 +193,11 @@
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
-      "vp_halfboard_horizontal_rear",
-      "vp_halfboard_horizontal_rear_rotW",
-      "vp_halfboard_horizontal_rear_rotS",
-      "vp_halfboard_horizontal_rear_rotE"
-    ]
+          "vp_halfboard_horizontal_rear",
+          "vp_halfboard_horizontal_rear_rotE",
+          "vp_halfboard_horizontal_rear_rotS",
+          "vp_halfboard_horizontal_rear_rotW"
+        ]
       }
     ]
   },
@@ -215,11 +215,11 @@
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
-      "vp_halfboard_vertical_rotNS",
-      "vp_halfboard_vertical_rotEW",
-      "vp_halfboard_vertical_rotNS",
-      "vp_halfboard_vertical_rotEW"
-      ]
+          "vp_halfboard_vertical_rotNS",
+          "vp_halfboard_vertical_rotEW",
+          "vp_halfboard_vertical_rotNS",
+          "vp_halfboard_vertical_rotEW"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/halfboard/vp_halfboard_new.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/halfboard/vp_halfboard_new.json
@@ -1,49 +1,89 @@
 [
   {
     "id": "vp_halfboard_cover_left",
-    "fg": [ "vp_halfboard_cover_left", "vp_halfboard_cover_left_rotW", "vp_halfboard_cover_left_rotS", "vp_halfboard_cover_left_rotE" ],
+    "fg": [
+      "vp_halfboard_cover_left",
+      "vp_halfboard_cover_left_rotE",
+      "vp_halfboard_cover_left_rotS",
+      "vp_halfboard_cover_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_halfboard_cover_left", "vp_halfboard_cover_left_rotW", "vp_halfboard_cover_left_rotS", "vp_halfboard_cover_left_rotE" ]
+        "bg": [
+          "vp_halfboard_cover_left",
+          "vp_halfboard_cover_left_rotE",
+          "vp_halfboard_cover_left_rotS",
+          "vp_halfboard_cover_left_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_halfboard_cover_right",
-    "fg": [ "vp_halfboard_cover_right", "vp_halfboard_cover_right_rotW", "vp_halfboard_cover_right_rotS", "vp_halfboard_cover_right_rotE" ],
+    "fg": [
+      "vp_halfboard_cover_right",
+      "vp_halfboard_cover_right_rotE",
+      "vp_halfboard_cover_right_rotS",
+      "vp_halfboard_cover_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_halfboard_cover_right", "vp_halfboard_cover_right_rotW", "vp_halfboard_cover_right_rotS", "vp_halfboard_cover_right_rotE" ]
+        "bg": [
+          "vp_halfboard_cover_right",
+          "vp_halfboard_cover_right_rotE",
+          "vp_halfboard_cover_right_rotS",
+          "vp_halfboard_cover_right_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_halfboard_wheel_left",
-    "fg": [ "vp_halfboard_wheel_left", "vp_halfboard_wheel_left_rotW", "vp_halfboard_wheel_left_rotS", "vp_halfboard_wheel_left_rotE" ],
+    "fg": [
+      "vp_halfboard_wheel_left",
+      "vp_halfboard_wheel_left_rotE",
+      "vp_halfboard_wheel_left_rotS",
+      "vp_halfboard_wheel_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_halfboard_wheel_left", "vp_halfboard_wheel_left_rotW", "vp_halfboard_wheel_left_rotS", "vp_halfboard_wheel_left_rotE" ]
+        "bg": [
+          "vp_halfboard_wheel_left",
+          "vp_halfboard_wheel_left_rotE",
+          "vp_halfboard_wheel_left_rotS",
+          "vp_halfboard_wheel_left_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_halfboard_wheel_right",
-    "fg": [ "vp_halfboard_wheel_right", "vp_halfboard_wheel_right_rotW", "vp_halfboard_wheel_right_rotS", "vp_halfboard_wheel_right_rotE" ],
+    "fg": [
+      "vp_halfboard_wheel_right",
+      "vp_halfboard_wheel_right_rotE",
+      "vp_halfboard_wheel_right_rotS",
+      "vp_halfboard_wheel_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_halfboard_wheel_right", "vp_halfboard_wheel_right_rotW", "vp_halfboard_wheel_right_rotS", "vp_halfboard_wheel_right_rotE" ]
+        "bg": [
+          "vp_halfboard_wheel_right",
+          "vp_halfboard_wheel_right_rotE",
+          "vp_halfboard_wheel_right_rotS",
+          "vp_halfboard_wheel_right_rotW"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/hddoors/vp_hddoor.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/hddoors/vp_hddoor.json
@@ -1,17 +1,17 @@
 [
   {
     "id": "vp_hddoor_left",
-    "fg": [ "vp_hddoor_L_rotN", "vp_hddoor_L_rotW", "vp_hddoor_L_rotS", "vp_hddoor_L_rotE" ],
+    "fg": [ "vp_hddoor_L_rotN", "vp_hddoor_L_rotE", "vp_hddoor_L_rotS", "vp_hddoor_L_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hddoor_left_open_rotN", "vp_hddoor_left_open_rotW", "vp_hddoor_left_open_rotS", "vp_hddoor_left_open_rotE" ]
+        "fg": [ "vp_hddoor_left_open_rotN", "vp_hddoor_left_open_rotE", "vp_hddoor_left_open_rotS", "vp_hddoor_left_open_rotW" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hddoor_left_open_rotN", "vp_hddoor_left_open_rotW", "vp_hddoor_left_open_rotS", "vp_hddoor_left_open_rotE" ]
+        "bg": [ "vp_hddoor_left_open_rotN", "vp_hddoor_left_open_rotE", "vp_hddoor_left_open_rotS", "vp_hddoor_left_open_rotW" ]
       }
     ]
   },
@@ -22,12 +22,12 @@
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hddoor_right_open_rotN", "vp_hddoor_right_open_rotW", "vp_hddoor_right_open_rotS", "vp_hddoor_right_open_rotE" ]
+        "fg": [ "vp_hddoor_right_open_rotN", "vp_hddoor_right_open_rotE", "vp_hddoor_right_open_rotS", "vp_hddoor_right_open_rotW" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hddoor_right_open_rotN", "vp_hddoor_right_open_rotW", "vp_hddoor_right_open_rotS", "vp_hddoor_right_open_rotE" ]
+        "bg": [ "vp_hddoor_right_open_rotN", "vp_hddoor_right_open_rotE", "vp_hddoor_right_open_rotS", "vp_hddoor_right_open_rotW" ]
       }
     ]
   },
@@ -35,9 +35,9 @@
     "id": "vp_hddoor_opaque_left",
     "fg": [
       "vp_hddoor_opaque_left_rotN",
-      "vp_hddoor_opaque_left_rotW",
+      "vp_hddoor_opaque_left_rotE",
       "vp_hddoor_opaque_left_rotS",
-      "vp_hddoor_opaque_left_rotE"
+      "vp_hddoor_opaque_left_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -45,9 +45,9 @@
         "id": "open",
         "fg": [
           "vp_hddoor_opaque_left_open_rotN",
-          "vp_hddoor_opaque_left_open_rotW",
+          "vp_hddoor_opaque_left_open_rotE",
           "vp_hddoor_opaque_left_open_rotS",
-          "vp_hddoor_opaque_left_open_rotE"
+          "vp_hddoor_opaque_left_open_rotW"
         ]
       },
       {
@@ -55,9 +55,9 @@
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
           "vp_hddoor_opaque_left_open_rotN",
-          "vp_hddoor_opaque_left_open_rotW",
+          "vp_hddoor_opaque_left_open_rotE",
           "vp_hddoor_opaque_left_open_rotS",
-          "vp_hddoor_opaque_left_open_rotE"
+          "vp_hddoor_opaque_left_open_rotW"
         ]
       }
     ]
@@ -66,9 +66,9 @@
     "id": "vp_hddoor_opaque_right",
     "fg": [
       "vp_hddoor_opaque_right_rotN",
-      "vp_hddoor_opaque_right_rotW",
+      "vp_hddoor_opaque_right_rotE",
       "vp_hddoor_opaque_right_rotS",
-      "vp_hddoor_opaque_right_rotE"
+      "vp_hddoor_opaque_right_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -76,9 +76,9 @@
         "id": "open",
         "fg": [
           "vp_hddoor_opaque_right_open_rotN",
-          "vp_hddoor_opaque_right_open_rotW",
+          "vp_hddoor_opaque_right_open_rotE",
           "vp_hddoor_opaque_right_open_rotS",
-          "vp_hddoor_opaque_right_open_rotE"
+          "vp_hddoor_opaque_right_open_rotW"
         ]
       },
       {
@@ -86,9 +86,9 @@
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
           "vp_hddoor_opaque_right_open_rotN",
-          "vp_hddoor_opaque_right_open_rotW",
+          "vp_hddoor_opaque_right_open_rotE",
           "vp_hddoor_opaque_right_open_rotS",
-          "vp_hddoor_opaque_right_open_rotE"
+          "vp_hddoor_opaque_right_open_rotW"
         ]
       }
     ]

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/hddoors/vp_hddoor_full.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/hddoors/vp_hddoor_full.json
@@ -1,53 +1,47 @@
 [
   {
-    "id": [ "vp_hddoor_full_left", "vp_hddoor_full_vertical_left", "vp_hddoor_full_nw", "vp_hddoor_full_front_left", "vp_hddoor_full_sw", "vp_hddoor_full_rear_left" ],
-    "fg": [ "vp_hddoor_L_rotN", "vp_hddoor_L_rotW", "vp_hddoor_L_rotS", "vp_hddoor_L_rotE" ],
+    "id": [
+      "vp_hddoor_full_left",
+      "vp_hddoor_full_vertical_left",
+      "vp_hddoor_full_nw",
+      "vp_hddoor_full_front_left",
+      "vp_hddoor_full_sw",
+      "vp_hddoor_full_rear_left"
+    ],
+    "fg": [ "vp_hddoor_L_rotN", "vp_hddoor_L_rotE", "vp_hddoor_L_rotS", "vp_hddoor_L_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [
-          "vp_hddoor_left_open_rotN",
-          "vp_hddoor_left_open_rotW",
-          "vp_hddoor_left_open_rotS",
-          "vp_hddoor_left_open_rotE"
-        ]
+        "fg": [ "vp_hddoor_left_open_rotN", "vp_hddoor_left_open_rotE", "vp_hddoor_left_open_rotS", "vp_hddoor_left_open_rotW" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [
-          "vp_hddoor_left_open_rotN",
-          "vp_hddoor_left_open_rotW",
-          "vp_hddoor_left_open_rotS",
-          "vp_hddoor_left_open_rotE"
-        ]
+        "bg": [ "vp_hddoor_left_open_rotN", "vp_hddoor_left_open_rotE", "vp_hddoor_left_open_rotS", "vp_hddoor_left_open_rotW" ]
       }
     ]
   },
   {
-    "id": [ "vp_hddoor_full_right", "vp_hddoor_full_vertical_right", "vp_hddoor_full_ne", "vp_hddoor_full_front_right", "vp_hddoor_full_se", "vp_hddoor_full_rear_right" ],
-    "fg": [ "vp_hddoor_R_rotN", "vp_hddoor_R_rotW", "vp_hddoor_R_rotS", "vp_hddoor_R_rotE" ],
+    "id": [
+      "vp_hddoor_full_right",
+      "vp_hddoor_full_vertical_right",
+      "vp_hddoor_full_ne",
+      "vp_hddoor_full_front_right",
+      "vp_hddoor_full_se",
+      "vp_hddoor_full_rear_right"
+    ],
+    "fg": [ "vp_hddoor_R_rotN", "vp_hddoor_R_rotE", "vp_hddoor_R_rotS", "vp_hddoor_R_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [
-          "vp_hddoor_right_open_rotN",
-          "vp_hddoor_right_open_rotW",
-          "vp_hddoor_right_open_rotS",
-          "vp_hddoor_right_open_rotE"
-        ]
+        "fg": [ "vp_hddoor_right_open_rotN", "vp_hddoor_right_open_rotE", "vp_hddoor_right_open_rotS", "vp_hddoor_right_open_rotW" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [
-          "vp_hddoor_right_open_rotN",
-          "vp_hddoor_right_open_rotW",
-          "vp_hddoor_right_open_rotS",
-          "vp_hddoor_right_open_rotE"
-        ]
+        "bg": [ "vp_hddoor_right_open_rotN", "vp_hddoor_right_open_rotE", "vp_hddoor_right_open_rotS", "vp_hddoor_right_open_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/hddoors/vp_hddoor_opaque_full.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/hddoors/vp_hddoor_opaque_full.json
@@ -1,16 +1,21 @@
 [
   {
     "id": "vp_hddoor_opaque_full_left",
-    "fg": [ "vp_hddoor_opaque_left_rotN", "vp_hddoor_opaque_left_rotW", "vp_hddoor_opaque_left_rotS", "vp_hddoor_opaque_left_rotE" ],
+    "fg": [
+      "vp_hddoor_opaque_left_rotN",
+      "vp_hddoor_opaque_left_rotE",
+      "vp_hddoor_opaque_left_rotS",
+      "vp_hddoor_opaque_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
         "fg": [
           "vp_hddoor_opaque_left_open_rotN",
-          "vp_hddoor_opaque_left_open_rotW",
+          "vp_hddoor_opaque_left_open_rotE",
           "vp_hddoor_opaque_left_open_rotS",
-          "vp_hddoor_opaque_left_open_rotE"
+          "vp_hddoor_opaque_left_open_rotW"
         ]
       },
       {
@@ -18,25 +23,30 @@
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
           "vp_hddoor_opaque_left_open_rotN",
-          "vp_hddoor_opaque_left_open_rotW",
+          "vp_hddoor_opaque_left_open_rotE",
           "vp_hddoor_opaque_left_open_rotS",
-          "vp_hddoor_opaque_left_open_rotE"
+          "vp_hddoor_opaque_left_open_rotW"
         ]
       }
     ]
   },
   {
     "id": "vp_hddoor_opaque_full_right",
-    "fg": [ "vp_hddoor_opaque_right_rotN", "vp_hddoor_opaque_right_rotW", "vp_hddoor_opaque_right_rotS", "vp_hddoor_opaque_right_rotE" ],
+    "fg": [
+      "vp_hddoor_opaque_right_rotN",
+      "vp_hddoor_opaque_right_rotE",
+      "vp_hddoor_opaque_right_rotS",
+      "vp_hddoor_opaque_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
         "fg": [
           "vp_hddoor_opaque_right_open_rotN",
-          "vp_hddoor_opaque_right_open_rotW",
+          "vp_hddoor_opaque_right_open_rotE",
           "vp_hddoor_opaque_right_open_rotS",
-          "vp_hddoor_opaque_right_open_rotE"
+          "vp_hddoor_opaque_right_open_rotW"
         ]
       },
       {
@@ -44,9 +54,9 @@
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
           "vp_hddoor_opaque_right_open_rotN",
-          "vp_hddoor_opaque_right_open_rotW",
+          "vp_hddoor_opaque_right_open_rotE",
           "vp_hddoor_opaque_right_open_rotS",
-          "vp_hddoor_opaque_right_open_rotE"
+          "vp_hddoor_opaque_right_open_rotW"
         ]
       }
     ]

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/lights/lights.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/lights/lights.json
@@ -3,35 +3,23 @@
     "id": "vp_light_blue",
     "fg": [ "vp_light_blue", "vp_light_blue_rotWE" ],
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center_32x48",
-        "bg": [ "vp_light_blue", "vp_light_blue_rotWE" ]
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center_32x48", "bg": [ "vp_light_blue", "vp_light_blue_rotWE" ] } ]
   },
   {
     "id": "vp_light_red",
     "fg": [ "vp_light_red", "vp_light_red_rotWE" ],
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center_32x48",
-        "bg": [ "vp_light_red", "vp_light_red_rotWE" ]
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center_32x48", "bg": [ "vp_light_red", "vp_light_red_rotWE" ] } ]
   },
   {
     "id": [ "vp_floodlight", "vp_directed_floodlight" ],
-    "fg": [ "vp_floodlight_rotN", "vp_floodlight_rotW", "vp_floodlight_rotS", "vp_floodlight_rotE" ],
+    "fg": [ "vp_floodlight_rotN", "vp_floodlight_rotE", "vp_floodlight_rotS", "vp_floodlight_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center_32x48",
-        "bg": [ "vp_floodlight_rotN", "vp_floodlight_rotW", "vp_floodlight_rotS", "vp_floodlight_rotE" ]
+        "bg": [ "vp_floodlight_rotN", "vp_floodlight_rotE", "vp_floodlight_rotS", "vp_floodlight_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/scooter/saddle_scooter.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/scooter/saddle_scooter.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "vp_saddle_scooter",
-    "fg": [ "saddle_scooter_rotN", "saddle_scooter_rotW", "saddle_scooter_rotS", "saddle_scooter_rotE" ],
+    "fg": [ "saddle_scooter_rotN", "saddle_scooter_rotE", "saddle_scooter_rotS", "saddle_scooter_rotW" ],
     "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/seat_windshield/seat_windshield.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/seat_windshield/seat_windshield.json
@@ -1,7 +1,12 @@
 [
   {
     "id": [ "vp_seat_windshield_leather", "vp_reclining_seat_windshield_leather" ],
-    "fg": [ "vp_seat_leather_windshield_rotN", "vp_seat_leather_windshield_rotW", "vp_seat_leather_windshield_rotS", "vp_seat_leather_windshield_rotE" ],
+    "fg": [
+      "vp_seat_leather_windshield_rotN",
+      "vp_seat_leather_windshield_rotE",
+      "vp_seat_leather_windshield_rotS",
+      "vp_seat_leather_windshield_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
@@ -9,27 +14,22 @@
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
           "vp_seat_leather_windshield_rotN",
-          "vp_seat_leather_windshield_rotW",
+          "vp_seat_leather_windshield_rotE",
           "vp_seat_leather_windshield_rotS",
-          "vp_seat_leather_windshield_rotE"
+          "vp_seat_leather_windshield_rotW"
         ]
       }
     ]
   },
   {
     "id": [ "vp_seat_windshield", "vp_reclining_seat_windshield" ],
-    "fg": [ "vp_seat_windshield_rotN", "vp_seat_windshield_rotW", "vp_seat_windshield_rotS", "vp_seat_windshield_rotE" ],
+    "fg": [ "vp_seat_windshield_rotN", "vp_seat_windshield_rotE", "vp_seat_windshield_rotS", "vp_seat_windshield_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [
-          "vp_seat_windshield_rotN",
-          "vp_seat_windshield_rotW",
-          "vp_seat_windshield_rotS",
-          "vp_seat_windshield_rotE"
-        ]
+        "bg": [ "vp_seat_windshield_rotN", "vp_seat_windshield_rotE", "vp_seat_windshield_rotS", "vp_seat_windshield_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/vp_bed/vp_bed.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/vp_bed/vp_bed.json
@@ -1,14 +1,10 @@
 [
   {
     "id": "vp_bed",
-    "fg": [ "vp_bed_faceN", "vp_bed_faceW", "vp_bed_faceS", "vp_bed_faceE" ],
+    "fg": [ "vp_bed_faceN", "vp_bed_faceE", "vp_bed_faceS", "vp_bed_faceW" ],
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [ "vp_bed_faceN", "vp_bed_faceW", "vp_bed_faceS", "vp_bed_faceE" ]
-      }
+      { "id": "broken", "fg": "crack_metal_center", "bg": [ "vp_bed_faceN", "vp_bed_faceE", "vp_bed_faceS", "vp_bed_faceW" ] }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/windshield/aligns-to-boards/vp_windshield_full.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/windshield/aligns-to-boards/vp_windshield_full.json
@@ -1,72 +1,112 @@
 [
   {
     "id": [ "vp_windshield_full", "vp_windshield_full_horizontal_rear" ],
-    "fg": [ "vp_windshield_full_faceS", "vp_windshield_full_faceE", "vp_windshield_full_faceN", "vp_windshield_full_faceW" ],
+    "fg": [ "vp_windshield_full_faceS", "vp_windshield_full_faceW", "vp_windshield_full_faceN", "vp_windshield_full_faceE" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_right",
-        "bg": [ "vp_windshield_full_faceS", "vp_windshield_full_faceE", "vp_windshield_full_faceN", "vp_windshield_full_faceW" ]
+        "bg": [ "vp_windshield_full_faceS", "vp_windshield_full_faceW", "vp_windshield_full_faceN", "vp_windshield_full_faceE" ]
       }
     ],
     "multitile": true
   },
   {
     "id": "vp_windshield_full_horizontal_front",
-    "fg": [ "vp_windshield_full_faceN", "vp_windshield_full_faceW", "vp_windshield_full_faceS", "vp_windshield_full_faceE" ],
+    "fg": [ "vp_windshield_full_faceN", "vp_windshield_full_faceE", "vp_windshield_full_faceS", "vp_windshield_full_faceW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_right",
-        "bg": [ "vp_windshield_full_faceN", "vp_windshield_full_faceW", "vp_windshield_full_faceS", "vp_windshield_full_faceE" ]
+        "bg": [ "vp_windshield_full_faceN", "vp_windshield_full_faceE", "vp_windshield_full_faceS", "vp_windshield_full_faceW" ]
       }
     ],
     "multitile": true
   },
   {
     "id": [ "vp_windshield_full_vertical_left", "vp_windshield_full_left" ],
-    "fg": [ "vp_windshield_full_faceW", "vp_windshield_full_left_rotW_right_rotE", "vp_windshield_full_faceE", "vp_windshield_full_faceN" ],
+    "fg": [
+      "vp_windshield_full_faceW",
+      "vp_windshield_full_faceN",
+      "vp_windshield_full_faceE",
+      "vp_windshield_full_left_rotW_right_rotE"
+    ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_right",
-        "bg": [ "vp_windshield_full_faceW", "vp_windshield_full_left_rotW_right_rotE", "vp_windshield_full_faceE", "vp_windshield_full_faceN" ]
+        "bg": [
+          "vp_windshield_full_faceW",
+          "vp_windshield_full_faceN",
+          "vp_windshield_full_faceE",
+          "vp_windshield_full_left_rotW_right_rotE"
+        ]
       }
     ],
     "multitile": true
   },
   {
     "id": [ "vp_windshield_full_vertical_right", "vp_windshield_full_right" ],
-    "fg": [ "vp_windshield_full_faceE", "vp_windshield_full_faceN", "vp_windshield_full_faceW", "vp_windshield_full_left_rotW_right_rotE" ],
+    "fg": [
+      "vp_windshield_full_faceE",
+      "vp_windshield_full_left_rotW_right_rotE",
+      "vp_windshield_full_faceW",
+      "vp_windshield_full_faceN"
+    ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_right",
-        "bg": [ "vp_windshield_full_faceE", "vp_windshield_full_faceN", "vp_windshield_full_faceW", "vp_windshield_full_left_rotW_right_rotE" ]
+        "bg": [
+          "vp_windshield_full_faceE",
+          "vp_windshield_full_left_rotW_right_rotE",
+          "vp_windshield_full_faceW",
+          "vp_windshield_full_faceN"
+        ]
       }
     ],
     "multitile": true
   },
   {
     "id": "vp_windshield_full_wheel_left",
-    "fg": [ "vp_windshield_full_faceW", "vp_windshield_full_wheel_left_rotW_right_rotE", "vp_windshield_full_faceE", "vp_windshield_full_faceN" ],
+    "fg": [
+      "vp_windshield_full_faceW",
+      "vp_windshield_full_faceN",
+      "vp_windshield_full_faceE",
+      "vp_windshield_full_wheel_left_rotW_right_rotE"
+    ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_right",
-        "bg": [ "vp_windshield_full_faceW", "vp_windshield_full_wheel_left_rotW_right_rotE", "vp_windshield_full_faceE", "vp_windshield_full_faceN" ]
+        "bg": [
+          "vp_windshield_full_faceW",
+          "vp_windshield_full_faceN",
+          "vp_windshield_full_faceE",
+          "vp_windshield_full_wheel_left_rotW_right_rotE"
+        ]
       }
     ],
     "multitile": true
   },
   {
     "id": "vp_windshield_full_wheel_right",
-    "fg": [ "vp_windshield_full_faceE", "vp_windshield_full_faceN", "vp_windshield_full_faceW", "vp_windshield_full_wheel_left_rotW_right_rotE" ],
+    "fg": [
+      "vp_windshield_full_faceE",
+      "vp_windshield_full_wheel_left_rotW_right_rotE",
+      "vp_windshield_full_faceW",
+      "vp_windshield_full_faceN"
+    ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_right",
-        "bg": [ "vp_windshield_full_faceE", "vp_windshield_full_faceN", "vp_windshield_full_faceW", "vp_windshield_full_wheel_left_rotW_right_rotE" ]
+        "bg": [
+          "vp_windshield_full_faceE",
+          "vp_windshield_full_wheel_left_rotW_right_rotE",
+          "vp_windshield_full_faceW",
+          "vp_windshield_full_faceN"
+        ]
       }
     ],
     "multitile": true

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/windshield/edges/vp_windshield_edge.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/windshield/edges/vp_windshield_edge.json
@@ -3,9 +3,9 @@
     "id": "vp_windshield_horizontal_front_edge",
     "fg": [
       "vp_windshield_horizontal_front_edge_rotN",
-      "vp_windshield_horizontal_front_edge_rotW",
+      "vp_windshield_horizontal_front_edge_rotE",
       "vp_windshield_horizontal_front_edge_rotS",
-      "vp_windshield_horizontal_front_edge_rotE"
+      "vp_windshield_horizontal_front_edge_rotW"
     ],
     "additional_tiles": [
       {
@@ -13,9 +13,9 @@
         "fg": [ "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48" ],
         "bg": [
           "vp_windshield_horizontal_front_edge_rotN",
-          "vp_windshield_horizontal_front_edge_rotW",
+          "vp_windshield_horizontal_front_edge_rotE",
           "vp_windshield_horizontal_front_edge_rotS",
-          "vp_windshield_horizontal_front_edge_rotE"
+          "vp_windshield_horizontal_front_edge_rotW"
         ]
       }
     ],
@@ -25,9 +25,9 @@
     "id": "vp_windshield_horizontal_rear_edge",
     "fg": [
       "vp_windshield_rear_edge",
-      "vp_windshield_rear_edge_rotW",
+      "vp_windshield_rear_edge_rotE",
       "vp_windshield_rear_edge_rotS",
-      "vp_windshield_rear_edge_rotE"
+      "vp_windshield_rear_edge_rotW"
     ],
     "additional_tiles": [
       {
@@ -35,9 +35,9 @@
         "fg": [ "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48" ],
         "bg": [
           "vp_windshield_rear_edge",
-          "vp_windshield_rear_edge_rotW",
+          "vp_windshield_rear_edge_rotE",
           "vp_windshield_rear_edge_rotS",
-          "vp_windshield_rear_edge_rotE"
+          "vp_windshield_rear_edge_rotW"
         ]
       }
     ],
@@ -47,9 +47,9 @@
     "id": "vp_windshield_nw_edge",
     "fg": [
       "vp_windshield_nw_edge_rotN",
-      "vp_windshield_nw_edge_rotW",
+      "vp_windshield_nw_edge_rotE",
       "vp_windshield_nw_edge_rotS",
-      "vp_windshield_nw_edge_rotE"
+      "vp_windshield_nw_edge_rotW"
     ],
     "additional_tiles": [
       {
@@ -57,9 +57,9 @@
         "fg": [ "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48" ],
         "bg": [
           "vp_windshield_nw_edge_rotN",
-          "vp_windshield_nw_edge_rotW",
+          "vp_windshield_nw_edge_rotE",
           "vp_windshield_nw_edge_rotS",
-          "vp_windshield_nw_edge_rotE"
+          "vp_windshield_nw_edge_rotW"
         ]
       }
     ],
@@ -69,9 +69,9 @@
     "id": "vp_windshield_ne_edge",
     "fg": [
       "vp_windshield_ne_edge_rotN",
-      "vp_windshield_ne_edge_rotW",
+      "vp_windshield_ne_edge_rotE",
       "vp_windshield_ne_edge_rotS",
-      "vp_windshield_ne_edge_rotE"
+      "vp_windshield_ne_edge_rotW"
     ],
     "additional_tiles": [
       {
@@ -79,9 +79,9 @@
         "fg": [ "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48" ],
         "bg": [
           "vp_windshield_ne_edge_rotN",
-          "vp_windshield_ne_edge_rotW",
+          "vp_windshield_ne_edge_rotE",
           "vp_windshield_ne_edge_rotS",
-          "vp_windshield_ne_edge_rotE"
+          "vp_windshield_ne_edge_rotW"
         ]
       }
     ],
@@ -89,25 +89,25 @@
   },
   {
     "id": "vp_windshield_sw_edge",
-    "fg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotW", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotE" ],
+    "fg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotE", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48" ],
-        "bg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotW", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotE" ]
+        "bg": [ "vp_halfboard_sw", "vp_halfboard_sw_rotE", "vp_halfboard_sw_rotS", "vp_halfboard_sw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_windshield_se_edge",
-    "fg": [ "vp_halfboard_se", "vp_halfboard_se_rotW", "vp_halfboard_se_rotS", "vp_halfboard_se_rotE" ],
+    "fg": [ "vp_halfboard_se", "vp_halfboard_se_rotE", "vp_halfboard_se_rotS", "vp_halfboard_se_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48" ],
-        "bg": [ "vp_halfboard_se", "vp_halfboard_se_rotW", "vp_halfboard_se_rotS", "vp_halfboard_se_rotE" ]
+        "bg": [ "vp_halfboard_se", "vp_halfboard_se_rotE", "vp_halfboard_se_rotS", "vp_halfboard_se_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/windshield/vp_windshield.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/windshield/vp_windshield.json
@@ -3,9 +3,9 @@
     "id": [ "vp_windshield", "vp_windshield_horizontal", "vp_windshield_horizontal_front", "vp_windshield_front_edge" ],
     "fg": [
       "vp_windshield_horizontal",
-      "vp_windshield_horizontal_rotW",
+      "vp_windshield_horizontal_rotE",
       "vp_windshield_horizontal_rotS",
-      "vp_windshield_horizontal_rotE"
+      "vp_windshield_horizontal_rotW"
     ],
     "additional_tiles": [
       {
@@ -13,9 +13,9 @@
         "fg": [ "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48" ],
         "bg": [
           "vp_windshield_horizontal",
-          "vp_windshield_horizontal_rotW",
+          "vp_windshield_horizontal_rotE",
           "vp_windshield_horizontal_rotS",
-          "vp_windshield_horizontal_rotE"
+          "vp_windshield_horizontal_rotW"
         ]
       }
     ],
@@ -23,87 +23,84 @@
   },
   {
     "id": "vp_windshield_horizontal_rear",
-    "fg": [ "vp_windshield_rear_rotNS", "vp_windshield_rear_rotW", "vp_windshield_rear_rotNS", "vp_windshield_rear_rotE" ],
+    "fg": [ "vp_windshield_rear_rotNS", "vp_windshield_rear_rotE", "vp_windshield_rear_rotNS", "vp_windshield_rear_rotW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48", "crack_glass_center_32x48" ],
-        "bg": [ "vp_windshield_rear_rotNS", "vp_windshield_rear_rotW", "vp_windshield_rear_rotNS", "vp_windshield_rear_rotE" ]
+        "bg": [ "vp_windshield_rear_rotNS", "vp_windshield_rear_rotE", "vp_windshield_rear_rotNS", "vp_windshield_rear_rotW" ]
       }
     ],
     "multitile": true
   },
   {
     "id": "vp_windshield_nw",
-    "fg": [ "vp_windshield_nw", "vp_windshield_nw_rotW", "vp_windshield_nw_rotS", "vp_windshield_nw_rotE" ],
+    "fg": [ "vp_windshield_nw", "vp_windshield_nw_rotE", "vp_windshield_nw_rotS", "vp_windshield_nw_rotW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_glass_right_32x48", "crack_glass_right_32x48", "crack_glass_right_32x48", "crack_glass_right_32x48" ],
-        "bg": [ "vp_windshield_nw", "vp_windshield_nw_rotW", "vp_windshield_nw_rotS", "vp_windshield_nw_rotE" ]
+        "bg": [ "vp_windshield_nw", "vp_windshield_nw_rotE", "vp_windshield_nw_rotS", "vp_windshield_nw_rotW" ]
       }
     ],
     "multitile": true
   },
   {
     "id": "vp_windshield_ne",
-    "fg": [ "vp_windshield_ne", "vp_windshield_ne_rotW", "vp_windshield_ne_rotS", "vp_windshield_ne_rotE" ],
+    "fg": [ "vp_windshield_ne", "vp_windshield_ne_rotE", "vp_windshield_ne_rotS", "vp_windshield_ne_rotW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_glass_left_32x48", "crack_glass_left_32x48", "crack_glass_left_32x48", "crack_glass_left_32x48" ],
-        "bg": [ "vp_windshield_ne", "vp_windshield_ne_rotW", "vp_windshield_ne_rotS", "vp_windshield_ne_rotE" ]
+        "bg": [ "vp_windshield_ne", "vp_windshield_ne_rotE", "vp_windshield_ne_rotS", "vp_windshield_ne_rotW" ]
       }
     ],
     "multitile": true
   },
   {
     "id": "vp_windshield_sw",
-    "fg": [ "vp_windshield_left", "vp_windshield_left_rotW", "vp_windshield_right", "vp_windshield_left_rotE" ],
+    "fg": [ "vp_windshield_left", "vp_windshield_left_rotE", "vp_windshield_right", "vp_windshield_left_rotW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_glass_right_32x48", "crack_glass_right_32x48", "crack_glass_right_32x48", "crack_glass_right_32x48" ],
-        "bg": [ "vp_windshield_left", "vp_windshield_left_rotW", "vp_windshield_right", "vp_windshield_left_rotE" ]
+        "bg": [ "vp_windshield_left", "vp_windshield_left_rotE", "vp_windshield_right", "vp_windshield_left_rotW" ]
       }
     ],
     "multitile": true
   },
   {
     "id": "vp_windshield_se",
-    "fg": [ "vp_windshield_left_rotS", "vp_windshield_right_rotW", "vp_windshield_left", "vp_windshield_right_rotE" ],
+    "fg": [ "vp_windshield_left_rotS", "vp_windshield_right_rotE", "vp_windshield_left", "vp_windshield_right_rotW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_glass_left_32x48", "crack_glass_left_32x48", "crack_glass_left_32x48", "crack_glass_left_32x48" ],
-        "bg": [ "vp_windshield_left_rotS", "vp_windshield_right_rotW", "vp_windshield_left", "vp_windshield_right_rotE" ]
+        "bg": [ "vp_windshield_left_rotS", "vp_windshield_right_rotE", "vp_windshield_left", "vp_windshield_right_rotW" ]
       }
     ],
     "multitile": true
   },
   {
     "id": [ "vp_windshield_vertical_left", "vp_windshield_left" ],
-    "fg": [ "vp_windshield_left", "vp_windshield_left_rotW", "vp_windshield_left_rotS", "vp_windshield_left_rotE" ],
+    "fg": [ "vp_windshield_left", "vp_windshield_left_rotE", "vp_windshield_left_rotS", "vp_windshield_left_rotW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_glass_left_32x48", "crack_glass_left_32x48", "crack_glass_left_32x48", "crack_glass_left_32x48" ],
-        "bg": ["vp_windshield_left", "vp_windshield_left_rotW", "vp_windshield_left_rotS", "vp_windshield_left_rotE"
-        ]
+        "bg": [ "vp_windshield_left", "vp_windshield_left_rotE", "vp_windshield_left_rotS", "vp_windshield_left_rotW" ]
       }
     ],
     "multitile": true
   },
   {
     "id": [ "vp_windshield_vertical_right", "vp_windshield_right" ],
-    "fg": [ "vp_windshield_right", "vp_windshield_right_rotW", "vp_windshield_right_rotS", "vp_windshield_right_rotE" ],
+    "fg": [ "vp_windshield_right", "vp_windshield_right_rotE", "vp_windshield_right_rotS", "vp_windshield_right_rotW" ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_glass_right_32x48", "crack_glass_right_32x48", "crack_glass_right_32x48", "crack_glass_right_32x48" ],
-        "bg": [
-         "vp_windshield_right", "vp_windshield_right_rotW", "vp_windshield_right_rotS", "vp_windshield_right_rotE"
-        ]
+        "bg": [ "vp_windshield_right", "vp_windshield_right_rotE", "vp_windshield_right_rotS", "vp_windshield_right_rotW" ]
       }
     ],
     "multitile": true

--- a/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/windshield/vp_windshield_new.json
+++ b/gfx/UltimateCataclysm/pngs_human_body_plus_32x48/vehicle/windshield/vp_windshield_new.json
@@ -1,74 +1,131 @@
 [
   {
-    "id": "vp_windshield_cover_left" ,
-    "fg": [ "vp_windshield_cover_left", "vp_windshield_cover_left_rotW", "vp_windshield_cover_left_rotS", "vp_windshield_cover_left_rotE" ],
+    "id": "vp_windshield_cover_left",
+    "fg": [
+      "vp_windshield_cover_left",
+      "vp_windshield_cover_left_rotE",
+      "vp_windshield_cover_left_rotS",
+      "vp_windshield_cover_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_windshield_cover_left", "vp_windshield_cover_left_rotW", "vp_windshield_cover_left_rotS", "vp_windshield_cover_left_rotE" ]
+        "bg": [
+          "vp_windshield_cover_left",
+          "vp_windshield_cover_left_rotE",
+          "vp_windshield_cover_left_rotS",
+          "vp_windshield_cover_left_rotW"
+        ]
       }
     ]
   },
   {
-    "id": "vp_windshield_cover_right" ,
-    "fg": [ "vp_windshield_cover_right", "vp_windshield_cover_right_rotW", "vp_windshield_cover_right_rotS", "vp_windshield_cover_right_rotE" ],
+    "id": "vp_windshield_cover_right",
+    "fg": [
+      "vp_windshield_cover_right",
+      "vp_windshield_cover_right_rotE",
+      "vp_windshield_cover_right_rotS",
+      "vp_windshield_cover_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_windshield_cover_right", "vp_windshield_cover_right_rotW", "vp_windshield_cover_right_rotS", "vp_windshield_cover_right_rotE" ]
+        "bg": [
+          "vp_windshield_cover_right",
+          "vp_windshield_cover_right_rotE",
+          "vp_windshield_cover_right_rotS",
+          "vp_windshield_cover_right_rotW"
+        ]
       }
     ]
   },
   {
-    "id": "vp_windshield_wheel_left" ,
-    "fg": [ "vp_windshield_wheel_left", "vp_windshield_wheel_left_rotW", "vp_windshield_wheel_left_rotS", "vp_windshield_wheel_left_rotE" ],
+    "id": "vp_windshield_wheel_left",
+    "fg": [
+      "vp_windshield_wheel_left",
+      "vp_windshield_wheel_left_rotE",
+      "vp_windshield_wheel_left_rotS",
+      "vp_windshield_wheel_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_windshield_wheel_left", "vp_windshield_wheel_left_rotW", "vp_windshield_wheel_left_rotS", "vp_windshield_wheel_left_rotE" ]
+        "bg": [
+          "vp_windshield_wheel_left",
+          "vp_windshield_wheel_left_rotE",
+          "vp_windshield_wheel_left_rotS",
+          "vp_windshield_wheel_left_rotW"
+        ]
       }
     ]
   },
   {
-    "id": "vp_windshield_wheel_right" ,
-    "fg": [ "vp_windshield_wheel_right", "vp_windshield_wheel_right_rotW", "vp_windshield_wheel_right_rotS", "vp_windshield_wheel_right_rotE" ],
+    "id": "vp_windshield_wheel_right",
+    "fg": [
+      "vp_windshield_wheel_right",
+      "vp_windshield_wheel_right_rotE",
+      "vp_windshield_wheel_right_rotS",
+      "vp_windshield_wheel_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_windshield_wheel_right", "vp_windshield_wheel_right_rotW", "vp_windshield_wheel_right_rotS", "vp_windshield_wheel_right_rotE" ]
+        "bg": [
+          "vp_windshield_wheel_right",
+          "vp_windshield_wheel_right_rotE",
+          "vp_windshield_wheel_right_rotS",
+          "vp_windshield_wheel_right_rotW"
+        ]
       }
     ]
   },
   {
-    "id": "vp_windshield_vertical_2_left" ,
-    "fg": [ "vp_windshield_left", "vp_windshield_vertical_2_left_rotW_right_rotE", "vp_windshield_left_rotS", "vp_windshield_left_rotE" ],
+    "id": "vp_windshield_vertical_2_left",
+    "fg": [
+      "vp_windshield_left",
+      "vp_windshield_left_rotE",
+      "vp_windshield_left_rotS",
+      "vp_windshield_vertical_2_left_rotW_right_rotE"
+    ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_glass_left_32x48", "crack_glass_left_32x48", "crack_glass_left_32x48", "crack_glass_left_32x48" ],
-        "bg": ["vp_windshield_left", "vp_windshield_vertical_2_left_rotW_right_rotE", "vp_windshield_left_rotS", "vp_windshield_left_rotE"
+        "bg": [
+          "vp_windshield_left",
+          "vp_windshield_left_rotE",
+          "vp_windshield_left_rotS",
+          "vp_windshield_vertical_2_left_rotW_right_rotE"
         ]
       }
     ],
     "multitile": true
   },
   {
-    "id": "vp_windshield_vertical_2_right" ,
-    "fg": [ "vp_windshield_right", "vp_windshield_right_rotW", "vp_windshield_right_rotS", "vp_windshield_vertical_2_left_rotW_right_rotE" ],
+    "id": "vp_windshield_vertical_2_right",
+    "fg": [
+      "vp_windshield_right",
+      "vp_windshield_vertical_2_left_rotW_right_rotE",
+      "vp_windshield_right_rotS",
+      "vp_windshield_right_rotW"
+    ],
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_glass_right_32x48", "crack_glass_right_32x48", "crack_glass_right_32x48", "crack_glass_right_32x48" ],
         "bg": [
-         "vp_windshield_right", "vp_windshield_right_rotW", "vp_windshield_right_rotS", "vp_windshield_vertical_2_left_rotW_right_rotE"
+          "vp_windshield_right",
+          "vp_windshield_vertical_2_left_rotW_right_rotE",
+          "vp_windshield_right_rotS",
+          "vp_windshield_right_rotW"
         ]
       }
     ],

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/fields/blood/fd_blood/fd_blood.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/fields/blood/fd_blood/fd_blood.json
@@ -4,56 +4,23 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "fd_blood_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "fd_blood_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "fd_blood_corner_nw",
-        "fd_blood_corner_sw",
-        "fd_blood_corner_se",
-        "fd_blood_corner_ne"
-      ],
+      "fg": [ "fd_blood_corner_nw", "fd_blood_corner_ne", "fd_blood_corner_se", "fd_blood_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
-      "fg": [
-        "fd_blood_t_connection_n",
-        "fd_blood_t_connection_w",
-        "fd_blood_t_connection_s",
-        "fd_blood_t_connection_e"
-      ],
+      "fg": [ "fd_blood_t_connection_n", "fd_blood_t_connection_e", "fd_blood_t_connection_s", "fd_blood_t_connection_w" ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "fd_blood_edge_ns",
-        "fd_blood_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "fd_blood_edge_ns", "fd_blood_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "fd_blood_end_piece_n",
-        "fd_blood_end_piece_w",
-        "fd_blood_end_piece_s",
-        "fd_blood_end_piece_e"
-      ],
+      "fg": [ "fd_blood_end_piece_n", "fd_blood_end_piece_e", "fd_blood_end_piece_s", "fd_blood_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "fd_blood_unconnected",
-        "fd_blood_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "fd_blood_unconnected", "fd_blood_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/fields/blood/fd_blood_insect.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/fields/blood/fd_blood_insect.json
@@ -1,59 +1,39 @@
 {
-  "id": ["fd_blood_insect", "fd_blood_invertebrate"],
+  "id": [
+    "fd_blood_insect",
+    "fd_blood_invertebrate"
+  ],
   "fg": "fd_blood_insect_unconnected",
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "fd_blood_insect_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "fd_blood_insect_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "fd_blood_insect_corner_nw",
-        "fd_blood_insect_corner_sw",
-        "fd_blood_insect_corner_se",
-        "fd_blood_insect_corner_ne"
-      ],
+      "fg": [ "fd_blood_insect_corner_nw", "fd_blood_insect_corner_ne", "fd_blood_insect_corner_se", "fd_blood_insect_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
       "fg": [
         "fd_blood_insect_t_connection_n",
-        "fd_blood_insect_t_connection_w",
+        "fd_blood_insect_t_connection_e",
         "fd_blood_insect_t_connection_s",
-        "fd_blood_insect_t_connection_e"
+        "fd_blood_insect_t_connection_w"
       ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "fd_blood_insect_edge_ns",
-        "fd_blood_insect_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "fd_blood_insect_edge_ns", "fd_blood_insect_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
       "fg": [
         "fd_blood_insect_end_piece_n",
-        "fd_blood_insect_end_piece_w",
+        "fd_blood_insect_end_piece_e",
         "fd_blood_insect_end_piece_s",
-        "fd_blood_insect_end_piece_e"
+        "fd_blood_insect_end_piece_w"
       ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "fd_blood_insect_unconnected",
-        "fd_blood_insect_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "fd_blood_insect_unconnected", "fd_blood_insect_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/fields/blood/fd_blood_int1/fd_blood_int1.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/fields/blood/fd_blood_int1/fd_blood_int1.json
@@ -4,56 +4,28 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "fd_blood_int1_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "fd_blood_int1_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "fd_blood_int1_corner_nw",
-        "fd_blood_int1_corner_sw",
-        "fd_blood_int1_corner_se",
-        "fd_blood_int1_corner_ne"
-      ],
+      "fg": [ "fd_blood_int1_corner_nw", "fd_blood_int1_corner_ne", "fd_blood_int1_corner_se", "fd_blood_int1_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
       "fg": [
         "fd_blood_int1_t_connection_n",
-        "fd_blood_int1_t_connection_w",
+        "fd_blood_int1_t_connection_e",
         "fd_blood_int1_t_connection_s",
-        "fd_blood_int1_t_connection_e"
+        "fd_blood_int1_t_connection_w"
       ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "fd_blood_int1_edge_ns",
-        "fd_blood_int1_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "fd_blood_int1_edge_ns", "fd_blood_int1_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "fd_blood_int1_end_piece_n",
-        "fd_blood_int1_end_piece_w",
-        "fd_blood_int1_end_piece_s",
-        "fd_blood_int1_end_piece_e"
-      ],
+      "fg": [ "fd_blood_int1_end_piece_n", "fd_blood_int1_end_piece_e", "fd_blood_int1_end_piece_s", "fd_blood_int1_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "fd_blood_int1_unconnected",
-        "fd_blood_int1_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "fd_blood_int1_unconnected", "fd_blood_int1_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/fields/blood/fd_blood_int2/fd_blood_int2.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/fields/blood/fd_blood_int2/fd_blood_int2.json
@@ -4,56 +4,28 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "fd_blood_int2_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "fd_blood_int2_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "fd_blood_int2_corner_nw",
-        "fd_blood_int2_corner_sw",
-        "fd_blood_int2_corner_se",
-        "fd_blood_int2_corner_ne"
-      ],
+      "fg": [ "fd_blood_int2_corner_nw", "fd_blood_int2_corner_ne", "fd_blood_int2_corner_se", "fd_blood_int2_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
       "fg": [
         "fd_blood_int2_t_connection_n",
-        "fd_blood_int2_t_connection_w",
+        "fd_blood_int2_t_connection_e",
         "fd_blood_int2_t_connection_s",
-        "fd_blood_int2_t_connection_e"
+        "fd_blood_int2_t_connection_w"
       ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "fd_blood_int2_edge_ns",
-        "fd_blood_int2_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "fd_blood_int2_edge_ns", "fd_blood_int2_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "fd_blood_int2_end_piece_n",
-        "fd_blood_int2_end_piece_w",
-        "fd_blood_int2_end_piece_s",
-        "fd_blood_int2_end_piece_e"
-      ],
+      "fg": [ "fd_blood_int2_end_piece_n", "fd_blood_int2_end_piece_e", "fd_blood_int2_end_piece_s", "fd_blood_int2_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "fd_blood_int2_unconnected",
-        "fd_blood_int2_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "fd_blood_int2_unconnected", "fd_blood_int2_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/fields/blood/fd_blood_int3/fd_blood_int3.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/fields/blood/fd_blood_int3/fd_blood_int3.json
@@ -4,56 +4,28 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "fd_blood_int3_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "fd_blood_int3_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "fd_blood_int3_corner_nw",
-        "fd_blood_int3_corner_sw",
-        "fd_blood_int3_corner_se",
-        "fd_blood_int3_corner_ne"
-      ],
+      "fg": [ "fd_blood_int3_corner_nw", "fd_blood_int3_corner_ne", "fd_blood_int3_corner_se", "fd_blood_int3_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
       "fg": [
         "fd_blood_int3_t_connection_n",
-        "fd_blood_int3_t_connection_w",
+        "fd_blood_int3_t_connection_e",
         "fd_blood_int3_t_connection_s",
-        "fd_blood_int3_t_connection_e"
+        "fd_blood_int3_t_connection_w"
       ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "fd_blood_int3_edge_ns",
-        "fd_blood_int3_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "fd_blood_int3_edge_ns", "fd_blood_int3_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "fd_blood_int3_end_piece_n",
-        "fd_blood_int3_end_piece_w",
-        "fd_blood_int3_end_piece_s",
-        "fd_blood_int3_end_piece_e"
-      ],
+      "fg": [ "fd_blood_int3_end_piece_n", "fd_blood_int3_end_piece_e", "fd_blood_int3_end_piece_s", "fd_blood_int3_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "fd_blood_int3_unconnected",
-        "fd_blood_int3_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "fd_blood_int3_unconnected", "fd_blood_int3_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/furniture/f_sink/f_sink.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/furniture/f_sink/f_sink.json
@@ -4,58 +4,27 @@
   "fg": "f_sink_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_sink_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_sink_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_sink_corner_nw",
-        "f_sink_corner_sw",
-        "f_sink_corner_se",
-        "f_sink_corner_ne"
-      ]
+      "fg": [ "f_sink_corner_nw", "f_sink_corner_ne", "f_sink_corner_se", "f_sink_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "f_sink_t_connection_n",
-        "f_sink_t_connection_w",
-        "f_sink_t_connection_s",
-        "f_sink_t_connection_e"
-      ]
+      "fg": [ "f_sink_t_connection_n", "f_sink_t_connection_e", "f_sink_t_connection_s", "f_sink_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_sink_edge_ns",
-        "f_sink_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_sink_edge_ns", "f_sink_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_sink_end_piece_n",
-        "f_sink_end_piece_w",
-        "f_sink_end_piece_s",
-        "f_sink_end_piece_e"
-      ]
+      "fg": [ "f_sink_end_piece_n", "f_sink_end_piece_e", "f_sink_end_piece_s", "f_sink_end_piece_w" ]
     },
     {
       "bg": "",
       "id": "unconnected",
-      "fg": [ 
-        "f_sink_unconnected",
-        "f_sink_unconnected",
-        "f_sink_unconnected",
-        "f_sink_unconnected"
-      ]
+      "fg": [ "f_sink_unconnected", "f_sink_unconnected", "f_sink_unconnected", "f_sink_unconnected" ]
     }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/magiclysm/t_demon_web_wall/t_demon_web_wall.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/magiclysm/t_demon_web_wall/t_demon_web_wall.json
@@ -8,18 +8,18 @@
       "id": "corner",
       "fg": [
         "t_demon_web_wall_corner_nw",
-        "t_demon_web_wall_corner_sw",
+        "t_demon_web_wall_corner_ne",
         "t_demon_web_wall_corner_se",
-        "t_demon_web_wall_corner_ne"
+        "t_demon_web_wall_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_demon_web_wall_t_connection_n",
-        "t_demon_web_wall_t_connection_w",
+        "t_demon_web_wall_t_connection_e",
         "t_demon_web_wall_t_connection_s",
-        "t_demon_web_wall_t_connection_e"
+        "t_demon_web_wall_t_connection_w"
       ]
     },
     { "id": "edge", "fg": [ "t_demon_web_wall_edge_ns", "t_demon_web_wall_edge_ew" ] },
@@ -27,12 +27,11 @@
       "id": "end_piece",
       "fg": [
         "t_demon_web_wall_end_piece_n",
-        "t_demon_web_wall_end_piece_w",
+        "t_demon_web_wall_end_piece_e",
         "t_demon_web_wall_end_piece_s",
-        "t_demon_web_wall_end_piece_e"
+        "t_demon_web_wall_end_piece_w"
       ]
     },
     { "id": "unconnected", "fg": [ "t_demon_web_wall_unconnected", "t_demon_web_wall_unconnected" ] }
   ]
 }
-

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/terrain/f_absence/f_absence.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/terrain/f_absence/f_absence.json
@@ -3,50 +3,20 @@
   "fg": "f_absence_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_absence_center"
-    },
+    { "id": "center", "fg": "f_absence_center" },
     {
       "id": "corner",
-      "fg": [
-        "f_absence_corner_nw",
-        "f_absence_corner_sw",
-        "f_absence_corner_se",
-        "f_absence_corner_ne"
-      ]
+      "fg": [ "f_absence_corner_nw", "f_absence_corner_ne", "f_absence_corner_se", "f_absence_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "f_absence_t_connection_n",
-        "f_absence_t_connection_w",
-        "f_absence_t_connection_s",
-        "f_absence_t_connection_e"
-      ]
+      "fg": [ "f_absence_t_connection_n", "f_absence_t_connection_e", "f_absence_t_connection_s", "f_absence_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_absence_edge_ns",
-        "f_absence_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_absence_edge_ns", "f_absence_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "f_absence_end_piece_n",
-        "f_absence_end_piece_w",
-        "f_absence_end_piece_s",
-        "f_absence_end_piece_e"
-      ]
+      "fg": [ "f_absence_end_piece_n", "f_absence_end_piece_e", "f_absence_end_piece_s", "f_absence_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_absence_unconnected",
-        "f_absence_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_absence_unconnected", "f_absence_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/terrain/railings/railing_fillers.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/terrain/railings/railing_fillers.json
@@ -1,59 +1,34 @@
 {
-  "id": ["t_metal_railing", "t_concrete_railing", "t_glass_railing"],
+  "id": [
+    "t_metal_railing",
+    "t_concrete_railing",
+    "t_glass_railing"
+  ],
   "multitile": true,
   "fg": "t_railing_unconnected",
   "bg": "t_concrete_unconnected",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "t_concrete_unconnected",
-      "fg": "t_railing_center"
-    },
+    { "id": "center", "bg": "t_concrete_unconnected", "fg": "t_railing_center" },
     {
       "id": "corner",
       "bg": "t_concrete_unconnected",
-      "fg": [
-        "t_railing_corner_nw",
-        "t_railing_corner_sw",
-        "t_railing_corner_se",
-        "t_railing_corner_ne"
-      ]
+      "fg": [ "t_railing_corner_nw", "t_railing_corner_ne", "t_railing_corner_se", "t_railing_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "t_concrete_unconnected",
-      "fg": [
-        "t_railing_t_connection_n",
-        "t_railing_t_connection_w",
-        "t_railing_t_connection_s",
-        "t_railing_t_connection_e"
-      ]
+      "fg": [ "t_railing_t_connection_n", "t_railing_t_connection_e", "t_railing_t_connection_s", "t_railing_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "t_concrete_unconnected",
-      "fg": [
-        "t_railing_edge_ns",
-        "t_railing_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "t_concrete_unconnected", "fg": [ "t_railing_edge_ns", "t_railing_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "t_concrete_unconnected",
-      "fg": [
-        "t_railing_end_piece_n",
-        "t_railing_end_piece_w",
-        "t_railing_end_piece_s",
-        "t_railing_end_piece_e"
-      ]
+      "fg": [ "t_railing_end_piece_n", "t_railing_end_piece_e", "t_railing_end_piece_s", "t_railing_end_piece_w" ]
     },
     {
       "bg": "t_concrete_unconnected",
       "id": "unconnected",
-      "fg": [
-        "t_railing_unconnected",
-        "t_railing_unconnected"
-      ]
+      "fg": [ "t_railing_unconnected", "t_railing_unconnected" ]
     }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/terrain/t_paper/t_paper.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/terrain/t_paper/t_paper.json
@@ -4,56 +4,23 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_paper_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "t_paper_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "t_paper_corner_nw",
-        "t_paper_corner_sw",
-        "t_paper_corner_se",
-        "t_paper_corner_ne"
-      ],
+      "fg": [ "t_paper_corner_nw", "t_paper_corner_ne", "t_paper_corner_se", "t_paper_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_paper_t_connection_n",
-        "t_paper_t_connection_w",
-        "t_paper_t_connection_s",
-        "t_paper_t_connection_e"
-      ],
+      "fg": [ "t_paper_t_connection_n", "t_paper_t_connection_e", "t_paper_t_connection_s", "t_paper_t_connection_w" ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_paper_edge_ns",
-        "t_paper_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "t_paper_edge_ns", "t_paper_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "t_paper_end_piece_n",
-        "t_paper_end_piece_w",
-        "t_paper_end_piece_s",
-        "t_paper_end_piece_e"
-      ],
+      "fg": [ "t_paper_end_piece_n", "t_paper_end_piece_e", "t_paper_end_piece_s", "t_paper_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_paper_unconnected",
-        "t_paper_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "t_paper_unconnected", "t_paper_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/terrain/t_sandbox/t_sandbox.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/terrain/t_sandbox/t_sandbox.json
@@ -4,56 +4,23 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sandbox_center",
-      "bg": ""
-    },
+    { "id": "center", "fg": "t_sandbox_center", "bg": "" },
     {
       "id": "corner",
-      "fg": [
-        "t_sandbox_corner_nw",
-        "t_sandbox_corner_sw",
-        "t_sandbox_corner_se",
-        "t_sandbox_corner_ne"
-      ],
+      "fg": [ "t_sandbox_corner_nw", "t_sandbox_corner_ne", "t_sandbox_corner_se", "t_sandbox_corner_sw" ],
       "bg": ""
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_sandbox_t_connection_n",
-        "t_sandbox_t_connection_w",
-        "t_sandbox_t_connection_s",
-        "t_sandbox_t_connection_e"
-      ],
+      "fg": [ "t_sandbox_t_connection_n", "t_sandbox_t_connection_e", "t_sandbox_t_connection_s", "t_sandbox_t_connection_w" ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sandbox_edge_ns",
-        "t_sandbox_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "t_sandbox_edge_ns", "t_sandbox_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "t_sandbox_end_piece_n",
-        "t_sandbox_end_piece_w",
-        "t_sandbox_end_piece_s",
-        "t_sandbox_end_piece_e"
-      ],
+      "fg": [ "t_sandbox_end_piece_n", "t_sandbox_end_piece_e", "t_sandbox_end_piece_s", "t_sandbox_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_sandbox_unconnected",
-        "t_sandbox_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "t_sandbox_unconnected", "t_sandbox_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/terrain/t_wax/t_wax.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/terrain/t_wax/t_wax.json
@@ -4,56 +4,19 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wax_center",
-      "bg": ""
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_wax_corner_nw",
-        "t_wax_corner_sw",
-        "t_wax_corner_se",
-        "t_wax_corner_ne"
-      ],
-      "bg": ""
-    },
+    { "id": "center", "fg": "t_wax_center", "bg": "" },
+    { "id": "corner", "fg": [ "t_wax_corner_nw", "t_wax_corner_ne", "t_wax_corner_se", "t_wax_corner_sw" ], "bg": "" },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wax_t_connection_n",
-        "t_wax_t_connection_w",
-        "t_wax_t_connection_s",
-        "t_wax_t_connection_e"
-      ],
+      "fg": [ "t_wax_t_connection_n", "t_wax_t_connection_e", "t_wax_t_connection_s", "t_wax_t_connection_w" ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wax_edge_ns",
-        "t_wax_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "t_wax_edge_ns", "t_wax_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wax_end_piece_n",
-        "t_wax_end_piece_w",
-        "t_wax_end_piece_s",
-        "t_wax_end_piece_e"
-      ],
+      "fg": [ "t_wax_end_piece_n", "t_wax_end_piece_e", "t_wax_end_piece_s", "t_wax_end_piece_w" ],
       "bg": ""
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wax_unconnected",
-        "t_wax_unconnected"
-      ],
-      "bg": ""
-    }
+    { "id": "unconnected", "fg": [ "t_wax_unconnected", "t_wax_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/boards/hdboard.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/boards/hdboard.json
@@ -1,73 +1,93 @@
 [
   {
     "id": "vp_hdboard_ne",
-    "fg": [ "vp_hdboard_ne", "vp_hdboard_ne_rotW", "vp_hdboard_ne_rotS", "vp_hdboard_ne_rotE" ],
+    "fg": [ "vp_hdboard_ne", "vp_hdboard_ne_rotE", "vp_hdboard_ne_rotS", "vp_hdboard_ne_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdboard_ne", "vp_hdboard_ne_rotW", "vp_hdboard_ne_rotS", "vp_hdboard_ne_rotE" ]
+        "bg": [ "vp_hdboard_ne", "vp_hdboard_ne_rotE", "vp_hdboard_ne_rotS", "vp_hdboard_ne_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdboard_nw",
-    "fg": [ "vp_hdboard_nw", "vp_hdboard_nw_rotW", "vp_hdboard_nw_rotS", "vp_hdboard_nw_rotE" ],
+    "fg": [ "vp_hdboard_nw", "vp_hdboard_nw_rotE", "vp_hdboard_nw_rotS", "vp_hdboard_nw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdboard_nw", "vp_hdboard_nw_rotW", "vp_hdboard_nw_rotS", "vp_hdboard_nw_rotE" ]
+        "bg": [ "vp_hdboard_nw", "vp_hdboard_nw_rotE", "vp_hdboard_nw_rotS", "vp_hdboard_nw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdboard_se",
-    "fg": [ "vp_hdboard_se", "vp_hdboard_se_rotW", "vp_hdboard_nw", "vp_hdboard_se_rotE" ],
+    "fg": [ "vp_hdboard_se", "vp_hdboard_se_rotE", "vp_hdboard_nw", "vp_hdboard_se_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdboard_se", "vp_hdboard_se_rotW", "vp_hdboard_nw", "vp_hdboard_se_rotE" ]
+        "bg": [ "vp_hdboard_se", "vp_hdboard_se_rotE", "vp_hdboard_nw", "vp_hdboard_se_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdboard_sw",
-    "fg": [ "vp_hdboard_sw", "vp_hdboard_sw_rotW", "vp_hdboard_ne", "vp_hdboard_sw_rotE" ],
+    "fg": [ "vp_hdboard_sw", "vp_hdboard_sw_rotE", "vp_hdboard_ne", "vp_hdboard_sw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdboard_sw", "vp_hdboard_sw_rotW", "vp_hdboard_ne", "vp_hdboard_sw_rotE" ]
+        "bg": [ "vp_hdboard_sw", "vp_hdboard_sw_rotE", "vp_hdboard_ne", "vp_hdboard_sw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdboard_vertical_left",
-    "fg": [ "vp_hdboard_vertical_left", "vp_hdboard_vertical_left_rotW", "vp_hdboard_vertical_right", "vp_hdboard_vertical_left_rotE" ],
+    "fg": [
+      "vp_hdboard_vertical_left",
+      "vp_hdboard_vertical_left_rotE",
+      "vp_hdboard_vertical_right",
+      "vp_hdboard_vertical_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdboard_vertical_left", "vp_hdboard_vertical_left_rotW", "vp_hdboard_vertical_right", "vp_hdboard_vertical_left_rotE" ]
+        "bg": [
+          "vp_hdboard_vertical_left",
+          "vp_hdboard_vertical_left_rotE",
+          "vp_hdboard_vertical_right",
+          "vp_hdboard_vertical_left_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_hdboard_vertical_right",
-    "fg": [ "vp_hdboard_vertical_right", "vp_hdboard_vertical_right_rotW", "vp_hdboard_vertical_left", "vp_hdboard_vertical_right_rotE" ],
+    "fg": [
+      "vp_hdboard_vertical_right",
+      "vp_hdboard_vertical_right_rotE",
+      "vp_hdboard_vertical_left",
+      "vp_hdboard_vertical_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdboard_vertical_right", "vp_hdboard_vertical_right_rotW", "vp_hdboard_vertical_left", "vp_hdboard_vertical_right_rotE" ]
+        "bg": [
+          "vp_hdboard_vertical_right",
+          "vp_hdboard_vertical_right_rotE",
+          "vp_hdboard_vertical_left",
+          "vp_hdboard_vertical_right_rotW"
+        ]
       }
     ]
   },
@@ -75,35 +95,49 @@
     "id": [ "vp_hdboard_horizontal", "vp_hdboard_horizontal_2" ],
     "fg": "vp_hdboard_horizontal_front",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_hdboard_horizontal_front"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_hdboard_horizontal_front" } ]
   },
   {
     "id": "vp_hdboard_horizontal_front",
-    "fg": [ "vp_hdboard_horizontal_front", "vp_hdboard_horizontal_front_rotW", "vp_hdboard_horizontal_front", "vp_hdboard_horizontal_front_rotE" ],
+    "fg": [
+      "vp_hdboard_horizontal_front",
+      "vp_hdboard_horizontal_front_rotE",
+      "vp_hdboard_horizontal_front",
+      "vp_hdboard_horizontal_front_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdboard_horizontal_front", "vp_hdboard_horizontal_front_rotW", "vp_hdboard_horizontal_front", "vp_hdboard_horizontal_front_rotE" ]
+        "bg": [
+          "vp_hdboard_horizontal_front",
+          "vp_hdboard_horizontal_front_rotE",
+          "vp_hdboard_horizontal_front",
+          "vp_hdboard_horizontal_front_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_hdboard_horizontal_rear",
-    "fg": [ "vp_hdboard_horizontal_rear", "vp_hdboard_horizontal_front_rotE", "vp_hdboard_horizontal_front", "vp_hdboard_horizontal_front_rotW" ],
+    "fg": [
+      "vp_hdboard_horizontal_rear",
+      "vp_hdboard_horizontal_front_rotW",
+      "vp_hdboard_horizontal_front",
+      "vp_hdboard_horizontal_front_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdboard_horizontal_rear", "vp_hdboard_horizontal_front_rotE", "vp_hdboard_horizontal_front", "vp_hdboard_horizontal_front_rotW" ]
+        "bg": [
+          "vp_hdboard_horizontal_rear",
+          "vp_hdboard_horizontal_front_rotW",
+          "vp_hdboard_horizontal_front",
+          "vp_hdboard_horizontal_front_rotE"
+        ]
       }
     ]
   },
@@ -111,12 +145,6 @@
     "id": [ "vp_hdboard_vertical", "vp_hdboard_vertical_2" ],
     "fg": "vp_hdboard_vertical_left",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_hdboard_vertical_left"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_hdboard_vertical_left" } ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/boards/stowboards/stowboards_hd.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/boards/stowboards/stowboards_hd.json
@@ -1,73 +1,93 @@
 [
   {
     "id": "vp_hdstowboard_ne",
-    "fg": [ "vp_hdstowboard_ne", "vp_hdstowboard_ne_rotW", "vp_hdstowboard_ne_rotS", "vp_hdstowboard_ne_rotE" ],
+    "fg": [ "vp_hdstowboard_ne", "vp_hdstowboard_ne_rotE", "vp_hdstowboard_ne_rotS", "vp_hdstowboard_ne_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdstowboard_ne", "vp_hdstowboard_ne_rotW", "vp_hdstowboard_ne_rotS", "vp_hdstowboard_ne_rotE" ]
+        "bg": [ "vp_hdstowboard_ne", "vp_hdstowboard_ne_rotE", "vp_hdstowboard_ne_rotS", "vp_hdstowboard_ne_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdstowboard_nw",
-    "fg": [ "vp_hdstowboard_nw", "vp_hdstowboard_nw_rotW", "vp_hdstowboard_nw_rotS", "vp_hdstowboard_nw_rotE" ],
+    "fg": [ "vp_hdstowboard_nw", "vp_hdstowboard_nw_rotE", "vp_hdstowboard_nw_rotS", "vp_hdstowboard_nw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdstowboard_nw", "vp_hdstowboard_nw_rotW", "vp_hdstowboard_nw_rotS", "vp_hdstowboard_nw_rotE" ]
+        "bg": [ "vp_hdstowboard_nw", "vp_hdstowboard_nw_rotE", "vp_hdstowboard_nw_rotS", "vp_hdstowboard_nw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdstowboard_se",
-    "fg": [ "vp_hdstowboard_se", "vp_hdstowboard_se_rotW", "vp_hdstowboard_nw", "vp_hdstowboard_se_rotE" ],
+    "fg": [ "vp_hdstowboard_se", "vp_hdstowboard_se_rotE", "vp_hdstowboard_nw", "vp_hdstowboard_se_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdstowboard_se", "vp_hdstowboard_se_rotW", "vp_hdstowboard_nw", "vp_hdstowboard_se_rotE" ]
+        "bg": [ "vp_hdstowboard_se", "vp_hdstowboard_se_rotE", "vp_hdstowboard_nw", "vp_hdstowboard_se_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdstowboard_sw",
-    "fg": [ "vp_hdstowboard_sw", "vp_hdstowboard_sw_rotW", "vp_hdstowboard_ne", "vp_hdstowboard_sw_rotE" ],
+    "fg": [ "vp_hdstowboard_sw", "vp_hdstowboard_sw_rotE", "vp_hdstowboard_ne", "vp_hdstowboard_sw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdstowboard_sw", "vp_hdstowboard_sw_rotW", "vp_hdstowboard_ne", "vp_hdstowboard_sw_rotE" ]
+        "bg": [ "vp_hdstowboard_sw", "vp_hdstowboard_sw_rotE", "vp_hdstowboard_ne", "vp_hdstowboard_sw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdstowboard_vertical_left",
-    "fg": [ "vp_hdstowboard_vertical_left", "vp_hdstowboard_vertical_left_rotW_right_rotE", "vp_hdstowboard_vertical_right", "vp_hdstowboard_vertical_left_rotE_right_rotW" ],
+    "fg": [
+      "vp_hdstowboard_vertical_left",
+      "vp_hdstowboard_vertical_left_rotE_right_rotW",
+      "vp_hdstowboard_vertical_right",
+      "vp_hdstowboard_vertical_left_rotW_right_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdstowboard_vertical_left", "vp_hdstowboard_vertical_left_rotW_right_rotE", "vp_hdstowboard_vertical_right", "vp_hdstowboard_vertical_left_rotE_right_rotW" ]
+        "bg": [
+          "vp_hdstowboard_vertical_left",
+          "vp_hdstowboard_vertical_left_rotE_right_rotW",
+          "vp_hdstowboard_vertical_right",
+          "vp_hdstowboard_vertical_left_rotW_right_rotE"
+        ]
       }
     ]
   },
   {
     "id": "vp_hdstowboard_vertical_right",
-    "fg": [ "vp_hdstowboard_vertical_right", "vp_hdstowboard_vertical_left_rotE_right_rotW", "vp_hdstowboard_vertical_left", "vp_hdstowboard_vertical_left_rotW_right_rotE" ],
+    "fg": [
+      "vp_hdstowboard_vertical_right",
+      "vp_hdstowboard_vertical_left_rotW_right_rotE",
+      "vp_hdstowboard_vertical_left",
+      "vp_hdstowboard_vertical_left_rotE_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdstowboard_vertical_right", "vp_hdstowboard_vertical_left_rotE_right_rotW", "vp_hdstowboard_vertical_left", "vp_hdstowboard_vertical_left_rotW_right_rotE" ]
+        "bg": [
+          "vp_hdstowboard_vertical_right",
+          "vp_hdstowboard_vertical_left_rotW_right_rotE",
+          "vp_hdstowboard_vertical_left",
+          "vp_hdstowboard_vertical_left_rotE_right_rotW"
+        ]
       }
     ]
   },
@@ -75,35 +95,49 @@
     "id": [ "vp_hdstowboard_horizontal", "vp_hdstowboard_horizontal_2" ],
     "fg": "vp_hdstowboard_horizontal_front",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_hdstowboard_horizontal_front"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_hdstowboard_horizontal_front" } ]
   },
   {
     "id": "vp_hdstowboard_horizontal_front",
-    "fg": [ "vp_hdstowboard_horizontal_front", "vp_hdstowboard_horizontal_front_rotW", "vp_hdstowboard_horizontal_front_rotS", "vp_hdstowboard_horizontal_front_rotE" ],
+    "fg": [
+      "vp_hdstowboard_horizontal_front",
+      "vp_hdstowboard_horizontal_front_rotE",
+      "vp_hdstowboard_horizontal_front_rotS",
+      "vp_hdstowboard_horizontal_front_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdstowboard_horizontal_front", "vp_hdstowboard_horizontal_front_rotW", "vp_hdstowboard_horizontal_front_rotS", "vp_hdstowboard_horizontal_front_rotE" ]
+        "bg": [
+          "vp_hdstowboard_horizontal_front",
+          "vp_hdstowboard_horizontal_front_rotE",
+          "vp_hdstowboard_horizontal_front_rotS",
+          "vp_hdstowboard_horizontal_front_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_hdstowboard_horizontal_rear",
-    "fg": [ "vp_hdstowboard_horizontal_rear", "vp_hdstowboard_horizontal_front_rotE", "vp_hdstowboard_horizontal_front", "vp_hdstowboard_horizontal_front_rotW" ],
+    "fg": [
+      "vp_hdstowboard_horizontal_rear",
+      "vp_hdstowboard_horizontal_front_rotW",
+      "vp_hdstowboard_horizontal_front",
+      "vp_hdstowboard_horizontal_front_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdstowboard_horizontal_rear", "vp_hdstowboard_horizontal_front_rotE", "vp_hdstowboard_horizontal_front", "vp_hdstowboard_horizontal_front_rotW" ]
+        "bg": [
+          "vp_hdstowboard_horizontal_rear",
+          "vp_hdstowboard_horizontal_front_rotW",
+          "vp_hdstowboard_horizontal_front",
+          "vp_hdstowboard_horizontal_front_rotE"
+        ]
       }
     ]
   },
@@ -111,12 +145,6 @@
     "id": "vp_hdstowboard_vertical",
     "fg": "vp_hdstowboard_vertical_left_rotE_right_rotW",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_hdstowboard_vertical_left_rotE_right_rotW"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_hdstowboard_vertical_left_rotE_right_rotW" } ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/boards/vp_hdhalfboard.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/boards/vp_hdhalfboard.json
@@ -1,73 +1,93 @@
 [
   {
     "id": "vp_hdhalfboard_ne",
-    "fg": [ "vp_hdhalfboard_ne", "vp_hdhalfboard_ne_rotW", "vp_hdhalfboard_ne_rotS", "vp_hdhalfboard_ne_rotE" ],
+    "fg": [ "vp_hdhalfboard_ne", "vp_hdhalfboard_ne_rotE", "vp_hdhalfboard_ne_rotS", "vp_hdhalfboard_ne_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdhalfboard_ne", "vp_hdhalfboard_ne_rotW", "vp_hdhalfboard_ne_rotS", "vp_hdhalfboard_ne_rotE" ]
+        "bg": [ "vp_hdhalfboard_ne", "vp_hdhalfboard_ne_rotE", "vp_hdhalfboard_ne_rotS", "vp_hdhalfboard_ne_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdhalfboard_nw",
-    "fg": [ "vp_hdhalfboard_nw", "vp_hdhalfboard_nw_rotW", "vp_hdhalfboard_nw_rotS", "vp_hdhalfboard_nw_rotE" ],
+    "fg": [ "vp_hdhalfboard_nw", "vp_hdhalfboard_nw_rotE", "vp_hdhalfboard_nw_rotS", "vp_hdhalfboard_nw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdhalfboard_nw", "vp_hdhalfboard_nw_rotW", "vp_hdhalfboard_nw_rotS", "vp_hdhalfboard_nw_rotE" ]
+        "bg": [ "vp_hdhalfboard_nw", "vp_hdhalfboard_nw_rotE", "vp_hdhalfboard_nw_rotS", "vp_hdhalfboard_nw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdhalfboard_se",
-    "fg": [ "vp_hdhalfboard_se", "vp_hdhalfboard_se_rotW", "vp_hdhalfboard_se_rotS", "vp_hdhalfboard_se_rotE" ],
+    "fg": [ "vp_hdhalfboard_se", "vp_hdhalfboard_se_rotE", "vp_hdhalfboard_se_rotS", "vp_hdhalfboard_se_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdhalfboard_se", "vp_hdhalfboard_se_rotW", "vp_hdhalfboard_se_rotS", "vp_hdhalfboard_se_rotE" ]
+        "bg": [ "vp_hdhalfboard_se", "vp_hdhalfboard_se_rotE", "vp_hdhalfboard_se_rotS", "vp_hdhalfboard_se_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdhalfboard_sw",
-    "fg": [ "vp_hdhalfboard_sw", "vp_hdhalfboard_sw_rotW", "vp_hdhalfboard_sw_rotS", "vp_hdhalfboard_sw_rotE" ],
+    "fg": [ "vp_hdhalfboard_sw", "vp_hdhalfboard_sw_rotE", "vp_hdhalfboard_sw_rotS", "vp_hdhalfboard_sw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdhalfboard_sw", "vp_hdhalfboard_sw_rotW", "vp_hdhalfboard_sw_rotS", "vp_hdhalfboard_sw_rotE" ]
+        "bg": [ "vp_hdhalfboard_sw", "vp_hdhalfboard_sw_rotE", "vp_hdhalfboard_sw_rotS", "vp_hdhalfboard_sw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hdhalfboard_vertical_left",
-    "fg": [ "vp_hdhalfboard_vertical_left", "vp_hdhalfboard_vertical_left_rotW", "vp_hdhalfboard_vertical_left_rotS", "vp_hdhalfboard_vertical_left_rotE" ],
+    "fg": [
+      "vp_hdhalfboard_vertical_left",
+      "vp_hdhalfboard_vertical_left_rotE",
+      "vp_hdhalfboard_vertical_left_rotS",
+      "vp_hdhalfboard_vertical_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdhalfboard_vertical_left", "vp_hdhalfboard_vertical_left_rotW", "vp_hdhalfboard_vertical_left_rotS", "vp_hdhalfboard_vertical_left_rotE" ]
+        "bg": [
+          "vp_hdhalfboard_vertical_left",
+          "vp_hdhalfboard_vertical_left_rotE",
+          "vp_hdhalfboard_vertical_left_rotS",
+          "vp_hdhalfboard_vertical_left_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_hdhalfboard_vertical_right",
-    "fg": [ "vp_hdhalfboard_vertical_right", "vp_hdhalfboard_vertical_right_rotW", "vp_hdhalfboard_vertical_right_rotS", "vp_hdhalfboard_vertical_right_rotE" ],
+    "fg": [
+      "vp_hdhalfboard_vertical_right",
+      "vp_hdhalfboard_vertical_right_rotE",
+      "vp_hdhalfboard_vertical_right_rotS",
+      "vp_hdhalfboard_vertical_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdhalfboard_vertical_right", "vp_hdhalfboard_vertical_right_rotW", "vp_hdhalfboard_vertical_right_rotS", "vp_hdhalfboard_vertical_right_rotE" ]
+        "bg": [
+          "vp_hdhalfboard_vertical_right",
+          "vp_hdhalfboard_vertical_right_rotE",
+          "vp_hdhalfboard_vertical_right_rotS",
+          "vp_hdhalfboard_vertical_right_rotW"
+        ]
       }
     ]
   },
@@ -75,9 +95,9 @@
     "id": "vp_hdhalfboard_horizontal",
     "fg": [
       "vp_hdhalfboard_horizontal_front",
-      "vp_hdhalfboard_horizontal_front_rotW",
+      "vp_hdhalfboard_horizontal_front_rotE",
       "vp_hdhalfboard_horizontal_front_rotS",
-      "vp_hdhalfboard_horizontal_front_rotE"
+      "vp_hdhalfboard_horizontal_front_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -85,11 +105,11 @@
         "id": "broken",
         "fg": "crack_metal_center",
         "bg": [
-      "vp_hdhalfboard_horizontal_front",
-      "vp_hdhalfboard_horizontal_front_rotW",
-      "vp_hdhalfboard_horizontal_front_rotS",
-      "vp_hdhalfboard_horizontal_front_rotE"
-    ]
+          "vp_hdhalfboard_horizontal_front",
+          "vp_hdhalfboard_horizontal_front_rotE",
+          "vp_hdhalfboard_horizontal_front_rotS",
+          "vp_hdhalfboard_horizontal_front_rotW"
+        ]
       }
     ]
   },
@@ -97,21 +117,15 @@
     "id": "vp_hdhalfboard_horizontal_2",
     "fg": "vp_hdhalfboard_horizontal_2_front",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_hdhalfboard_horizontal_2_front"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_hdhalfboard_horizontal_2_front" } ]
   },
   {
     "id": "vp_hdhalfboard_horizontal_front",
     "fg": [
       "vp_hdhalfboard_horizontal_front",
-      "vp_hdhalfboard_horizontal_front_rotW",
+      "vp_hdhalfboard_horizontal_front_rotE",
       "vp_hdhalfboard_horizontal_front_rotS",
-      "vp_hdhalfboard_horizontal_front_rotE"
+      "vp_hdhalfboard_horizontal_front_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -119,11 +133,11 @@
         "id": "broken",
         "fg": "crack_metal_center",
         "bg": [
-      "vp_hdhalfboard_horizontal_front",
-      "vp_hdhalfboard_horizontal_front_rotW",
-      "vp_hdhalfboard_horizontal_front_rotS",
-      "vp_hdhalfboard_horizontal_front_rotE"
-    ]
+          "vp_hdhalfboard_horizontal_front",
+          "vp_hdhalfboard_horizontal_front_rotE",
+          "vp_hdhalfboard_horizontal_front_rotS",
+          "vp_hdhalfboard_horizontal_front_rotW"
+        ]
       }
     ]
   },
@@ -131,8 +145,52 @@
     "id": "vp_hdhalfboard_horizontal_2_front",
     "fg": [
       "vp_hdhalfboard_horizontal_2_front",
-      "vp_hdhalfboard_horizontal_2_front_rotW",
+      "vp_hdhalfboard_horizontal_2_front_rotE",
       "vp_hdhalfboard_horizontal_2_front_rotS",
+      "vp_hdhalfboard_horizontal_2_front_rotW"
+    ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": "crack_metal_center",
+        "bg": [
+          "vp_hdhalfboard_horizontal_2_front",
+          "vp_hdhalfboard_horizontal_2_front_rotE",
+          "vp_hdhalfboard_horizontal_2_front_rotS",
+          "vp_hdhalfboard_horizontal_2_front_rotW"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_hdhalfboard_horizontal_rear",
+    "fg": [
+      "vp_hdhalfboard_horizontal_rear",
+      "vp_hdhalfboard_horizontal_front_rotW",
+      "vp_hdhalfboard_horizontal_front",
+      "vp_hdhalfboard_horizontal_front_rotE"
+    ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": "crack_metal_center",
+        "bg": [
+          "vp_hdhalfboard_horizontal_rear",
+          "vp_hdhalfboard_horizontal_front_rotW",
+          "vp_hdhalfboard_horizontal_front",
+          "vp_hdhalfboard_horizontal_front_rotE"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_hdhalfboard_horizontal_2_rear",
+    "fg": [
+      "vp_hdhalfboard_horizontal_2_rear",
+      "vp_hdhalfboard_horizontal_2_front_rotW",
+      "vp_hdhalfboard_horizontal_2_front",
       "vp_hdhalfboard_horizontal_2_front_rotE"
     ],
     "multitile": true,
@@ -141,47 +199,11 @@
         "id": "broken",
         "fg": "crack_metal_center",
         "bg": [
-      "vp_hdhalfboard_horizontal_2_front",
-      "vp_hdhalfboard_horizontal_2_front_rotW",
-      "vp_hdhalfboard_horizontal_2_front_rotS",
-      "vp_hdhalfboard_horizontal_2_front_rotE"
-    ]
-      }
-    ]
-  },
-  {
-    "id": "vp_hdhalfboard_horizontal_rear",
-    "fg": [ "vp_hdhalfboard_horizontal_rear",
-      "vp_hdhalfboard_horizontal_front_rotE",
-      "vp_hdhalfboard_horizontal_front",
-      "vp_hdhalfboard_horizontal_front_rotW" ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [ "vp_hdhalfboard_horizontal_rear",
-      "vp_hdhalfboard_horizontal_front_rotE",
-      "vp_hdhalfboard_horizontal_front",
-      "vp_hdhalfboard_horizontal_front_rotW" ]
-      }
-    ]
-  },
-  {
-    "id": "vp_hdhalfboard_horizontal_2_rear",
-    "fg": [ "vp_hdhalfboard_horizontal_2_rear",
-      "vp_hdhalfboard_horizontal_2_front_rotE",
-      "vp_hdhalfboard_horizontal_2_front",
-      "vp_hdhalfboard_horizontal_2_front_rotW" ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [ "vp_hdhalfboard_horizontal_2_rear",
-      "vp_hdhalfboard_horizontal_2_front_rotE",
-      "vp_hdhalfboard_horizontal_2_front",
-      "vp_hdhalfboard_horizontal_2_front_rotW" ]
+          "vp_hdhalfboard_horizontal_2_rear",
+          "vp_hdhalfboard_horizontal_2_front_rotW",
+          "vp_hdhalfboard_horizontal_2_front",
+          "vp_hdhalfboard_horizontal_2_front_rotE"
+        ]
       }
     ]
   },
@@ -189,59 +211,67 @@
     "id": "vp_hdhalfboard_vertical",
     "fg": "vp_hdhalfboard_vertical",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_hdhalfboard_vertical"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_hdhalfboard_vertical" } ]
   },
   {
     "id": "vp_hdhalfboard_vertical_2",
     "fg": "vp_hdhalfboard_vertical_2",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_hdhalfboard_vertical_2"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_hdhalfboard_vertical_2" } ]
   },
   {
     "id": "vp_hdhalfboard_vertical_2_left",
-    "fg": [ "vp_hdhalfboard_vertical_2_left", "vp_hdhalfboard_vertical_left_rotW", "vp_hdhalfboard_vertical_left_rotS", "vp_hdhalfboard_vertical_left_rotE" ],
+    "fg": [
+      "vp_hdhalfboard_vertical_2_left",
+      "vp_hdhalfboard_vertical_left_rotE",
+      "vp_hdhalfboard_vertical_left_rotS",
+      "vp_hdhalfboard_vertical_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdhalfboard_vertical_2_left", "vp_hdhalfboard_vertical_left_rotW", "vp_hdhalfboard_vertical_left_rotS", "vp_hdhalfboard_vertical_left_rotE" ]
+        "bg": [
+          "vp_hdhalfboard_vertical_2_left",
+          "vp_hdhalfboard_vertical_left_rotE",
+          "vp_hdhalfboard_vertical_left_rotS",
+          "vp_hdhalfboard_vertical_left_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_hdhalfboard_vertical_2_right",
-    "fg": [ "vp_hdhalfboard_vertical_2_right", "vp_hdhalfboard_vertical_right_rotW", "vp_hdhalfboard_vertical_right_rotS", "vp_hdhalfboard_vertical_right_rotE" ],
+    "fg": [
+      "vp_hdhalfboard_vertical_2_right",
+      "vp_hdhalfboard_vertical_right_rotE",
+      "vp_hdhalfboard_vertical_right_rotS",
+      "vp_hdhalfboard_vertical_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdhalfboard_vertical_2_right", "vp_hdhalfboard_vertical_right_rotW", "vp_hdhalfboard_vertical_right_rotS", "vp_hdhalfboard_vertical_right_rotE" ]
+        "bg": [
+          "vp_hdhalfboard_vertical_2_right",
+          "vp_hdhalfboard_vertical_right_rotE",
+          "vp_hdhalfboard_vertical_right_rotS",
+          "vp_hdhalfboard_vertical_right_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_hdhalfboard_cover",
-    "fg": [ "vp_hdhalfboard_cover", "vp_hdhalfboard_cover_rotW", "vp_hdhalfboard_cover_rotS", "vp_hdhalfboard_cover_rotE" ],
+    "fg": [ "vp_hdhalfboard_cover", "vp_hdhalfboard_cover_rotE", "vp_hdhalfboard_cover_rotS", "vp_hdhalfboard_cover_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hdhalfboard_cover", "vp_hdhalfboard_cover_rotW", "vp_hdhalfboard_cover_rotS", "vp_hdhalfboard_cover_rotE" ]
+        "bg": [ "vp_hdhalfboard_cover", "vp_hdhalfboard_cover_rotE", "vp_hdhalfboard_cover_rotS", "vp_hdhalfboard_cover_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/boards/vp_xlhalfboard.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/boards/vp_xlhalfboard.json
@@ -1,25 +1,25 @@
 [
   {
     "id": "vp_xlhalfboard_ne",
-    "fg": [ "vp_xlhalfboard_ne", "vp_xlhalfboard_ne_rotW", "vp_xlhalfboard_ne_rotS", "vp_xlhalfboard_ne_rotE" ],
+    "fg": [ "vp_xlhalfboard_ne", "vp_xlhalfboard_ne_rotE", "vp_xlhalfboard_ne_rotS", "vp_xlhalfboard_ne_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_xlhalfboard_ne", "vp_xlhalfboard_ne_rotW", "vp_xlhalfboard_ne_rotS", "vp_xlhalfboard_ne_rotE" ]
+        "bg": [ "vp_xlhalfboard_ne", "vp_xlhalfboard_ne_rotE", "vp_xlhalfboard_ne_rotS", "vp_xlhalfboard_ne_rotW" ]
       }
     ]
   },
   {
     "id": "vp_xlhalfboard_nw",
-    "fg": [ "vp_xlhalfboard_nw", "vp_xlhalfboard_nw_rotW", "vp_xlhalfboard_nw_rotS", "vp_xlhalfboard_nw_rotE" ],
+    "fg": [ "vp_xlhalfboard_nw", "vp_xlhalfboard_nw_rotE", "vp_xlhalfboard_nw_rotS", "vp_xlhalfboard_nw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_xlhalfboard_nw", "vp_xlhalfboard_nw_rotW", "vp_xlhalfboard_nw_rotS", "vp_xlhalfboard_nw_rotE" ]
+        "bg": [ "vp_xlhalfboard_nw", "vp_xlhalfboard_nw_rotE", "vp_xlhalfboard_nw_rotS", "vp_xlhalfboard_nw_rotW" ]
       }
     ]
   },
@@ -27,79 +27,51 @@
     "id": "vp_xlhalfboard_se",
     "fg": "vp_xlhalfboard_se",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_xlhalfboard_se"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_xlhalfboard_se" } ]
   },
   {
     "id": "vp_xlhalfboard_sw",
     "fg": "vp_xlhalfboard_sw",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_xlhalfboard_sw"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_xlhalfboard_sw" } ]
   },
   {
     "id": "vp_xlhalfboard_vertical_left",
     "fg": "vp_xlhalfboard_vertical_left",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_xlhalfboard_vertical_left"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_xlhalfboard_vertical_left" } ]
   },
   {
     "id": "vp_xlhalfboard_vertical_right",
     "fg": "vp_xlhalfboard_vertical_right",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_xlhalfboard_vertical_right"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_xlhalfboard_vertical_right" } ]
   },
   {
     "id": [ "vp_xlhalfboard_horizontal", "vp_xlhalfboard_horizontal_2" ],
     "fg": "vp_xlhalfboard_horizontal_front",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_xlhalfboard_horizontal_front"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_xlhalfboard_horizontal_front" } ]
   },
   {
     "id": "vp_xlhalfboard_horizontal_front",
-    "fg": [ "vp_xlhalfboard_horizontal_front",
-      "vp_xlhalfboard_horizontal_front_rotW",
+    "fg": [
+      "vp_xlhalfboard_horizontal_front",
+      "vp_xlhalfboard_horizontal_front_rotE",
       "vp_xlhalfboard_horizontal_front_rotS",
-      "vp_xlhalfboard_horizontal_front_rotE"
+      "vp_xlhalfboard_horizontal_front_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_xlhalfboard_horizontal_front",
-      "vp_xlhalfboard_horizontal_front_rotW",
-      "vp_xlhalfboard_horizontal_front_rotS",
-      "vp_xlhalfboard_horizontal_front_rotE"
-    ]
+        "bg": [
+          "vp_xlhalfboard_horizontal_front",
+          "vp_xlhalfboard_horizontal_front_rotE",
+          "vp_xlhalfboard_horizontal_front_rotS",
+          "vp_xlhalfboard_horizontal_front_rotW"
+        ]
       }
     ]
   },
@@ -107,35 +79,23 @@
     "id": "vp_xlhalfboard_horizontal_rear",
     "fg": "vp_xlhalfboard_horizontal_rear",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_xlhalfboard_horizontal_rear"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_xlhalfboard_horizontal_rear" } ]
   },
   {
     "id": [ "vp_xlhalfboard_vertical", "vp_xlhalfboard_vertical_2" ],
     "fg": "vp_xlhalfboard_vertical",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_xlhalfboard_vertical"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_xlhalfboard_vertical" } ]
   },
   {
     "id": "vp_xlhalfboard_cover",
-    "fg": [ "vp_xlhalfboard_cover", "vp_xlhalfboard_cover_rotW", "vp_xlhalfboard_cover_rotS", "vp_xlhalfboard_cover_rotE" ],
+    "fg": [ "vp_xlhalfboard_cover", "vp_xlhalfboard_cover_rotE", "vp_xlhalfboard_cover_rotS", "vp_xlhalfboard_cover_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_xlhalfboard_cover", "vp_xlhalfboard_cover_rotW", "vp_xlhalfboard_cover_rotS", "vp_xlhalfboard_cover_rotE" ]
+        "bg": [ "vp_xlhalfboard_cover", "vp_xlhalfboard_cover_rotE", "vp_xlhalfboard_cover_rotS", "vp_xlhalfboard_cover_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/boards/wood/board.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/boards/wood/board.json
@@ -3,74 +3,8 @@
     "id": "vp_woodboard_ne",
     "fg": [
       "vp_woodboard_ne_rotN_sw_rotS",
-      "vp_woodboard_ne_rotW_sw_rotE",
-      "vp_woodboard_sw_rotN_ne_rotS",
-      "vp_woodboard_sw_rotw_ne_rotE"
-    ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [
-          "vp_woodboard_ne_rotN_sw_rotS",
-          "vp_woodboard_ne_rotW_sw_rotE",
-          "vp_woodboard_sw_rotN_ne_rotS",
-          "vp_woodboard_sw_rotw_ne_rotE"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_woodboard_nw",
-    "fg": [
-      "vp_woodboard_nw_rotN_se_rotS",
-      "vp_woodboard_nw_rotw_se_rotE",
-      "vp_woodboard_se_rotN_nw_rotS",
-      "vp_woodboard_se_rotW_nw_rotE"
-    ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [
-          "vp_woodboard_nw_rotN_se_rotS",
-          "vp_woodboard_nw_rotw_se_rotE",
-          "vp_woodboard_se_rotN_nw_rotS",
-          "vp_woodboard_se_rotW_nw_rotE"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_woodboard_se",
-    "fg": [
-      "vp_woodboard_se_rotN_nw_rotS",
-      "vp_woodboard_se_rotW_nw_rotE",
-      "vp_woodboard_nw_rotN_se_rotS",
-      "vp_woodboard_nw_rotw_se_rotE"
-    ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [
-          "vp_woodboard_se_rotN_nw_rotS",
-          "vp_woodboard_se_rotW_nw_rotE",
-          "vp_woodboard_nw_rotN_se_rotS",
-          "vp_woodboard_nw_rotw_se_rotE"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_woodboard_sw",
-    "fg": [
-      "vp_woodboard_sw_rotN_ne_rotS",
       "vp_woodboard_sw_rotw_ne_rotE",
-      "vp_woodboard_ne_rotN_sw_rotS",
+      "vp_woodboard_sw_rotN_ne_rotS",
       "vp_woodboard_ne_rotW_sw_rotE"
     ],
     "multitile": true,
@@ -79,10 +13,76 @@
         "id": "broken",
         "fg": "crack_metal_center",
         "bg": [
-          "vp_woodboard_sw_rotN_ne_rotS",
-          "vp_woodboard_sw_rotw_ne_rotE",
           "vp_woodboard_ne_rotN_sw_rotS",
+          "vp_woodboard_sw_rotw_ne_rotE",
+          "vp_woodboard_sw_rotN_ne_rotS",
           "vp_woodboard_ne_rotW_sw_rotE"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_woodboard_nw",
+    "fg": [
+      "vp_woodboard_nw_rotN_se_rotS",
+      "vp_woodboard_se_rotW_nw_rotE",
+      "vp_woodboard_se_rotN_nw_rotS",
+      "vp_woodboard_nw_rotw_se_rotE"
+    ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": "crack_metal_center",
+        "bg": [
+          "vp_woodboard_nw_rotN_se_rotS",
+          "vp_woodboard_se_rotW_nw_rotE",
+          "vp_woodboard_se_rotN_nw_rotS",
+          "vp_woodboard_nw_rotw_se_rotE"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_woodboard_se",
+    "fg": [
+      "vp_woodboard_se_rotN_nw_rotS",
+      "vp_woodboard_nw_rotw_se_rotE",
+      "vp_woodboard_nw_rotN_se_rotS",
+      "vp_woodboard_se_rotW_nw_rotE"
+    ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": "crack_metal_center",
+        "bg": [
+          "vp_woodboard_se_rotN_nw_rotS",
+          "vp_woodboard_nw_rotw_se_rotE",
+          "vp_woodboard_nw_rotN_se_rotS",
+          "vp_woodboard_se_rotW_nw_rotE"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_woodboard_sw",
+    "fg": [
+      "vp_woodboard_sw_rotN_ne_rotS",
+      "vp_woodboard_ne_rotW_sw_rotE",
+      "vp_woodboard_ne_rotN_sw_rotS",
+      "vp_woodboard_sw_rotw_ne_rotE"
+    ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": "crack_metal_center",
+        "bg": [
+          "vp_woodboard_sw_rotN_ne_rotS",
+          "vp_woodboard_ne_rotW_sw_rotE",
+          "vp_woodboard_ne_rotN_sw_rotS",
+          "vp_woodboard_sw_rotw_ne_rotE"
         ]
       }
     ]
@@ -91,30 +91,8 @@
     "id": "vp_woodboard_vertical_left",
     "fg": [
       "vp_woodboard_vertical_left_rotN_right_rotS",
-      "vp_woodboard_horizontal_rear_rotN_front_rotS",
-      "vp_woodboard_vertical_right_rotN_left_rotS",
-      "vp_woodboard_horizontal_front_rotN_rear_rotS"
-    ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [
-          "vp_woodboard_vertical_left_rotN_right_rotS",
-          "vp_woodboard_horizontal_rear_rotN_front_rotS",
-          "vp_woodboard_vertical_right_rotN_left_rotS",
-          "vp_woodboard_horizontal_front_rotN_rear_rotS"
-        ]
-      }
-    ]
-  },
-  {
-    "id": "vp_woodboard_vertical_right",
-    "fg": [
-      "vp_woodboard_vertical_right_rotN_left_rotS",
       "vp_woodboard_horizontal_front_rotN_rear_rotS",
-      "vp_woodboard_vertical_left_rotN_right_rotS",
+      "vp_woodboard_vertical_right_rotN_left_rotS",
       "vp_woodboard_horizontal_rear_rotN_front_rotS"
     ],
     "multitile": true,
@@ -123,25 +101,21 @@
         "id": "broken",
         "fg": "crack_metal_center",
         "bg": [
-          "vp_woodboard_vertical_right_rotN_left_rotS",
-          "vp_woodboard_horizontal_front_rotN_rear_rotS",
           "vp_woodboard_vertical_left_rotN_right_rotS",
+          "vp_woodboard_horizontal_front_rotN_rear_rotS",
+          "vp_woodboard_vertical_right_rotN_left_rotS",
           "vp_woodboard_horizontal_rear_rotN_front_rotS"
         ]
       }
     ]
   },
   {
-    "id": [
-      "vp_woodboard_horizontal",
-      "vp_woodboard_vertical",
-      "vp_woodboard_horizontal_front"
-    ],
+    "id": "vp_woodboard_vertical_right",
     "fg": [
-      "vp_woodboard_horizontal_front_rotN_rear_rotS",
-      "vp_woodboard_horizontal_front_rotW_rear_rotE",
+      "vp_woodboard_vertical_right_rotN_left_rotS",
       "vp_woodboard_horizontal_rear_rotN_front_rotS",
-      "vp_woodboard_horizontal_rear_rotW_front_rotE"
+      "vp_woodboard_vertical_left_rotN_right_rotS",
+      "vp_woodboard_horizontal_front_rotN_rear_rotS"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -149,20 +123,20 @@
         "id": "broken",
         "fg": "crack_metal_center",
         "bg": [
-          "vp_woodboard_horizontal_front_rotN_rear_rotS",
-          "vp_woodboard_horizontal_front_rotW_rear_rotE",
+          "vp_woodboard_vertical_right_rotN_left_rotS",
           "vp_woodboard_horizontal_rear_rotN_front_rotS",
-          "vp_woodboard_horizontal_rear_rotW_front_rotE"
+          "vp_woodboard_vertical_left_rotN_right_rotS",
+          "vp_woodboard_horizontal_front_rotN_rear_rotS"
         ]
       }
     ]
   },
   {
-    "id": "vp_woodboard_horizontal_rear",
+    "id": [ "vp_woodboard_horizontal", "vp_woodboard_vertical", "vp_woodboard_horizontal_front" ],
     "fg": [
-      "vp_woodboard_horizontal_rear_rotN_front_rotS",
-      "vp_woodboard_horizontal_rear_rotW_front_rotE",
       "vp_woodboard_horizontal_front_rotN_rear_rotS",
+      "vp_woodboard_horizontal_rear_rotW_front_rotE",
+      "vp_woodboard_horizontal_rear_rotN_front_rotS",
       "vp_woodboard_horizontal_front_rotW_rear_rotE"
     ],
     "multitile": true,
@@ -171,10 +145,32 @@
         "id": "broken",
         "fg": "crack_metal_center",
         "bg": [
-          "vp_woodboard_horizontal_rear_rotN_front_rotS",
-          "vp_woodboard_horizontal_rear_rotW_front_rotE",
           "vp_woodboard_horizontal_front_rotN_rear_rotS",
+          "vp_woodboard_horizontal_rear_rotW_front_rotE",
+          "vp_woodboard_horizontal_rear_rotN_front_rotS",
           "vp_woodboard_horizontal_front_rotW_rear_rotE"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "vp_woodboard_horizontal_rear",
+    "fg": [
+      "vp_woodboard_horizontal_rear_rotN_front_rotS",
+      "vp_woodboard_horizontal_front_rotW_rear_rotE",
+      "vp_woodboard_horizontal_front_rotN_rear_rotS",
+      "vp_woodboard_horizontal_rear_rotW_front_rotE"
+    ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "broken",
+        "fg": "crack_metal_center",
+        "bg": [
+          "vp_woodboard_horizontal_rear_rotN_front_rotS",
+          "vp_woodboard_horizontal_front_rotW_rear_rotE",
+          "vp_woodboard_horizontal_front_rotN_rear_rotS",
+          "vp_woodboard_horizontal_rear_rotW_front_rotE"
         ]
       }
     ]

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/cargo/baskets.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/cargo/baskets.json
@@ -3,23 +3,27 @@
     "id": [ "vp_basketsm", "vp_basketsm_external" ],
     "fg": [ "vp_basketsm_rotNrotS", "vp_basketsm_rotErotW" ],
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [ "vp_basketsm_rotNrotS", "vp_basketsm_rotErotW" ]
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": [ "vp_basketsm_rotNrotS", "vp_basketsm_rotErotW" ] } ]
   },
   {
     "id": "vp_basketsm_bike_rear",
-    "fg": [ "vp_basketsm_bike_rear_rotN", "vp_basketsm_bike_rear_rotW", "vp_basketsm_bike_rear_rotS", "vp_basketsm_bike_rear_rotE" ],
+    "fg": [
+      "vp_basketsm_bike_rear_rotN",
+      "vp_basketsm_bike_rear_rotE",
+      "vp_basketsm_bike_rear_rotS",
+      "vp_basketsm_bike_rear_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_basketsm_bike_rear_rotN", "vp_basketsm_bike_rear_rotW", "vp_basketsm_bike_rear_rotS", "vp_basketsm_bike_rear_rotE" ]
+        "bg": [
+          "vp_basketsm_bike_rear_rotN",
+          "vp_basketsm_bike_rear_rotE",
+          "vp_basketsm_bike_rear_rotS",
+          "vp_basketsm_bike_rear_rotW"
+        ]
       }
     ]
   },
@@ -27,23 +31,17 @@
     "id": [ "vp_basketlg", "vp_basketlg_external" ],
     "fg": [ "vp_basketlg_rotNrotS", "vp_basketlg_rotErotW" ],
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [ "vp_basketlg_rotNrotS", "vp_basketlg_rotErotW" ]
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": [ "vp_basketlg_rotNrotS", "vp_basketlg_rotErotW" ] } ]
   },
   {
     "id": "vp_basketlg_cart",
-    "fg": [ "vp_basketlg_cart_rotN", "vp_basketlg_cart_rotW", "vp_basketlg_cart_rotS", "vp_basketlg_cart_rotE" ],
+    "fg": [ "vp_basketlg_cart_rotN", "vp_basketlg_cart_rotE", "vp_basketlg_cart_rotS", "vp_basketlg_cart_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_basketlg_cart_rotN", "vp_basketlg_cart_rotW", "vp_basketlg_cart_rotS", "vp_basketlg_cart_rotE" ]
+        "bg": [ "vp_basketlg_cart_rotN", "vp_basketlg_cart_rotE", "vp_basketlg_cart_rotS", "vp_basketlg_cart_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/cargo/trunk.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/cargo/trunk.json
@@ -3,35 +3,23 @@
     "id": "vp_box",
     "fg": [ "vp_box", "vp_box_rot" ],
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [ "vp_box", "vp_box_rot" ]
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": [ "vp_box", "vp_box_rot" ] } ]
   },
   {
     "id": "vp_wood box",
     "fg": [ "vp_wood_box_rotNS", "vp_wood_box_rotEW" ],
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [ "vp_wood_box_rotNS", "vp_wood_box_rotEW" ]
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": [ "vp_wood_box_rotNS", "vp_wood_box_rotEW" ] } ]
   },
   {
     "id": "vp_box_wheelbarrow",
-    "fg": [ "vp_box_wheelbarrow_rotN", "vp_box_wheelbarrow_rotW", "vp_box_wheelbarrow_rotS", "vp_box_wheelbarrow_rotE" ],
+    "fg": [ "vp_box_wheelbarrow_rotN", "vp_box_wheelbarrow_rotE", "vp_box_wheelbarrow_rotS", "vp_box_wheelbarrow_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_box_wheelbarrow_rotN", "vp_box_wheelbarrow_rotW", "vp_box_wheelbarrow_rotS", "vp_box_wheelbarrow_rotE" ]
+        "bg": [ "vp_box_wheelbarrow_rotN", "vp_box_wheelbarrow_rotE", "vp_box_wheelbarrow_rotS", "vp_box_wheelbarrow_rotW" ]
       }
     ]
   },
@@ -39,36 +27,18 @@
     "id": "vp_trunk",
     "fg": "vp_trunk",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_trunk"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_trunk" } ]
   },
   {
     "id": "vp_trunk_rear_edge",
     "fg": "vp_trunk_rear_edge",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_trunk_rear_edge"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_trunk_rear_edge" } ]
   },
   {
     "id": "vp_cargo_space",
     "fg": "vp_cargo_space",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_cargo_space"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_cargo_space" } ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/doors/vp_door.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/doors/vp_door.json
@@ -1,48 +1,48 @@
 [
   {
     "id": [ "vp_hddoor_trunk_front", "vp_hdhatch_front", "vp_hdhatch_opaque" ],
-    "fg": [ "vp_hddoor_trunk", "vp_hddoor_trunk_rotW", "vp_hddoor_trunk_rotS", "vp_hddoor_trunk_rotE" ],
+    "fg": [ "vp_hddoor_trunk", "vp_hddoor_trunk_rotE", "vp_hddoor_trunk_rotS", "vp_hddoor_trunk_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hddoor_trunk_open", "vp_hddoor_trunk_open_rotW", "vp_hddoor_trunk_open", "vp_hddoor_trunk_open_rotE" ]
+        "fg": [ "vp_hddoor_trunk_open", "vp_hddoor_trunk_open_rotE", "vp_hddoor_trunk_open", "vp_hddoor_trunk_open_rotW" ]
       },
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_hddoor_trunk_open", "vp_hddoor_trunk_open_rotW", "vp_hddoor_trunk_open", "vp_hddoor_trunk_open_rotE" ]
+        "bg": [ "vp_hddoor_trunk_open", "vp_hddoor_trunk_open_rotE", "vp_hddoor_trunk_open", "vp_hddoor_trunk_open_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hddoor_front",
-    "fg": [ "vp_hddoor_front_rotS", "vp_hddoor_front_rotW", "vp_hddoor_front_rotS", "vp_hddoor_front_rotE" ],
+    "fg": [ "vp_hddoor_front_rotS", "vp_hddoor_front_rotE", "vp_hddoor_front_rotS", "vp_hddoor_front_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotW", "vp_door_front_open_rotN", "vp_door_front_open_rotE" ]
+        "fg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotE", "vp_door_front_open_rotN", "vp_door_front_open_rotW" ]
       },
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotW", "vp_door_front_open_rotN", "vp_door_front_open_rotE" ]
+        "bg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotE", "vp_door_front_open_rotN", "vp_door_front_open_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hddoor_rear",
-    "fg": [ "vp_hddoor_rear_rotN", "vp_hddoor_rear_rotW", "vp_hddoor_rear_rotS", "vp_hddoor_rear_rotE" ],
+    "fg": [ "vp_hddoor_rear_rotN", "vp_hddoor_rear_rotE", "vp_hddoor_rear_rotS", "vp_hddoor_rear_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
         "fg": [
           "vp_door_rear_edge_open_rotN",
-          "vp_door_rear_edge_open_rotW",
+          "vp_door_rear_edge_open_rotE",
           "vp_door_rear_edge_open_rotN",
-          "vp_door_rear_edge_open_rotE"
+          "vp_door_rear_edge_open_rotW"
         ]
       },
       {
@@ -50,9 +50,9 @@
         "fg": "crack_metal_center",
         "bg": [
           "vp_door_rear_edge_open_rotN",
-          "vp_door_rear_edge_open_rotW",
+          "vp_door_rear_edge_open_rotE",
           "vp_door_rear_edge_open_rotN",
-          "vp_door_rear_edge_open_rotE"
+          "vp_door_rear_edge_open_rotW"
         ]
       }
     ]
@@ -61,20 +61,20 @@
     "id": "vp_hddoor_opaque_front",
     "fg": [
       "vp_hddoor_opaque_front_rotS",
-      "vp_hddoor_opaque_front_rotW",
+      "vp_hddoor_opaque_front_rotE",
       "vp_hddoor_opaque_front_rotS",
-      "vp_hddoor_opaque_front_rotE"
+      "vp_hddoor_opaque_front_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotW", "vp_door_front_open_rotN", "vp_door_front_open_rotE" ]
+        "fg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotE", "vp_door_front_open_rotN", "vp_door_front_open_rotW" ]
       },
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotW", "vp_door_front_open_rotN", "vp_door_front_open_rotE" ]
+        "bg": [ "vp_door_front_open_rotN", "vp_door_front_open_rotE", "vp_door_front_open_rotN", "vp_door_front_open_rotW" ]
       }
     ]
   },
@@ -82,9 +82,9 @@
     "id": "vp_hddoor_opaque_rear",
     "fg": [
       "vp_hddoor_opaque_rear_rotN",
-      "vp_hddoor_opaque_rear_rotW",
+      "vp_hddoor_opaque_rear_rotE",
       "vp_hddoor_opaque_rear_rotN",
-      "vp_hddoor_opaque_rear_rotE"
+      "vp_hddoor_opaque_rear_rotW"
     ],
     "multitile": true,
     "additional_tiles": [
@@ -92,9 +92,9 @@
         "id": "open",
         "fg": [
           "vp_door_rear_edge_open_rotN",
-          "vp_door_rear_edge_open_rotW",
+          "vp_door_rear_edge_open_rotE",
           "vp_door_rear_edge_open_rotN",
-          "vp_door_rear_edge_open_rotE"
+          "vp_door_rear_edge_open_rotW"
         ]
       },
       {
@@ -102,9 +102,9 @@
         "fg": "crack_metal_center",
         "bg": [
           "vp_door_rear_edge_open_rotN",
-          "vp_door_rear_edge_open_rotW",
+          "vp_door_rear_edge_open_rotE",
           "vp_door_rear_edge_open_rotN",
-          "vp_door_rear_edge_open_rotE"
+          "vp_door_rear_edge_open_rotW"
         ]
       }
     ]

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/seats/car_seats/car_seats.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/seats/car_seats/car_seats.json
@@ -1,193 +1,225 @@
 [
   {
     "id": [ "vp_folding_seat", "vp_reclining_seat_front", "vp_seat_front" ],
-    "fg": [ "vp_seat_up", "vp_seat_left", "vp_seat_down", "vp_seat_right" ],
+    "fg": [ "vp_seat_up", "vp_seat_right", "vp_seat_down", "vp_seat_left" ],
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [ "vp_seat_up", "vp_seat_left", "vp_seat_down", "vp_seat_right" ]
-      }
+      { "id": "broken", "fg": "crack_metal_center", "bg": [ "vp_seat_up", "vp_seat_right", "vp_seat_down", "vp_seat_left" ] }
     ]
   },
   {
     "id": "vp_seat_back_front",
-    "fg": [ "vp_seat_back", "vp_seat_back_rotW", "vp_seat_back_rotS", "vp_seat_back_rotE" ],
+    "fg": [ "vp_seat_back", "vp_seat_back_rotE", "vp_seat_back_rotS", "vp_seat_back_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_back", "vp_seat_back_rotW", "vp_seat_back_rotS", "vp_seat_back_rotE" ]
+        "bg": [ "vp_seat_back", "vp_seat_back_rotE", "vp_seat_back_rotS", "vp_seat_back_rotW" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_left",
-    "fg": [ "vp_seat_back_left", "vp_seat_back_left_rotW", "vp_seat_back_left_rotS", "vp_seat_back_left_rotE" ],
+    "fg": [ "vp_seat_back_left", "vp_seat_back_left_rotE", "vp_seat_back_left_rotS", "vp_seat_back_left_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_back_left", "vp_seat_back_left_rotW", "vp_seat_back_left_rotS", "vp_seat_back_left_rotE" ]
+        "bg": [ "vp_seat_back_left", "vp_seat_back_left_rotE", "vp_seat_back_left_rotS", "vp_seat_back_left_rotW" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_right",
-    "fg": [ "vp_seat_back_right", "vp_seat_back_right_rotW", "vp_seat_back_right_rotS", "vp_seat_back_right_rotE" ],
+    "fg": [ "vp_seat_back_right", "vp_seat_back_right_rotE", "vp_seat_back_right_rotS", "vp_seat_back_right_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_back_right", "vp_seat_back_right_rotW", "vp_seat_back_right_rotS", "vp_seat_back_right_rotE" ]
+        "bg": [ "vp_seat_back_right", "vp_seat_back_right_rotE", "vp_seat_back_right_rotS", "vp_seat_back_right_rotW" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_vertical",
-    "fg": [ "vp_seat_back_rotE", "vp_seat_back", "vp_seat_back_rotW", "vp_seat_back_rotS" ],
+    "fg": [ "vp_seat_back_rotE", "vp_seat_back_rotS", "vp_seat_back_rotW", "vp_seat_back" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_back_rotE", "vp_seat_back", "vp_seat_back_rotW", "vp_seat_back_rotS" ]
+        "bg": [ "vp_seat_back_rotE", "vp_seat_back_rotS", "vp_seat_back_rotW", "vp_seat_back" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_vertical_left",
-    "fg": [ "vp_seat_back_left_rotE", "vp_seat_back_left", "vp_seat_back_left_rotW", "vp_seat_back_left_rotS" ],
+    "fg": [ "vp_seat_back_left_rotE", "vp_seat_back_left_rotS", "vp_seat_back_left_rotW", "vp_seat_back_left" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_back_left_rotE", "vp_seat_back_left", "vp_seat_back_left_rotW", "vp_seat_back_left_rotS" ]
+        "bg": [ "vp_seat_back_left_rotE", "vp_seat_back_left_rotS", "vp_seat_back_left_rotW", "vp_seat_back_left" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_vertical_right",
-    "fg": [ "vp_seat_back_right_rotE", "vp_seat_back_right", "vp_seat_back_right_rotW", "vp_seat_back_right_rotS" ],
+    "fg": [ "vp_seat_back_right_rotE", "vp_seat_back_right_rotS", "vp_seat_back_right_rotW", "vp_seat_back_right" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_back_right_rotE", "vp_seat_back_right", "vp_seat_back_right_rotW", "vp_seat_back_right_rotS" ]
+        "bg": [ "vp_seat_back_right_rotE", "vp_seat_back_right_rotS", "vp_seat_back_right_rotW", "vp_seat_back_right" ]
       }
     ]
   },
   {
     "id": [ "vp_seat_leather_front", "vp_reclining_seat_leather_front" ],
-    "fg": [ "vp_seat_leather_up", "vp_seat_leather_left", "vp_seat_leather_down", "vp_seat_leather_right" ],
+    "fg": [ "vp_seat_leather_up", "vp_seat_leather_right", "vp_seat_leather_down", "vp_seat_leather_left" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_leather_up", "vp_seat_leather_left", "vp_seat_leather_down", "vp_seat_leather_right" ]
+        "bg": [ "vp_seat_leather_up", "vp_seat_leather_right", "vp_seat_leather_down", "vp_seat_leather_left" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_leather_front",
-    "fg": [ "vp_seat_back_leather", "vp_seat_back_leather_rotW", "vp_seat_back_leather_rotS", "vp_seat_back_leather_rotE" ],
+    "fg": [ "vp_seat_back_leather", "vp_seat_back_leather_rotE", "vp_seat_back_leather_rotS", "vp_seat_back_leather_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_back_leather", "vp_seat_back_leather_rotW", "vp_seat_back_leather_rotS", "vp_seat_back_leather_rotE" ]
+        "bg": [ "vp_seat_back_leather", "vp_seat_back_leather_rotE", "vp_seat_back_leather_rotS", "vp_seat_back_leather_rotW" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_leather_left",
-    "fg": [ "vp_seat_back_leather_left", "vp_seat_back_leather_left_rotW", "vp_seat_back_leather_left_rotS", "vp_seat_back_leather_left_rotE" ],
+    "fg": [
+      "vp_seat_back_leather_left",
+      "vp_seat_back_leather_left_rotE",
+      "vp_seat_back_leather_left_rotS",
+      "vp_seat_back_leather_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_back_leather_left", "vp_seat_back_leather_left_rotW", "vp_seat_back_leather_left_rotS", "vp_seat_back_leather_left_rotE" ]
+        "bg": [
+          "vp_seat_back_leather_left",
+          "vp_seat_back_leather_left_rotE",
+          "vp_seat_back_leather_left_rotS",
+          "vp_seat_back_leather_left_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_seat_back_leather_right",
-    "fg": [ "vp_seat_back_leather_right", "vp_seat_back_leather_right_rotW", "vp_seat_back_leather_right_rotS", "vp_seat_back_leather_right_rotE" ],
+    "fg": [
+      "vp_seat_back_leather_right",
+      "vp_seat_back_leather_right_rotE",
+      "vp_seat_back_leather_right_rotS",
+      "vp_seat_back_leather_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_back_leather_right", "vp_seat_back_leather_right_rotW", "vp_seat_back_leather_right_rotS", "vp_seat_back_leather_right_rotE" ]
+        "bg": [
+          "vp_seat_back_leather_right",
+          "vp_seat_back_leather_right_rotE",
+          "vp_seat_back_leather_right_rotS",
+          "vp_seat_back_leather_right_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_seat_back_leather_vertical",
-    "fg": [ "vp_seat_back_leather_rotE", "vp_seat_back_leather", "vp_seat_back_leather_rotW", "vp_seat_back_leather_rotS" ],
+    "fg": [ "vp_seat_back_leather_rotE", "vp_seat_back_leather_rotS", "vp_seat_back_leather_rotW", "vp_seat_back_leather" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_back_leather_rotE", "vp_seat_back_leather", "vp_seat_back_leather_rotW", "vp_seat_back_leather_rotS" ]
+        "bg": [ "vp_seat_back_leather_rotE", "vp_seat_back_leather_rotS", "vp_seat_back_leather_rotW", "vp_seat_back_leather" ]
       }
     ]
   },
   {
     "id": "vp_seat_back_leather_vertical_left",
-    "fg": [ "vp_seat_back_leather_left_rotE", "vp_seat_back_leather_left", "vp_seat_back_leather_left_rotW", "vp_seat_back_leather_left_rotS" ],
+    "fg": [
+      "vp_seat_back_leather_left_rotE",
+      "vp_seat_back_leather_left_rotS",
+      "vp_seat_back_leather_left_rotW",
+      "vp_seat_back_leather_left"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_back_leather_left_rotE", "vp_seat_back_leather_left", "vp_seat_back_leather_left_rotW", "vp_seat_back_leather_left_rotS" ]
+        "bg": [
+          "vp_seat_back_leather_left_rotE",
+          "vp_seat_back_leather_left_rotS",
+          "vp_seat_back_leather_left_rotW",
+          "vp_seat_back_leather_left"
+        ]
       }
     ]
   },
   {
     "id": "vp_seat_back_leather_vertical_right",
-    "fg": [ "vp_seat_back_leather_right_rotE", "vp_seat_back_leather_right", "vp_seat_back_leather_right_rotW", "vp_seat_back_leather_right_rotS" ],
+    "fg": [
+      "vp_seat_back_leather_right_rotE",
+      "vp_seat_back_leather_right_rotS",
+      "vp_seat_back_leather_right_rotW",
+      "vp_seat_back_leather_right"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_back_leather_right_rotE", "vp_seat_back_leather_right", "vp_seat_back_leather_right_rotW", "vp_seat_back_leather_right_rotS" ]
+        "bg": [
+          "vp_seat_back_leather_right_rotE",
+          "vp_seat_back_leather_right_rotS",
+          "vp_seat_back_leather_right_rotW",
+          "vp_seat_back_leather_right"
+        ]
       }
     ]
   },
   {
     "id": "vp_seat_rear",
-    "fg": [ "vp_seat_down", "vp_seat_right", "vp_seat_up", "vp_seat_left" ],
+    "fg": [ "vp_seat_down", "vp_seat_left", "vp_seat_up", "vp_seat_right" ],
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [ "vp_seat_down", "vp_seat_right", "vp_seat_up", "vp_seat_left" ]
-      }
+      { "id": "broken", "fg": "crack_metal_center", "bg": [ "vp_seat_down", "vp_seat_left", "vp_seat_up", "vp_seat_right" ] }
     ]
   },
   {
     "id": "vp_seat_leather_rear",
-    "fg": [ "vp_seat_leather_down", "vp_seat_leather_right", "vp_seat_leather_up", "vp_seat_leather_left" ],
+    "fg": [ "vp_seat_leather_down", "vp_seat_leather_left", "vp_seat_leather_up", "vp_seat_leather_right" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_seat_leather_down", "vp_seat_leather_right", "vp_seat_leather_up", "vp_seat_leather_left" ]
+        "bg": [ "vp_seat_leather_down", "vp_seat_leather_left", "vp_seat_leather_up", "vp_seat_leather_right" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/seats/vp_saddle.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/seats/vp_saddle.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "vp_saddle", "vp_saddle_pedal" ],
-    "fg": [ "saddle_pedal_rotN", "saddle_pedal_rotW", "saddle_pedal_rotS", "saddle_pedal_rotE" ],
+    "fg": [ "saddle_pedal_rotN", "saddle_pedal_rotE", "saddle_pedal_rotS", "saddle_pedal_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "saddle_pedal_rotN", "saddle_pedal_rotW", "saddle_pedal_rotS", "saddle_pedal_rotE" ]
+        "bg": [ "saddle_pedal_rotN", "saddle_pedal_rotE", "saddle_pedal_rotS", "saddle_pedal_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/seed_drills/vp_seed_drill.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/seed_drills/vp_seed_drill.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "vp_seed_drill" ],
-    "fg": [ "vp_seed_drill_N", "vp_seed_drill_W", "vp_seed_drill_S", "vp_seed_drill_E" ],
+    "fg": [ "vp_seed_drill_N", "vp_seed_drill_E", "vp_seed_drill_S", "vp_seed_drill_W" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "3987_vp_cargo_space_2",
-        "bg": [ "vp_seed_drill_N", "vp_seed_drill_W", "vp_seed_drill_S", "vp_seed_drill_E" ]
+        "bg": [ "vp_seed_drill_N", "vp_seed_drill_E", "vp_seed_drill_S", "vp_seed_drill_W" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/tanks/tanks.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/tanks/tanks.json
@@ -1,13 +1,13 @@
 [
   {
     "id": "vp_external_tank",
-    "fg": [ "vp_external_tank", "vp_external_tank_rotE", "vp_external_tank_rotS", "vp_external_tank_rotW" ],
+    "fg": [ "vp_external_tank", "vp_external_tank_rotW", "vp_external_tank_rotS", "vp_external_tank_rotE" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_external_tank", "vp_external_tank_rotE", "vp_external_tank_rotS", "vp_external_tank_rotW" ]
+        "bg": [ "vp_external_tank", "vp_external_tank_rotW", "vp_external_tank_rotS", "vp_external_tank_rotE" ]
       }
     ]
   },
@@ -15,12 +15,6 @@
     "id": "vp_tank_55gal_drum",
     "fg": [ "vp_tank_55gal_drum_rotNS", "vp_tank_55gal_drum_rotEW" ],
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": [ "vp_tank_55gal_drum_rotNS", "vp_tank_55gal_drum_rotEW" ]
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": [ "vp_tank_55gal_drum_rotNS", "vp_tank_55gal_drum_rotEW" ] } ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/wheelchair/wheelchair.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/wheelchair/wheelchair.json
@@ -1,13 +1,13 @@
 [
   {
     "id": "vp_basketsm_wheelchair",
-    "fg": [ "wheelchair_north", "wheelchair_west", "wheelchair_south", "wheelchair_east" ],
+    "fg": [ "wheelchair_north", "wheelchair_east", "wheelchair_south", "wheelchair_west" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "wheelchair_north", "wheelchair_west", "wheelchair_south", "wheelchair_east" ]
+        "bg": [ "wheelchair_north", "wheelchair_east", "wheelchair_south", "wheelchair_west" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/wheels/wheels.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/wheels/wheels.json
@@ -3,35 +3,29 @@
     "id": "vp_wheel",
     "fg": "vp_wheel",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_metal_center",
-        "bg": "vp_wheel"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_metal_center", "bg": "vp_wheel" } ]
   },
   {
     "id": [ "vp_wheel_bicycle_front", "vp_wheel_bicycle_or_front" ],
-    "fg": [ "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotW", "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotE" ],
+    "fg": [ "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotE", "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotW", "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotE" ]
+        "bg": [ "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotE", "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotE" ]
       }
     ]
   },
   {
     "id": [ "vp_wheel_bicycle_rear", "vp_wheel_bicycle_or_rear" ],
-    "fg": [ "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotE", "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotW" ],
+    "fg": [ "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotW", "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotE" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotE", "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotW" ]
+        "bg": [ "vp_wheel_bicycle_rotS", "vp_wheel_bicycle_rotW", "vp_wheel_bicycle_rotN", "vp_wheel_bicycle_rotE" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/windshields/reinforced/vp_windshield_reinforced.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/windshields/reinforced/vp_windshield_reinforced.json
@@ -6,13 +6,23 @@
       "vp_reinforced_windshield_horizontal_front",
       "vp_reinforced_windshield_front_edge"
     ],
-    "fg": [ "vp_reinforced_windshield_horizontal_front", "vp_reinforced_windshield_horizontal_front_rotW", "vp_reinforced_windshield_horizontal_front_rotS", "vp_reinforced_windshield_horizontal_front_rotE" ],
+    "fg": [
+      "vp_reinforced_windshield_horizontal_front",
+      "vp_reinforced_windshield_horizontal_front_rotE",
+      "vp_reinforced_windshield_horizontal_front_rotS",
+      "vp_reinforced_windshield_horizontal_front_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_center",
-        "bg": [ "vp_reinforced_windshield_horizontal_front", "vp_reinforced_windshield_horizontal_front_rotW", "vp_reinforced_windshield_horizontal_front_rotS", "vp_reinforced_windshield_horizontal_front_rotE" ]
+        "bg": [
+          "vp_reinforced_windshield_horizontal_front",
+          "vp_reinforced_windshield_horizontal_front_rotE",
+          "vp_reinforced_windshield_horizontal_front_rotS",
+          "vp_reinforced_windshield_horizontal_front_rotW"
+        ]
       }
     ]
   },
@@ -20,47 +30,55 @@
     "id": "vp_reinforced_windshield_horizontal_rear",
     "fg": "vp_windshield_reinforced_horizontal_rear",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_glass_center",
-        "bg": "vp_windshield_reinforced_horizontal_rear"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_glass_center", "bg": "vp_windshield_reinforced_horizontal_rear" } ]
   },
   {
     "id": "vp_reinforced_windshield_horizontal_rear_edge",
     "fg": "vp_windshield_reinforced_horizontal_rear_edge",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_glass_center",
-        "bg": "vp_windshield_reinforced_horizontal_rear_edge"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_glass_center", "bg": "vp_windshield_reinforced_horizontal_rear_edge" } ]
   },
   {
     "id": "vp_reinforced_windshield_nw",
-    "fg": [ "vp_windshield_reinforced_nw", "vp_windshield_reinforced_nw_rotW", "vp_windshield_reinforced_nw_rotS", "vp_windshield_reinforced_nw_rotE" ],
+    "fg": [
+      "vp_windshield_reinforced_nw",
+      "vp_windshield_reinforced_nw_rotE",
+      "vp_windshield_reinforced_nw_rotS",
+      "vp_windshield_reinforced_nw_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_center",
-        "bg": [ "vp_windshield_reinforced_nw", "vp_windshield_reinforced_nw_rotW", "vp_windshield_reinforced_nw_rotS", "vp_windshield_reinforced_nw_rotE" ]
+        "bg": [
+          "vp_windshield_reinforced_nw",
+          "vp_windshield_reinforced_nw_rotE",
+          "vp_windshield_reinforced_nw_rotS",
+          "vp_windshield_reinforced_nw_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_reinforced_windshield_ne",
-    "fg": [ "vp_windshield_reinforced_ne", "vp_windshield_reinforced_ne_rotW", "vp_windshield_reinforced_ne_rotS", "vp_windshield_reinforced_ne_rotE" ],
+    "fg": [
+      "vp_windshield_reinforced_ne",
+      "vp_windshield_reinforced_ne_rotE",
+      "vp_windshield_reinforced_ne_rotS",
+      "vp_windshield_reinforced_ne_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_center",
-        "bg": [ "vp_windshield_reinforced_ne", "vp_windshield_reinforced_ne_rotW", "vp_windshield_reinforced_ne_rotS", "vp_windshield_reinforced_ne_rotE" ]
+        "bg": [
+          "vp_windshield_reinforced_ne",
+          "vp_windshield_reinforced_ne_rotE",
+          "vp_windshield_reinforced_ne_rotS",
+          "vp_windshield_reinforced_ne_rotW"
+        ]
       }
     ]
   },
@@ -68,71 +86,99 @@
     "id": "vp_reinforced_windshield_sw",
     "fg": "vp_windshield_reinforced_sw",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_glass_center",
-        "bg": "vp_windshield_reinforced_sw"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_glass_center", "bg": "vp_windshield_reinforced_sw" } ]
   },
   {
     "id": "vp_reinforced_windshield_se",
     "fg": "vp_windshield_reinforced_se",
     "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "broken",
-        "fg": "crack_glass_center",
-        "bg": "vp_windshield_reinforced_se"
-      }
-    ]
+    "additional_tiles": [ { "id": "broken", "fg": "crack_glass_center", "bg": "vp_windshield_reinforced_se" } ]
   },
   {
     "id": "vp_reinforced_windshield_sw_edge",
-    "fg": [ "vp_windshield_reinforced_sw_edge", "vp_windshield_reinforced_sw_edge_rotW", "vp_windshield_reinforced_sw_edge_rotS", "vp_windshield_reinforced_sw_edge_rotE" ],
+    "fg": [
+      "vp_windshield_reinforced_sw_edge",
+      "vp_windshield_reinforced_sw_edge_rotE",
+      "vp_windshield_reinforced_sw_edge_rotS",
+      "vp_windshield_reinforced_sw_edge_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_center",
-        "bg": [ "vp_windshield_reinforced_sw_edge", "vp_windshield_reinforced_sw_edge_rotW", "vp_windshield_reinforced_sw_edge_rotS", "vp_windshield_reinforced_sw_edge_rotE" ]
+        "bg": [
+          "vp_windshield_reinforced_sw_edge",
+          "vp_windshield_reinforced_sw_edge_rotE",
+          "vp_windshield_reinforced_sw_edge_rotS",
+          "vp_windshield_reinforced_sw_edge_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_reinforced_windshield_se_edge",
-    "fg": [ "vp_windshield_reinforced_se_edge", "vp_windshield_reinforced_se_edge_rotW", "vp_windshield_reinforced_se_edge_rotS", "vp_windshield_reinforced_se_edge_rotE" ],
+    "fg": [
+      "vp_windshield_reinforced_se_edge",
+      "vp_windshield_reinforced_se_edge_rotE",
+      "vp_windshield_reinforced_se_edge_rotS",
+      "vp_windshield_reinforced_se_edge_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_center",
-        "bg": [ "vp_windshield_reinforced_se_edge", "vp_windshield_reinforced_se_edge_rotW", "vp_windshield_reinforced_se_edge_rotS", "vp_windshield_reinforced_se_edge_rotE" ]
+        "bg": [
+          "vp_windshield_reinforced_se_edge",
+          "vp_windshield_reinforced_se_edge_rotE",
+          "vp_windshield_reinforced_se_edge_rotS",
+          "vp_windshield_reinforced_se_edge_rotW"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_reinforced_windshield_vertical_left", "vp_reinforced_windshield_left" ],
-    "fg": [ "vp_windshield_reinforced_vertical_left", "vp_windshield_reinforced_vertical_left_rotW", "vp_windshield_reinforced_vertical_left_rotS", "vp_windshield_reinforced_vertical_left_rotE" ],
+    "fg": [
+      "vp_windshield_reinforced_vertical_left",
+      "vp_windshield_reinforced_vertical_left_rotE",
+      "vp_windshield_reinforced_vertical_left_rotS",
+      "vp_windshield_reinforced_vertical_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_center",
-        "bg": [ "vp_windshield_reinforced_vertical_left", "vp_windshield_reinforced_vertical_left_rotW", "vp_windshield_reinforced_vertical_left_rotS", "vp_windshield_reinforced_vertical_left_rotE" ]
+        "bg": [
+          "vp_windshield_reinforced_vertical_left",
+          "vp_windshield_reinforced_vertical_left_rotE",
+          "vp_windshield_reinforced_vertical_left_rotS",
+          "vp_windshield_reinforced_vertical_left_rotW"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_reinforced_windshield_vertical_right", "vp_reinforced_windshield_right" ],
-    "fg": [ "vp_windshield_reinforced_vertical_right", "vp_windshield_reinforced_vertical_right_rotW", "vp_windshield_reinforced_vertical_right_rotS", "vp_windshield_reinforced_vertical_right_rotE" ],
+    "fg": [
+      "vp_windshield_reinforced_vertical_right",
+      "vp_windshield_reinforced_vertical_right_rotE",
+      "vp_windshield_reinforced_vertical_right_rotS",
+      "vp_windshield_reinforced_vertical_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_center",
-        "bg": [ "vp_windshield_reinforced_vertical_right", "vp_windshield_reinforced_vertical_right_rotW", "vp_windshield_reinforced_vertical_right_rotS", "vp_windshield_reinforced_vertical_right_rotE" ]
+        "bg": [
+          "vp_windshield_reinforced_vertical_right",
+          "vp_windshield_reinforced_vertical_right_rotE",
+          "vp_windshield_reinforced_vertical_right_rotS",
+          "vp_windshield_reinforced_vertical_right_rotW"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/windshields/reinforced/vp_windshield_reinforced_full.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_32x32/vehicle/windshields/reinforced/vp_windshield_reinforced_full.json
@@ -1,25 +1,45 @@
 [
   {
     "id": [ "vp_reinforced_windshield_full_vertical_left", "vp_reinforced_windshield_full_left" ],
-    "fg": [ "vp_windshield_reinforced_vertical_left", "vp_windshield_reinforced_vertical_left_rotW", "vp_windshield_reinforced_vertical_left_rotS", "vp_windshield_reinforced_vertical_left_rotE" ],
+    "fg": [
+      "vp_windshield_reinforced_vertical_left",
+      "vp_windshield_reinforced_vertical_left_rotE",
+      "vp_windshield_reinforced_vertical_left_rotS",
+      "vp_windshield_reinforced_vertical_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_center",
-        "bg": [ "vp_windshield_reinforced_vertical_left", "vp_windshield_reinforced_vertical_left_rotW", "vp_windshield_reinforced_vertical_left_rotS", "vp_windshield_reinforced_vertical_left_rotE" ]
+        "bg": [
+          "vp_windshield_reinforced_vertical_left",
+          "vp_windshield_reinforced_vertical_left_rotE",
+          "vp_windshield_reinforced_vertical_left_rotS",
+          "vp_windshield_reinforced_vertical_left_rotW"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_reinforced_windshield_full_vertical_right", "vp_reinforced_windshield_full_right" ],
-    "fg": [ "vp_windshield_reinforced_vertical_right", "vp_windshield_reinforced_vertical_right_rotW", "vp_windshield_reinforced_vertical_right_rotS", "vp_windshield_reinforced_vertical_right_rotE" ],
+    "fg": [
+      "vp_windshield_reinforced_vertical_right",
+      "vp_windshield_reinforced_vertical_right_rotE",
+      "vp_windshield_reinforced_vertical_right_rotS",
+      "vp_windshield_reinforced_vertical_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_glass_center",
-        "bg": [ "vp_windshield_reinforced_vertical_right", "vp_windshield_reinforced_vertical_right_rotW", "vp_windshield_reinforced_vertical_right_rotS", "vp_windshield_reinforced_vertical_right_rotE" ]
+        "bg": [
+          "vp_windshield_reinforced_vertical_right",
+          "vp_windshield_reinforced_vertical_right_rotE",
+          "vp_windshield_reinforced_vertical_right_rotS",
+          "vp_windshield_reinforced_vertical_right_rotW"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/magiclysm/wizard_tower1/wizard_tower1.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/magiclysm/wizard_tower1/wizard_tower1.json
@@ -1,7 +1,7 @@
 [
   {
     "id": [ "wizardtower1_ground", "wizardtower1_living", "wizardtower1_golems", "wizardtower1_study", "wizardtower1_roof" ],
-    "fg": [ "wizard_tower1_rot_N", "wizard_tower1_rot_W", "wizard_tower1_rot_S", "wizard_tower1_rot_E" ],
+    "fg": [ "wizard_tower1_rot_N", "wizard_tower1_rot_E", "wizard_tower1_rot_S", "wizard_tower1_rot_W" ],
     "bg": "field_large",
     "rotates": true
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/vehicle/vp_door_trunk_horizontal_2(boards)/vp_door_trunk_horizontal_2.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/vehicle/vp_door_trunk_horizontal_2(boards)/vp_door_trunk_horizontal_2.json
@@ -1,17 +1,32 @@
 [
   {
     "id": "vp_door_trunk_horizontal_2",
-    "fg": [ "vp_door_trunk_horizontal_2", "vp_door_trunk_horizontal_2_rotW", "vp_door_trunk_horizontal_2_rotS", "vp_door_trunk_horizontal_2_rotE" ],
+    "fg": [
+      "vp_door_trunk_horizontal_2",
+      "vp_door_trunk_horizontal_2_rotE",
+      "vp_door_trunk_horizontal_2_rotS",
+      "vp_door_trunk_horizontal_2_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_trunk_horizontal_2_open", "vp_door_trunk_horizontal_2_open_rotW", "vp_door_trunk_horizontal_2_open_rotS", "vp_door_trunk_horizontal_2_open_rotE" ]
+        "fg": [
+          "vp_door_trunk_horizontal_2_open",
+          "vp_door_trunk_horizontal_2_open_rotE",
+          "vp_door_trunk_horizontal_2_open_rotS",
+          "vp_door_trunk_horizontal_2_open_rotW"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large" ],
-        "bg": [ "vp_door_trunk_horizontal_2_open", "vp_door_trunk_horizontal_2_open_rotW", "vp_door_trunk_horizontal_2_open_rotS", "vp_door_trunk_horizontal_2_open_rotE" ]
+        "bg": [
+          "vp_door_trunk_horizontal_2_open",
+          "vp_door_trunk_horizontal_2_open_rotE",
+          "vp_door_trunk_horizontal_2_open_rotS",
+          "vp_door_trunk_horizontal_2_open_rotW"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/vehicle/vp_halfboard_hatch_wheel/vp_halfboard_hatch_wheel.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/vehicle/vp_halfboard_hatch_wheel/vp_halfboard_hatch_wheel.json
@@ -1,25 +1,45 @@
 [
   {
     "id": "vp_halfboard_hatch_wheel_left",
-    "fg": [ "vp_halfboard_hatch_wheel_left", "vp_halfboard_hatch_wheel_left_rotW", "vp_halfboard_hatch_wheel_left_rotS", "vp_halfboard_hatch_wheel_left_rotE" ],
+    "fg": [
+      "vp_halfboard_hatch_wheel_left",
+      "vp_halfboard_hatch_wheel_left_rotE",
+      "vp_halfboard_hatch_wheel_left_rotS",
+      "vp_halfboard_hatch_wheel_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large" ],
-        "bg": [ "vp_halfboard_hatch_wheel_left", "vp_halfboard_hatch_wheel_left_rotW", "vp_halfboard_hatch_wheel_left_rotS", "vp_halfboard_hatch_wheel_left_rotE" ]
+        "bg": [
+          "vp_halfboard_hatch_wheel_left",
+          "vp_halfboard_hatch_wheel_left_rotE",
+          "vp_halfboard_hatch_wheel_left_rotS",
+          "vp_halfboard_hatch_wheel_left_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_halfboard_hatch_wheel_right",
-    "fg": [ "vp_halfboard_hatch_wheel_right", "vp_halfboard_hatch_wheel_right_rotW", "vp_halfboard_hatch_wheel_right_rotS", "vp_halfboard_hatch_wheel_right_rotE" ],
+    "fg": [
+      "vp_halfboard_hatch_wheel_right",
+      "vp_halfboard_hatch_wheel_right_rotE",
+      "vp_halfboard_hatch_wheel_right_rotS",
+      "vp_halfboard_hatch_wheel_right_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large" ],
-        "bg": [ "vp_halfboard_hatch_wheel_right", "vp_halfboard_hatch_wheel_right_rotW", "vp_halfboard_hatch_wheel_right_rotS", "vp_halfboard_hatch_wheel_right_rotE" ]
+        "bg": [
+          "vp_halfboard_hatch_wheel_right",
+          "vp_halfboard_hatch_wheel_right_rotE",
+          "vp_halfboard_hatch_wheel_right_rotS",
+          "vp_halfboard_hatch_wheel_right_rotW"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/vehicle/vp_halfboard_horizontal_2_rear/vp_halfboard_horizontal_2_rear.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/vehicle/vp_halfboard_horizontal_2_rear/vp_halfboard_horizontal_2_rear.json
@@ -1,13 +1,23 @@
 [
   {
     "id": "vp_halfboard_horizontal_2_rear",
-    "fg": [ "vp_halfboard_horizontal_2_rear", "vp_halfboard_horizontal_2_rear_rotW", "vp_halfboard_horizontal_2_rear_rotS", "vp_halfboard_horizontal_2_rear_rotE" ],
+    "fg": [
+      "vp_halfboard_horizontal_2_rear",
+      "vp_halfboard_horizontal_2_rear_rotE",
+      "vp_halfboard_horizontal_2_rear_rotS",
+      "vp_halfboard_horizontal_2_rear_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": [ "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large" ],
-        "bg": [ "vp_halfboard_horizontal_2_rear", "vp_halfboard_horizontal_2_rear_rotW", "vp_halfboard_horizontal_2_rear_rotS", "vp_halfboard_horizontal_2_rear_rotE" ]
+        "bg": [
+          "vp_halfboard_horizontal_2_rear",
+          "vp_halfboard_horizontal_2_rear_rotE",
+          "vp_halfboard_horizontal_2_rear_rotS",
+          "vp_halfboard_horizontal_2_rear_rotW"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/vehicle/vp_hatch/aligns-to-boards/vp_hatch_boards.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/vehicle/vp_hatch/aligns-to-boards/vp_hatch_boards.json
@@ -1,193 +1,253 @@
 [
   {
     "id": "vp_hatch_left",
-    "fg": [ "vp_hatch_left", "vp_hatch_left_rotW", "vp_hatch_left_rotS", "vp_hatch_left_rotE" ],
+    "fg": [ "vp_hatch_left", "vp_hatch_left_rotE", "vp_hatch_left_rotS", "vp_hatch_left_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_left_open", "vp_hatch_left_open_rotW", "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotE" ]
+        "fg": [ "vp_hatch_left_open", "vp_hatch_left_open_rotE", "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotW" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hatch_left_open", "vp_hatch_left_open_rotW", "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotE" ]
+        "bg": [ "vp_hatch_left_open", "vp_hatch_left_open_rotE", "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hatch_right",
-    "fg": [ "vp_hatch_left_rotS", "vp_hatch_left_rotE", "vp_hatch_left", "vp_hatch_left_rotW" ],
+    "fg": [ "vp_hatch_left_rotS", "vp_hatch_left_rotW", "vp_hatch_left", "vp_hatch_left_rotE" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotE", "vp_hatch_left_open", "vp_hatch_left_open_rotW" ]
+        "fg": [ "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotW", "vp_hatch_left_open", "vp_hatch_left_open_rotE" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotE", "vp_hatch_left_open", "vp_hatch_left_open_rotW" ]
+        "bg": [ "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotW", "vp_hatch_left_open", "vp_hatch_left_open_rotE" ]
       }
     ]
   },
   {
     "id": "vp_hatch_wheel_left",
-    "fg": [ "vp_hatch_left", "vp_hatch_wheel_left_rotW", "vp_hatch_left_rotS", "vp_hatch_left_rotE" ],
+    "fg": [ "vp_hatch_left", "vp_hatch_left_rotE", "vp_hatch_left_rotS", "vp_hatch_wheel_left_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_left_open", "vp_hatch_wheel_left_open_rotW", "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotE" ]
+        "fg": [ "vp_hatch_left_open", "vp_hatch_left_open_rotE", "vp_hatch_left_open_rotS", "vp_hatch_wheel_left_open_rotW" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hatch_left_open", "vp_hatch_left_open_rotW", "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotE" ]
+        "bg": [ "vp_hatch_left_open", "vp_hatch_left_open_rotE", "vp_hatch_left_open_rotS", "vp_hatch_wheel_left_open_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hatch_wheel_right",
-    "fg": [ "vp_hatch_left_rotS", "vp_hatch_left_rotE", "vp_hatch_left", "vp_hatch_wheel_left_rotW" ],
+    "fg": [ "vp_hatch_left_rotS", "vp_hatch_wheel_left_rotW", "vp_hatch_left", "vp_hatch_left_rotE" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotE", "vp_hatch_left_open", "vp_hatch_wheel_left_open_rotW" ]
+        "fg": [ "vp_hatch_left_open_rotS", "vp_hatch_wheel_left_open_rotW", "vp_hatch_left_open", "vp_hatch_left_open_rotE" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotE", "vp_hatch_left_open", "vp_hatch_wheel_left_open_rotW" ]
+        "bg": [ "vp_hatch_left_open_rotS", "vp_hatch_wheel_left_open_rotW", "vp_hatch_left_open", "vp_hatch_left_open_rotE" ]
       }
     ]
   },
   {
-    "id": [ "vp_hatch_horizontal_rear", "vp_hatch_horizontal", "vp_hatch_horizontal_2"],
-    "fg": [ "vp_hatch_horizontal_rear", "vp_hatch_left_rotS", "vp_hatch_left_rotE", "vp_hatch_left" ],
+    "id": [ "vp_hatch_horizontal_rear", "vp_hatch_horizontal", "vp_hatch_horizontal_2" ],
+    "fg": [ "vp_hatch_horizontal_rear", "vp_hatch_left", "vp_hatch_left_rotE", "vp_hatch_left_rotS" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_horizontal_rear_open", "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotE", "vp_hatch_left_open" ]
+        "fg": [ "vp_hatch_horizontal_rear_open", "vp_hatch_left_open", "vp_hatch_left_open_rotE", "vp_hatch_left_open_rotS" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hatch_horizontal_rear_open", "vp_hatch_left_open_rotS", "vp_hatch_left_open_rotE", "vp_hatch_left_open" ]
+        "bg": [ "vp_hatch_horizontal_rear_open", "vp_hatch_left_open", "vp_hatch_left_open_rotE", "vp_hatch_left_open_rotS" ]
       }
     ]
   },
   {
     "id": "vp_hatch_horizontal_front",
-    "fg": [ "vp_hatch_left_rotE", "vp_hatch_left", "vp_hatch_horizontal_rear", "vp_hatch_left_rotS" ],
+    "fg": [ "vp_hatch_left_rotE", "vp_hatch_left_rotS", "vp_hatch_horizontal_rear", "vp_hatch_left" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_left_open_rotE", "vp_hatch_left_open", "vp_hatch_horizontal_rear_open", "vp_hatch_left_open_rotS" ]
+        "fg": [ "vp_hatch_left_open_rotE", "vp_hatch_left_open_rotS", "vp_hatch_horizontal_rear_open", "vp_hatch_left_open" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hatch_left_open_rotE", "vp_hatch_left_open", "vp_hatch_horizontal_rear_open", "vp_hatch_left_open_rotS" ]
+        "bg": [ "vp_hatch_left_open_rotE", "vp_hatch_left_open_rotS", "vp_hatch_horizontal_rear_open", "vp_hatch_left_open" ]
       }
     ]
   },
   {
     "id": "vp_hatch_opaque_left",
-    "fg": [ "vp_hatch_left", "vp_hatch_opaque_left_rotW", "vp_hatch_left_rotS", "vp_hatch_opaque_left_rotE" ],
+    "fg": [ "vp_hatch_left", "vp_hatch_opaque_left_rotE", "vp_hatch_left_rotS", "vp_hatch_opaque_left_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_opaque_left_open", "vp_hatch_opaque_left_open_rotW", "vp_hatch_opaque_left_open_rotS", "vp_hatch_opaque_left_open_rotE" ]
+        "fg": [
+          "vp_hatch_opaque_left_open",
+          "vp_hatch_opaque_left_open_rotE",
+          "vp_hatch_opaque_left_open_rotS",
+          "vp_hatch_opaque_left_open_rotW"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hatch_opaque_left_open", "vp_hatch_opaque_left_open_rotW", "vp_hatch_opaque_left_open_rotS", "vp_hatch_opaque_left_open_rotE" ]
+        "bg": [
+          "vp_hatch_opaque_left_open",
+          "vp_hatch_opaque_left_open_rotE",
+          "vp_hatch_opaque_left_open_rotS",
+          "vp_hatch_opaque_left_open_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_hatch_opaque_right",
-    "fg": [ "vp_hatch_left_rotS", "vp_hatch_opaque_left_rotE", "vp_hatch_left", "vp_hatch_opaque_left_rotW" ],
+    "fg": [ "vp_hatch_left_rotS", "vp_hatch_opaque_left_rotW", "vp_hatch_left", "vp_hatch_opaque_left_rotE" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_opaque_left_open_rotS", "vp_hatch_opaque_left_open_rotE", "vp_hatch_opaque_left_open", "vp_hatch_opaque_left_open_rotW" ]
+        "fg": [
+          "vp_hatch_opaque_left_open_rotS",
+          "vp_hatch_opaque_left_open_rotW",
+          "vp_hatch_opaque_left_open",
+          "vp_hatch_opaque_left_open_rotE"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hatch_opaque_left_open_rotS", "vp_hatch_opaque_left_open_rotE", "vp_hatch_opaque_left_open", "vp_hatch_opaque_left_open_rotW" ]
+        "bg": [
+          "vp_hatch_opaque_left_open_rotS",
+          "vp_hatch_opaque_left_open_rotW",
+          "vp_hatch_opaque_left_open",
+          "vp_hatch_opaque_left_open_rotE"
+        ]
       }
     ]
   },
   {
     "id": "vp_hatch_opaque_wheel_left",
-    "fg": [ "vp_hatch_left", "vp_hatch_opaque_wheel_left_rotW", "vp_hatch_left_rotS", "vp_hatch_opaque_left_rotE" ],
+    "fg": [ "vp_hatch_left", "vp_hatch_opaque_left_rotE", "vp_hatch_left_rotS", "vp_hatch_opaque_wheel_left_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_opaque_left_open", "vp_hatch_opaque_wheel_left_open_rotW", "vp_hatch_opaque_left_open_rotS", "vp_hatch_opaque_left_open_rotE" ]
+        "fg": [
+          "vp_hatch_opaque_left_open",
+          "vp_hatch_opaque_left_open_rotE",
+          "vp_hatch_opaque_left_open_rotS",
+          "vp_hatch_opaque_wheel_left_open_rotW"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hatch_opaque_left_open", "vp_hatch_opaque_wheel_left_open_rotW", "vp_hatch_opaque_left_open_rotS", "vp_hatch_opaque_left_open_rotE" ]
+        "bg": [
+          "vp_hatch_opaque_left_open",
+          "vp_hatch_opaque_left_open_rotE",
+          "vp_hatch_opaque_left_open_rotS",
+          "vp_hatch_opaque_wheel_left_open_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_hatch_opaque_wheel_right",
-    "fg": [ "vp_hatch_left_rotS", "vp_hatch_opaque_left_rotE", "vp_hatch_left", "vp_hatch_opaque_wheel_left_rotW" ],
+    "fg": [ "vp_hatch_left_rotS", "vp_hatch_opaque_wheel_left_rotW", "vp_hatch_left", "vp_hatch_opaque_left_rotE" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_opaque_left_open_rotS", "vp_hatch_opaque_left_open_rotE", "vp_hatch_opaque_left_open", "vp_hatch_opaque_wheel_left_open_rotW" ]
+        "fg": [
+          "vp_hatch_opaque_left_open_rotS",
+          "vp_hatch_opaque_wheel_left_open_rotW",
+          "vp_hatch_opaque_left_open",
+          "vp_hatch_opaque_left_open_rotE"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hatch_opaque_left_open_rotS", "vp_hatch_opaque_left_open_rotE", "vp_hatch_opaque_left_open", "vp_hatch_opaque_wheel_left_open_rotW" ]
+        "bg": [
+          "vp_hatch_opaque_left_open_rotS",
+          "vp_hatch_opaque_wheel_left_open_rotW",
+          "vp_hatch_opaque_left_open",
+          "vp_hatch_opaque_left_open_rotE"
+        ]
       }
     ]
   },
   {
-    "id": [ "vp_hatch_opaque_horizontal_rear", "vp_hatch_opaque_horizontal", "vp_hatch_opaque_horizontal_2"],
-    "fg": [ "vp_hatch_opaque_horizontal_rear", "vp_hatch_left_rotS", "vp_hatch_opaque_left_rotE", "vp_hatch_left" ],
+    "id": [ "vp_hatch_opaque_horizontal_rear", "vp_hatch_opaque_horizontal", "vp_hatch_opaque_horizontal_2" ],
+    "fg": [ "vp_hatch_opaque_horizontal_rear", "vp_hatch_left", "vp_hatch_opaque_left_rotE", "vp_hatch_left_rotS" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_opaque_horizontal_rear_open", "vp_hatch_opaque_left_open_rotS", "vp_hatch_opaque_left_open_rotE", "vp_hatch_opaque_left_open" ]
+        "fg": [
+          "vp_hatch_opaque_horizontal_rear_open",
+          "vp_hatch_opaque_left_open",
+          "vp_hatch_opaque_left_open_rotE",
+          "vp_hatch_opaque_left_open_rotS"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hatch_opaque_horizontal_rear_open", "vp_hatch_opaque_left_open_rotS", "vp_hatch_opaque_left_open_rotE", "vp_hatch_opaque_left_open" ]
+        "bg": [
+          "vp_hatch_opaque_horizontal_rear_open",
+          "vp_hatch_opaque_left_open",
+          "vp_hatch_opaque_left_open_rotE",
+          "vp_hatch_opaque_left_open_rotS"
+        ]
       }
     ]
   },
   {
     "id": "vp_hatch_opaque_horizontal_front",
-    "fg": [ "vp_hatch_opaque_left_rotE", "vp_hatch_left", "vp_hatch_opaque_horizontal_rear", "vp_hatch_left_rotS" ],
+    "fg": [ "vp_hatch_opaque_left_rotE", "vp_hatch_left_rotS", "vp_hatch_opaque_horizontal_rear", "vp_hatch_left" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_opaque_left_open_rotE", "vp_hatch_opaque_left_open", "vp_hatch_opaque_horizontal_rear_open", "vp_hatch_opaque_left_open_rotS" ]
+        "fg": [
+          "vp_hatch_opaque_left_open_rotE",
+          "vp_hatch_opaque_left_open_rotS",
+          "vp_hatch_opaque_horizontal_rear_open",
+          "vp_hatch_opaque_left_open"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_hatch_opaque_left_open_rotE", "vp_hatch_opaque_left_open", "vp_hatch_opaque_horizontal_rear_open", "vp_hatch_opaque_left_open_rotS" ]
+        "bg": [
+          "vp_hatch_opaque_left_open_rotE",
+          "vp_hatch_opaque_left_open_rotS",
+          "vp_hatch_opaque_horizontal_rear_open",
+          "vp_hatch_opaque_left_open"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/vehicle/vp_hatch/vp_hatch.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/vehicle/vp_hatch/vp_hatch.json
@@ -1,33 +1,30 @@
 [
   {
     "id": "vp_hatch_front",
-    "fg": [ "vp_hatch", "vp_hatch_rotW", "vp_hatch_rotS", "vp_hatch_rotE" ],
+    "fg": [ "vp_hatch", "vp_hatch_rotE", "vp_hatch_rotS", "vp_hatch_rotW" ],
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "open",
-        "fg": [ "vp_hatch_open", "vp_hatch_open_rotW", "vp_hatch_open_rotS", "vp_hatch_open_rotE" ]
-      },
+      { "id": "open", "fg": [ "vp_hatch_open", "vp_hatch_open_rotE", "vp_hatch_open_rotS", "vp_hatch_open_rotW" ] },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large" ],
-        "bg": [ "vp_hatch_open", "vp_hatch_open_rotW", "vp_hatch_open_rotS", "vp_hatch_open_rotE" ]
+        "bg": [ "vp_hatch_open", "vp_hatch_open_rotE", "vp_hatch_open_rotS", "vp_hatch_open_rotW" ]
       }
     ]
   },
   {
     "id": "vp_hatch_opaque_front",
-    "fg": [ "vp_hatch_opaque", "vp_hatch_opaque_rotW", "vp_hatch_opaque_rotS", "vp_hatch_opaque_rotE" ],
+    "fg": [ "vp_hatch_opaque", "vp_hatch_opaque_rotE", "vp_hatch_opaque_rotS", "vp_hatch_opaque_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_hatch_opaque_open", "vp_hatch_opaque_open_rotW", "vp_hatch_opaque_open_rotS", "vp_hatch_opaque_open_rotE" ]
+        "fg": [ "vp_hatch_opaque_open", "vp_hatch_opaque_open_rotE", "vp_hatch_opaque_open_rotS", "vp_hatch_opaque_open_rotW" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large" ],
-        "bg": [ "vp_hatch_opaque_open", "vp_hatch_opaque_open_rotW", "vp_hatch_opaque_open_rotS", "vp_hatch_opaque_open_rotE" ]
+        "bg": [ "vp_hatch_opaque_open", "vp_hatch_opaque_open_rotE", "vp_hatch_opaque_open_rotS", "vp_hatch_opaque_open_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/vehicle/vp_trunk_hatch_wheel/vp_door_trunk_hacth_wheel_left.json
+++ b/gfx/UltimateCataclysm/pngs_incomplete_large_64x64/vehicle/vp_trunk_hatch_wheel/vp_door_trunk_hacth_wheel_left.json
@@ -1,33 +1,63 @@
 [
   {
     "id": "vp_door_trunk_hatch_wheel_left",
-    "fg": [ "vp_door_trunk_hatch_wheel_left", "vp_door_trunk_hatch_wheel_left_rotW", "vp_door_trunk_hatch_wheel_left_rotS", "vp_door_trunk_hatch_wheel_left_rotE" ],
+    "fg": [
+      "vp_door_trunk_hatch_wheel_left",
+      "vp_door_trunk_hatch_wheel_left_rotE",
+      "vp_door_trunk_hatch_wheel_left_rotS",
+      "vp_door_trunk_hatch_wheel_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_trunk_hatch_wheel_left_open", "vp_door_trunk_hatch_wheel_left_open_rotW", "vp_door_trunk_hatch_wheel_left_open_rotS", "vp_door_trunk_hatch_wheel_left_open_rotE" ]
+        "fg": [
+          "vp_door_trunk_hatch_wheel_left_open",
+          "vp_door_trunk_hatch_wheel_left_open_rotE",
+          "vp_door_trunk_hatch_wheel_left_open_rotS",
+          "vp_door_trunk_hatch_wheel_left_open_rotW"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large" ],
-        "bg": [ "vp_door_trunk_hatch_wheel_left_open", "vp_door_trunk_hatch_wheel_left_open_rotW", "vp_door_trunk_hatch_wheel_left_open_rotS", "vp_door_trunk_hatch_wheel_left_open_rotE" ]
+        "bg": [
+          "vp_door_trunk_hatch_wheel_left_open",
+          "vp_door_trunk_hatch_wheel_left_open_rotE",
+          "vp_door_trunk_hatch_wheel_left_open_rotS",
+          "vp_door_trunk_hatch_wheel_left_open_rotW"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_door_trunk_wheel_left", "vp_door_trunk_wheel_right" ],
-    "fg": [ "vp_door_trunk_hatch_wheel_left", "vp_door_trunk_hatch_floor_wheel_left_rotW", "vp_door_trunk_hatch_wheel_left_rotS", "vp_door_trunk_hatch_floor_wheel_left_rotE" ],
+    "fg": [
+      "vp_door_trunk_hatch_wheel_left",
+      "vp_door_trunk_hatch_floor_wheel_left_rotE",
+      "vp_door_trunk_hatch_wheel_left_rotS",
+      "vp_door_trunk_hatch_floor_wheel_left_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_trunk_hatch_wheel_left_open", "vp_door_trunk_hatch_floor_wheel_left_open_rotW", "vp_door_trunk_hatch_wheel_left_open_rotS", "vp_door_trunk_hatch_floor_wheel_left_open_rotE" ]
+        "fg": [
+          "vp_door_trunk_hatch_wheel_left_open",
+          "vp_door_trunk_hatch_floor_wheel_left_open_rotE",
+          "vp_door_trunk_hatch_wheel_left_open_rotS",
+          "vp_door_trunk_hatch_floor_wheel_left_open_rotW"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large", "crack_metal_center_large" ],
-        "bg": [ "vp_door_trunk_hatch_wheel_left_open", "vp_door_trunk_hatch_floor_wheel_left_open_rotW", "vp_door_trunk_hatch_wheel_left_open_rotS", "vp_door_trunk_hatch_floor_wheel_left_open_rotE" ]
+        "bg": [
+          "vp_door_trunk_hatch_wheel_left_open",
+          "vp_door_trunk_hatch_floor_wheel_left_open_rotE",
+          "vp_door_trunk_hatch_wheel_left_open_rotS",
+          "vp_door_trunk_hatch_floor_wheel_left_open_rotW"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_large_64x64/overmap/bridge/bridge.json
+++ b/gfx/UltimateCataclysm/pngs_large_64x64/overmap/bridge/bridge.json
@@ -1,19 +1,24 @@
-[{
-  "id": "bridgehead_ground",
-  "fg": [ "bridgehead_faceN", "bridgehead_faceW", "bridgehead_faceS", "bridgehead_faceE" ],
-  "bg": "t_water_moving_sh_center_large",
-  "rotates": true
-},{
-  "id": "bridge",
-  "fg": [ "bridge_faceNS", "bridge_faceEW", "bridge_faceNS", "bridge_faceEW" ],
-  "bg": "t_water_moving_dp_center_large",
-  "rotates": true
-},{
-  "id": "bridgehead_ramp",
-  "fg": [ "bridgehead_ramp_faceN", "bridgehead_ramp_faceW", "bridgehead_ramp_faceS", "bridgehead_ramp_faceE" ],
-  "rotates": true
-},{
-  "id": "bridge_road",
-  "fg": [ "bridge_faceNS", "bridge_faceEW", "bridge_faceNS", "bridge_faceEW" ],
-  "rotates": true
-}]
+[
+  {
+    "id": "bridgehead_ground",
+    "fg": [ "bridgehead_faceN", "bridgehead_faceE", "bridgehead_faceS", "bridgehead_faceW" ],
+    "bg": "t_water_moving_sh_center_large",
+    "rotates": true
+  },
+  {
+    "id": "bridge",
+    "fg": [ "bridge_faceNS", "bridge_faceEW", "bridge_faceNS", "bridge_faceEW" ],
+    "bg": "t_water_moving_dp_center_large",
+    "rotates": true
+  },
+  {
+    "id": "bridgehead_ramp",
+    "fg": [ "bridgehead_ramp_faceN", "bridgehead_ramp_faceE", "bridgehead_ramp_faceS", "bridgehead_ramp_faceW" ],
+    "rotates": true
+  },
+  {
+    "id": "bridge_road",
+    "fg": [ "bridge_faceNS", "bridge_faceEW", "bridge_faceNS", "bridge_faceEW" ],
+    "rotates": true
+  }
+]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_acid/fd_acid.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_acid/fd_acid.json
@@ -23,35 +23,35 @@
       "fg": [
         {
           "weight": 8,
-          "sprite": [ "fd_acid_0_corner_nw", "fd_acid_0_corner_sw", "fd_acid_0_corner_se", "fd_acid_0_corner_ne" ]
+          "sprite": [ "fd_acid_0_corner_nw", "fd_acid_0_corner_ne", "fd_acid_0_corner_se", "fd_acid_0_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_1_corner_nw", "fd_acid_1_corner_sw", "fd_acid_1_corner_se", "fd_acid_1_corner_ne" ]
+          "sprite": [ "fd_acid_1_corner_nw", "fd_acid_1_corner_ne", "fd_acid_1_corner_se", "fd_acid_1_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_2_corner_nw", "fd_acid_2_corner_sw", "fd_acid_2_corner_se", "fd_acid_2_corner_ne" ]
+          "sprite": [ "fd_acid_2_corner_nw", "fd_acid_2_corner_ne", "fd_acid_2_corner_se", "fd_acid_2_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_3_corner_nw", "fd_acid_3_corner_sw", "fd_acid_3_corner_se", "fd_acid_3_corner_ne" ]
+          "sprite": [ "fd_acid_3_corner_nw", "fd_acid_3_corner_ne", "fd_acid_3_corner_se", "fd_acid_3_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_4_corner_nw", "fd_acid_4_corner_sw", "fd_acid_4_corner_se", "fd_acid_4_corner_ne" ]
+          "sprite": [ "fd_acid_4_corner_nw", "fd_acid_4_corner_ne", "fd_acid_4_corner_se", "fd_acid_4_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_5_corner_nw", "fd_acid_5_corner_sw", "fd_acid_5_corner_se", "fd_acid_5_corner_ne" ]
+          "sprite": [ "fd_acid_5_corner_nw", "fd_acid_5_corner_ne", "fd_acid_5_corner_se", "fd_acid_5_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_6_corner_nw", "fd_acid_6_corner_sw", "fd_acid_6_corner_se", "fd_acid_6_corner_ne" ]
+          "sprite": [ "fd_acid_6_corner_nw", "fd_acid_6_corner_ne", "fd_acid_6_corner_se", "fd_acid_6_corner_sw" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_7_corner_nw", "fd_acid_7_corner_sw", "fd_acid_7_corner_se", "fd_acid_7_corner_ne" ]
+          "sprite": [ "fd_acid_7_corner_nw", "fd_acid_7_corner_ne", "fd_acid_7_corner_se", "fd_acid_7_corner_sw" ]
         }
       ]
     },
@@ -61,35 +61,35 @@
       "fg": [
         {
           "weight": 8,
-          "sprite": [ "fd_acid_0_t_connection_n", "fd_acid_0_t_connection_w", "fd_acid_0_t_connection_s", "fd_acid_0_t_connection_e" ]
+          "sprite": [ "fd_acid_0_t_connection_n", "fd_acid_0_t_connection_e", "fd_acid_0_t_connection_s", "fd_acid_0_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_1_t_connection_n", "fd_acid_1_t_connection_w", "fd_acid_1_t_connection_s", "fd_acid_1_t_connection_e" ]
+          "sprite": [ "fd_acid_1_t_connection_n", "fd_acid_1_t_connection_e", "fd_acid_1_t_connection_s", "fd_acid_1_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_2_t_connection_n", "fd_acid_2_t_connection_w", "fd_acid_2_t_connection_s", "fd_acid_2_t_connection_e" ]
+          "sprite": [ "fd_acid_2_t_connection_n", "fd_acid_2_t_connection_e", "fd_acid_2_t_connection_s", "fd_acid_2_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_3_t_connection_n", "fd_acid_3_t_connection_w", "fd_acid_3_t_connection_s", "fd_acid_3_t_connection_e" ]
+          "sprite": [ "fd_acid_3_t_connection_n", "fd_acid_3_t_connection_e", "fd_acid_3_t_connection_s", "fd_acid_3_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_4_t_connection_n", "fd_acid_4_t_connection_w", "fd_acid_4_t_connection_s", "fd_acid_4_t_connection_e" ]
+          "sprite": [ "fd_acid_4_t_connection_n", "fd_acid_4_t_connection_e", "fd_acid_4_t_connection_s", "fd_acid_4_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_5_t_connection_n", "fd_acid_5_t_connection_w", "fd_acid_5_t_connection_s", "fd_acid_5_t_connection_e" ]
+          "sprite": [ "fd_acid_5_t_connection_n", "fd_acid_5_t_connection_e", "fd_acid_5_t_connection_s", "fd_acid_5_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_6_t_connection_n", "fd_acid_6_t_connection_w", "fd_acid_6_t_connection_s", "fd_acid_6_t_connection_e" ]
+          "sprite": [ "fd_acid_6_t_connection_n", "fd_acid_6_t_connection_e", "fd_acid_6_t_connection_s", "fd_acid_6_t_connection_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_7_t_connection_n", "fd_acid_7_t_connection_w", "fd_acid_7_t_connection_s", "fd_acid_7_t_connection_e" ]
+          "sprite": [ "fd_acid_7_t_connection_n", "fd_acid_7_t_connection_e", "fd_acid_7_t_connection_s", "fd_acid_7_t_connection_w" ]
         }
       ]
     },
@@ -113,35 +113,35 @@
       "fg": [
         {
           "weight": 8,
-          "sprite": [ "fd_acid_0_end_piece_n", "fd_acid_0_end_piece_w", "fd_acid_0_end_piece_s", "fd_acid_0_end_piece_e" ]
+          "sprite": [ "fd_acid_0_end_piece_n", "fd_acid_0_end_piece_e", "fd_acid_0_end_piece_s", "fd_acid_0_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_1_end_piece_n", "fd_acid_1_end_piece_w", "fd_acid_1_end_piece_s", "fd_acid_1_end_piece_e" ]
+          "sprite": [ "fd_acid_1_end_piece_n", "fd_acid_1_end_piece_e", "fd_acid_1_end_piece_s", "fd_acid_1_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_2_end_piece_n", "fd_acid_2_end_piece_w", "fd_acid_2_end_piece_s", "fd_acid_2_end_piece_e" ]
+          "sprite": [ "fd_acid_2_end_piece_n", "fd_acid_2_end_piece_e", "fd_acid_2_end_piece_s", "fd_acid_2_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_3_end_piece_n", "fd_acid_3_end_piece_w", "fd_acid_3_end_piece_s", "fd_acid_3_end_piece_e" ]
+          "sprite": [ "fd_acid_3_end_piece_n", "fd_acid_3_end_piece_e", "fd_acid_3_end_piece_s", "fd_acid_3_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_4_end_piece_n", "fd_acid_4_end_piece_w", "fd_acid_4_end_piece_s", "fd_acid_4_end_piece_e" ]
+          "sprite": [ "fd_acid_4_end_piece_n", "fd_acid_4_end_piece_e", "fd_acid_4_end_piece_s", "fd_acid_4_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_5_end_piece_n", "fd_acid_5_end_piece_w", "fd_acid_5_end_piece_s", "fd_acid_5_end_piece_e" ]
+          "sprite": [ "fd_acid_5_end_piece_n", "fd_acid_5_end_piece_e", "fd_acid_5_end_piece_s", "fd_acid_5_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_6_end_piece_n", "fd_acid_6_end_piece_w", "fd_acid_6_end_piece_s", "fd_acid_6_end_piece_e" ]
+          "sprite": [ "fd_acid_6_end_piece_n", "fd_acid_6_end_piece_e", "fd_acid_6_end_piece_s", "fd_acid_6_end_piece_w" ]
         },
         {
           "weight": 8,
-          "sprite": [ "fd_acid_7_end_piece_n", "fd_acid_7_end_piece_w", "fd_acid_7_end_piece_s", "fd_acid_7_end_piece_e" ]
+          "sprite": [ "fd_acid_7_end_piece_n", "fd_acid_7_end_piece_e", "fd_acid_7_end_piece_s", "fd_acid_7_end_piece_w" ]
         }
       ]
     },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_bile/fd_bile.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_bile/fd_bile.json
@@ -3,50 +3,17 @@
   "fg": "fd_bile_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "fd_bile_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "fd_bile_corner_nw",
-        "fd_bile_corner_sw",
-        "fd_bile_corner_se",
-        "fd_bile_corner_ne"
-      ]
-    },
+    { "id": "center", "fg": "fd_bile_center" },
+    { "id": "corner", "fg": [ "fd_bile_corner_nw", "fd_bile_corner_ne", "fd_bile_corner_se", "fd_bile_corner_sw" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "fd_bile_t_connection_n",
-        "fd_bile_t_connection_w",
-        "fd_bile_t_connection_s",
-        "fd_bile_t_connection_e"
-      ]
+      "fg": [ "fd_bile_t_connection_n", "fd_bile_t_connection_e", "fd_bile_t_connection_s", "fd_bile_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "fd_bile_edge_ns",
-        "fd_bile_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "fd_bile_edge_ns", "fd_bile_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "fd_bile_end_piece_n",
-        "fd_bile_end_piece_w",
-        "fd_bile_end_piece_s",
-        "fd_bile_end_piece_e"
-      ]
+      "fg": [ "fd_bile_end_piece_n", "fd_bile_end_piece_e", "fd_bile_end_piece_s", "fd_bile_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "fd_bile_unconnected",
-        "fd_bile_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "fd_bile_unconnected", "fd_bile_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_congealed_light/fd_congealed_light.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_congealed_light/fd_congealed_light.json
@@ -3,50 +3,35 @@
   "fg": "fd_congealed_light_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "fd_congealed_light_center"
-    },
+    { "id": "center", "fg": "fd_congealed_light_center" },
     {
       "id": "corner",
       "fg": [
         "fd_congealed_light_corner_nw",
-        "fd_congealed_light_corner_sw",
+        "fd_congealed_light_corner_ne",
         "fd_congealed_light_corner_se",
-        "fd_congealed_light_corner_ne"
+        "fd_congealed_light_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "fd_congealed_light_t_connection_n",
-        "fd_congealed_light_t_connection_w",
+        "fd_congealed_light_t_connection_e",
         "fd_congealed_light_t_connection_s",
-        "fd_congealed_light_t_connection_e"
+        "fd_congealed_light_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "fd_congealed_light_edge_ns",
-        "fd_congealed_light_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "fd_congealed_light_edge_ns", "fd_congealed_light_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "fd_congealed_light_end_piece_n",
-        "fd_congealed_light_end_piece_w",
+        "fd_congealed_light_end_piece_e",
         "fd_congealed_light_end_piece_s",
-        "fd_congealed_light_end_piece_e"
+        "fd_congealed_light_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "fd_congealed_light_unconnected",
-        "fd_congealed_light_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "fd_congealed_light_unconnected", "fd_congealed_light_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_dust/fd_dust.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_dust/fd_dust.json
@@ -15,16 +15,16 @@
       },
       {
         "id": "corner",
-        "fg": [ "fd_dust1_corner_NW", "fd_dust1_corner_SW", "fd_dust1_corner_SE", "fd_dust1_corner_NE" ]
+        "fg": [ "fd_dust1_corner_NW", "fd_dust1_corner_NE", "fd_dust1_corner_SE", "fd_dust1_corner_SW" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "fd_dust1_t_connection_N", "fd_dust1_t_connection_W", "fd_dust1_t_connection_S", "fd_dust1_t_connection_E" ]
+        "fg": [ "fd_dust1_t_connection_N", "fd_dust1_t_connection_E", "fd_dust1_t_connection_S", "fd_dust1_t_connection_W" ]
       },
       { "id": "edge", "fg": [ "fd_dust1_edge_NS", "fd_dust1_edge_EW" ] },
       {
         "id": "end_piece",
-        "fg": [ "fd_dust1_end_piece_N", "fd_dust1_end_piece_W", "fd_dust1_end_piece_S", "fd_dust1_end_piece_E" ]
+        "fg": [ "fd_dust1_end_piece_N", "fd_dust1_end_piece_E", "fd_dust1_end_piece_S", "fd_dust1_end_piece_W" ]
       },
       { "id": "unconnected", "fg": [ "fd_dust1_unconnected", "fd_dust1_unconnected" ] }
     ]
@@ -45,16 +45,16 @@
       },
       {
         "id": "corner",
-        "fg": [ "fd_dust2_corner_NW", "fd_dust2_corner_SW", "fd_dust2_corner_SE", "fd_dust2_corner_NE" ]
+        "fg": [ "fd_dust2_corner_NW", "fd_dust2_corner_NE", "fd_dust2_corner_SE", "fd_dust2_corner_SW" ]
       },
       {
         "id": "t_connection",
-        "fg": [ "fd_dust2_t_connection_N", "fd_dust2_t_connection_W", "fd_dust2_t_connection_S", "fd_dust2_t_connection_E" ]
+        "fg": [ "fd_dust2_t_connection_N", "fd_dust2_t_connection_E", "fd_dust2_t_connection_S", "fd_dust2_t_connection_W" ]
       },
       { "id": "edge", "fg": [ "fd_dust2_edge_NS", "fd_dust2_edge_EW" ] },
       {
         "id": "end_piece",
-        "fg": [ "fd_dust2_end_piece_N", "fd_dust2_end_piece_W", "fd_dust2_end_piece_S", "fd_dust2_end_piece_E" ]
+        "fg": [ "fd_dust2_end_piece_N", "fd_dust2_end_piece_E", "fd_dust2_end_piece_S", "fd_dust2_end_piece_W" ]
       },
       { "id": "unconnected", "fg": [ "fd_dust2_unconnected", "fd_dust2_unconnected" ] }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_electricity/fd_electricity.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_electricity/fd_electricity.json
@@ -3,50 +3,30 @@
   "fg": "fd_electricity_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "fd_electricity_center"
-    },
+    { "id": "center", "fg": "fd_electricity_center" },
     {
       "id": "corner",
-      "fg": [
-        "fd_electricity_corner_nw",
-        "fd_electricity_corner_sw",
-        "fd_electricity_corner_se",
-        "fd_electricity_corner_ne"
-      ]
+      "fg": [ "fd_electricity_corner_nw", "fd_electricity_corner_ne", "fd_electricity_corner_se", "fd_electricity_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "fd_electricity_t_connection_n",
-        "fd_electricity_t_connection_w",
+        "fd_electricity_t_connection_e",
         "fd_electricity_t_connection_s",
-        "fd_electricity_t_connection_e"
+        "fd_electricity_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "fd_electricity_edge_ns",
-        "fd_electricity_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "fd_electricity_edge_ns", "fd_electricity_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "fd_electricity_end_piece_n",
-        "fd_electricity_end_piece_w",
+        "fd_electricity_end_piece_e",
         "fd_electricity_end_piece_s",
-        "fd_electricity_end_piece_e"
+        "fd_electricity_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "fd_electricity_unconnected",
-        "fd_electricity_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "fd_electricity_unconnected", "fd_electricity_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_mechanical_fluid/fd_mechanical_fluid.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_mechanical_fluid/fd_mechanical_fluid.json
@@ -19,27 +19,27 @@
             "weight": 1,
             "sprite": [
               "int1_fd_mechfluid_1_corner_nw",
-              "int1_fd_mechfluid_1_corner_sw",
+              "int1_fd_mechfluid_1_corner_ne",
               "int1_fd_mechfluid_1_corner_se",
-              "int1_fd_mechfluid_1_corner_ne"
+              "int1_fd_mechfluid_1_corner_sw"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int1_fd_mechfluid_2_corner_nw",
-              "int1_fd_mechfluid_2_corner_sw",
+              "int1_fd_mechfluid_2_corner_ne",
               "int1_fd_mechfluid_2_corner_se",
-              "int1_fd_mechfluid_2_corner_ne"
+              "int1_fd_mechfluid_2_corner_sw"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int1_fd_mechfluid_3_corner_nw",
-              "int1_fd_mechfluid_3_corner_sw",
+              "int1_fd_mechfluid_3_corner_ne",
               "int1_fd_mechfluid_3_corner_se",
-              "int1_fd_mechfluid_3_corner_ne"
+              "int1_fd_mechfluid_3_corner_sw"
             ]
           }
         ]
@@ -51,27 +51,27 @@
             "weight": 1,
             "sprite": [
               "int1_fd_mechfluid_1_t_connection_n",
-              "int1_fd_mechfluid_1_t_connection_w",
+              "int1_fd_mechfluid_1_t_connection_e",
               "int1_fd_mechfluid_1_t_connection_s",
-              "int1_fd_mechfluid_1_t_connection_e"
+              "int1_fd_mechfluid_1_t_connection_w"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int1_fd_mechfluid_2_t_connection_n",
-              "int1_fd_mechfluid_2_t_connection_w",
+              "int1_fd_mechfluid_2_t_connection_e",
               "int1_fd_mechfluid_2_t_connection_s",
-              "int1_fd_mechfluid_2_t_connection_e"
+              "int1_fd_mechfluid_2_t_connection_w"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int1_fd_mechfluid_3_t_connection_n",
-              "int1_fd_mechfluid_3_t_connection_w",
+              "int1_fd_mechfluid_3_t_connection_e",
               "int1_fd_mechfluid_3_t_connection_s",
-              "int1_fd_mechfluid_3_t_connection_e"
+              "int1_fd_mechfluid_3_t_connection_w"
             ]
           }
         ]
@@ -91,27 +91,27 @@
             "weight": 1,
             "sprite": [
               "int1_fd_mechfluid_1_end_piece_n",
-              "int1_fd_mechfluid_1_end_piece_w",
+              "int1_fd_mechfluid_1_end_piece_e",
               "int1_fd_mechfluid_1_end_piece_s",
-              "int1_fd_mechfluid_1_end_piece_e"
+              "int1_fd_mechfluid_1_end_piece_w"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int1_fd_mechfluid_2_end_piece_n",
-              "int1_fd_mechfluid_2_end_piece_w",
+              "int1_fd_mechfluid_2_end_piece_e",
               "int1_fd_mechfluid_2_end_piece_s",
-              "int1_fd_mechfluid_2_end_piece_e"
+              "int1_fd_mechfluid_2_end_piece_w"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int1_fd_mechfluid_3_end_piece_n",
-              "int1_fd_mechfluid_3_end_piece_w",
+              "int1_fd_mechfluid_3_end_piece_e",
               "int1_fd_mechfluid_3_end_piece_s",
-              "int1_fd_mechfluid_3_end_piece_e"
+              "int1_fd_mechfluid_3_end_piece_w"
             ]
           }
         ]
@@ -146,27 +146,27 @@
             "weight": 1,
             "sprite": [
               "int2_fd_mechfluid_1_corner_nw",
-              "int2_fd_mechfluid_1_corner_sw",
+              "int2_fd_mechfluid_1_corner_ne",
               "int2_fd_mechfluid_1_corner_se",
-              "int2_fd_mechfluid_1_corner_ne"
+              "int2_fd_mechfluid_1_corner_sw"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int2_fd_mechfluid_2_corner_nw",
-              "int2_fd_mechfluid_2_corner_sw",
+              "int2_fd_mechfluid_2_corner_ne",
               "int2_fd_mechfluid_2_corner_se",
-              "int2_fd_mechfluid_2_corner_ne"
+              "int2_fd_mechfluid_2_corner_sw"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int2_fd_mechfluid_3_corner_nw",
-              "int2_fd_mechfluid_3_corner_sw",
+              "int2_fd_mechfluid_3_corner_ne",
               "int2_fd_mechfluid_3_corner_se",
-              "int2_fd_mechfluid_3_corner_ne"
+              "int2_fd_mechfluid_3_corner_sw"
             ]
           }
         ]
@@ -178,27 +178,27 @@
             "weight": 1,
             "sprite": [
               "int2_fd_mechfluid_1_t_connection_n",
-              "int2_fd_mechfluid_1_t_connection_w",
+              "int2_fd_mechfluid_1_t_connection_e",
               "int2_fd_mechfluid_1_t_connection_s",
-              "int2_fd_mechfluid_1_t_connection_e"
+              "int2_fd_mechfluid_1_t_connection_w"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int2_fd_mechfluid_2_t_connection_n",
-              "int2_fd_mechfluid_2_t_connection_w",
+              "int2_fd_mechfluid_2_t_connection_e",
               "int2_fd_mechfluid_2_t_connection_s",
-              "int2_fd_mechfluid_2_t_connection_e"
+              "int2_fd_mechfluid_2_t_connection_w"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int2_fd_mechfluid_3_t_connection_n",
-              "int2_fd_mechfluid_3_t_connection_w",
+              "int2_fd_mechfluid_3_t_connection_e",
               "int2_fd_mechfluid_3_t_connection_s",
-              "int2_fd_mechfluid_3_t_connection_e"
+              "int2_fd_mechfluid_3_t_connection_w"
             ]
           }
         ]
@@ -218,27 +218,27 @@
             "weight": 1,
             "sprite": [
               "int2_fd_mechfluid_1_end_piece_n",
-              "int2_fd_mechfluid_1_end_piece_w",
+              "int2_fd_mechfluid_1_end_piece_e",
               "int2_fd_mechfluid_1_end_piece_s",
-              "int2_fd_mechfluid_1_end_piece_e"
+              "int2_fd_mechfluid_1_end_piece_w"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int2_fd_mechfluid_2_end_piece_n",
-              "int2_fd_mechfluid_2_end_piece_w",
+              "int2_fd_mechfluid_2_end_piece_e",
               "int2_fd_mechfluid_2_end_piece_s",
-              "int2_fd_mechfluid_2_end_piece_e"
+              "int2_fd_mechfluid_2_end_piece_w"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int2_fd_mechfluid_3_end_piece_n",
-              "int2_fd_mechfluid_3_end_piece_w",
+              "int2_fd_mechfluid_3_end_piece_e",
               "int2_fd_mechfluid_3_end_piece_s",
-              "int2_fd_mechfluid_3_end_piece_e"
+              "int2_fd_mechfluid_3_end_piece_w"
             ]
           }
         ]
@@ -273,27 +273,27 @@
             "weight": 1,
             "sprite": [
               "int3_fd_mechfluid_1_corner_nw",
-              "int3_fd_mechfluid_1_corner_sw",
+              "int3_fd_mechfluid_1_corner_ne",
               "int3_fd_mechfluid_1_corner_se",
-              "int3_fd_mechfluid_1_corner_ne"
+              "int3_fd_mechfluid_1_corner_sw"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int3_fd_mechfluid_2_corner_nw",
-              "int3_fd_mechfluid_2_corner_sw",
+              "int3_fd_mechfluid_2_corner_ne",
               "int3_fd_mechfluid_2_corner_se",
-              "int3_fd_mechfluid_2_corner_ne"
+              "int3_fd_mechfluid_2_corner_sw"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int3_fd_mechfluid_3_corner_nw",
-              "int3_fd_mechfluid_3_corner_sw",
+              "int3_fd_mechfluid_3_corner_ne",
               "int3_fd_mechfluid_3_corner_se",
-              "int3_fd_mechfluid_3_corner_ne"
+              "int3_fd_mechfluid_3_corner_sw"
             ]
           }
         ]
@@ -305,27 +305,27 @@
             "weight": 1,
             "sprite": [
               "int3_fd_mechfluid_1_t_connection_n",
-              "int3_fd_mechfluid_1_t_connection_w",
+              "int3_fd_mechfluid_1_t_connection_e",
               "int3_fd_mechfluid_1_t_connection_s",
-              "int3_fd_mechfluid_1_t_connection_e"
+              "int3_fd_mechfluid_1_t_connection_w"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int3_fd_mechfluid_2_t_connection_n",
-              "int3_fd_mechfluid_2_t_connection_w",
+              "int3_fd_mechfluid_2_t_connection_e",
               "int3_fd_mechfluid_2_t_connection_s",
-              "int3_fd_mechfluid_2_t_connection_e"
+              "int3_fd_mechfluid_2_t_connection_w"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int3_fd_mechfluid_3_t_connection_n",
-              "int3_fd_mechfluid_3_t_connection_w",
+              "int3_fd_mechfluid_3_t_connection_e",
               "int3_fd_mechfluid_3_t_connection_s",
-              "int3_fd_mechfluid_3_t_connection_e"
+              "int3_fd_mechfluid_3_t_connection_w"
             ]
           }
         ]
@@ -345,27 +345,27 @@
             "weight": 1,
             "sprite": [
               "int3_fd_mechfluid_1_end_piece_n",
-              "int3_fd_mechfluid_1_end_piece_w",
+              "int3_fd_mechfluid_1_end_piece_e",
               "int3_fd_mechfluid_1_end_piece_s",
-              "int3_fd_mechfluid_1_end_piece_e"
+              "int3_fd_mechfluid_1_end_piece_w"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int3_fd_mechfluid_2_end_piece_n",
-              "int3_fd_mechfluid_2_end_piece_w",
+              "int3_fd_mechfluid_2_end_piece_e",
               "int3_fd_mechfluid_2_end_piece_s",
-              "int3_fd_mechfluid_2_end_piece_e"
+              "int3_fd_mechfluid_2_end_piece_w"
             ]
           },
           {
             "weight": 1,
             "sprite": [
               "int3_fd_mechfluid_3_end_piece_n",
-              "int3_fd_mechfluid_3_end_piece_w",
+              "int3_fd_mechfluid_3_end_piece_e",
               "int3_fd_mechfluid_3_end_piece_s",
-              "int3_fd_mechfluid_3_end_piece_e"
+              "int3_fd_mechfluid_3_end_piece_w"
             ]
           }
         ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_sludge/fd_sludge.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_sludge/fd_sludge.json
@@ -6,25 +6,58 @@
     {
       "id": "center",
       "fg": [
-        {"weight": 1, "sprite": "fd_sludge_1_center"},
-        {"weight": 1, "sprite": "fd_sludge_2_center"},
-        {"weight": 1, "sprite": "fd_sludge_3_center"}
+        { "weight": 1, "sprite": "fd_sludge_1_center" },
+        { "weight": 1, "sprite": "fd_sludge_2_center" },
+        { "weight": 1, "sprite": "fd_sludge_3_center" }
       ]
     },
     {
       "id": "corner",
       "fg": [
-        { "weight": 1, "sprite": [ "fd_sludge_1_corner_nw", "fd_sludge_1_corner_sw", "fd_sludge_1_corner_se", "fd_sludge_1_corner_ne" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_2_corner_nw", "fd_sludge_2_corner_sw", "fd_sludge_2_corner_se", "fd_sludge_2_corner_ne" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_3_corner_nw", "fd_sludge_3_corner_sw", "fd_sludge_3_corner_se", "fd_sludge_3_corner_ne" ] }
+        {
+          "weight": 1,
+          "sprite": [ "fd_sludge_1_corner_nw", "fd_sludge_1_corner_ne", "fd_sludge_1_corner_se", "fd_sludge_1_corner_sw" ]
+        },
+        {
+          "weight": 1,
+          "sprite": [ "fd_sludge_2_corner_nw", "fd_sludge_2_corner_ne", "fd_sludge_2_corner_se", "fd_sludge_2_corner_sw" ]
+        },
+        {
+          "weight": 1,
+          "sprite": [ "fd_sludge_3_corner_nw", "fd_sludge_3_corner_ne", "fd_sludge_3_corner_se", "fd_sludge_3_corner_sw" ]
+        }
       ]
     },
     {
       "id": "t_connection",
       "fg": [
-        { "weight": 1, "sprite": [ "fd_sludge_1_t_connection_n", "fd_sludge_1_t_connection_w", "fd_sludge_1_t_connection_s", "fd_sludge_1_t_connection_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_2_t_connection_n", "fd_sludge_2_t_connection_w", "fd_sludge_2_t_connection_s", "fd_sludge_2_t_connection_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_3_t_connection_n", "fd_sludge_3_t_connection_w", "fd_sludge_3_t_connection_s", "fd_sludge_3_t_connection_e" ] }
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_1_t_connection_n",
+            "fd_sludge_1_t_connection_e",
+            "fd_sludge_1_t_connection_s",
+            "fd_sludge_1_t_connection_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_2_t_connection_n",
+            "fd_sludge_2_t_connection_e",
+            "fd_sludge_2_t_connection_s",
+            "fd_sludge_2_t_connection_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_3_t_connection_n",
+            "fd_sludge_3_t_connection_e",
+            "fd_sludge_3_t_connection_s",
+            "fd_sludge_3_t_connection_w"
+          ]
+        }
       ]
     },
     {
@@ -38,17 +71,26 @@
     {
       "id": "end_piece",
       "fg": [
-        { "weight": 1, "sprite": [ "fd_sludge_1_end_piece_n", "fd_sludge_1_end_piece_w", "fd_sludge_1_end_piece_s", "fd_sludge_1_end_piece_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_2_end_piece_n", "fd_sludge_2_end_piece_w", "fd_sludge_2_end_piece_s", "fd_sludge_2_end_piece_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_3_end_piece_n", "fd_sludge_3_end_piece_w", "fd_sludge_3_end_piece_s", "fd_sludge_3_end_piece_e" ] }
+        {
+          "weight": 1,
+          "sprite": [ "fd_sludge_1_end_piece_n", "fd_sludge_1_end_piece_e", "fd_sludge_1_end_piece_s", "fd_sludge_1_end_piece_w" ]
+        },
+        {
+          "weight": 1,
+          "sprite": [ "fd_sludge_2_end_piece_n", "fd_sludge_2_end_piece_e", "fd_sludge_2_end_piece_s", "fd_sludge_2_end_piece_w" ]
+        },
+        {
+          "weight": 1,
+          "sprite": [ "fd_sludge_3_end_piece_n", "fd_sludge_3_end_piece_e", "fd_sludge_3_end_piece_s", "fd_sludge_3_end_piece_w" ]
+        }
       ]
     },
     {
       "id": "unconnected",
       "fg": [
-        {"weight": 1, "sprite": ["fd_sludge_1_unconnected", "fd_sludge_1_unconnected"]},
-        {"weight": 1, "sprite": ["fd_sludge_2_unconnected", "fd_sludge_2_unconnected"]},
-        {"weight": 1, "sprite": ["fd_sludge_3_unconnected", "fd_sludge_3_unconnected"]}
+        { "weight": 1, "sprite": [ "fd_sludge_1_unconnected", "fd_sludge_1_unconnected" ] },
+        { "weight": 1, "sprite": [ "fd_sludge_2_unconnected", "fd_sludge_2_unconnected" ] },
+        { "weight": 1, "sprite": [ "fd_sludge_3_unconnected", "fd_sludge_3_unconnected" ] }
       ]
     }
   ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_sludge_int1/fd_sludge_int1.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_sludge_int1/fd_sludge_int1.json
@@ -6,25 +6,73 @@
     {
       "id": "center",
       "fg": [
-        {"weight": 1, "sprite": "fd_sludge_int1_1_center"},
-        {"weight": 1, "sprite": "fd_sludge_int1_2_center"},
-        {"weight": 1, "sprite": "fd_sludge_int1_3_center"}
+        { "weight": 1, "sprite": "fd_sludge_int1_1_center" },
+        { "weight": 1, "sprite": "fd_sludge_int1_2_center" },
+        { "weight": 1, "sprite": "fd_sludge_int1_3_center" }
       ]
     },
     {
       "id": "corner",
       "fg": [
-        { "weight": 1, "sprite": [ "fd_sludge_int1_1_corner_nw", "fd_sludge_int1_1_corner_sw", "fd_sludge_int1_1_corner_se", "fd_sludge_int1_1_corner_ne" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int1_2_corner_nw", "fd_sludge_int1_2_corner_sw", "fd_sludge_int1_2_corner_se", "fd_sludge_int1_2_corner_ne" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int1_3_corner_nw", "fd_sludge_int1_3_corner_sw", "fd_sludge_int1_3_corner_se", "fd_sludge_int1_3_corner_ne" ] }
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int1_1_corner_nw",
+            "fd_sludge_int1_1_corner_ne",
+            "fd_sludge_int1_1_corner_se",
+            "fd_sludge_int1_1_corner_sw"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int1_2_corner_nw",
+            "fd_sludge_int1_2_corner_ne",
+            "fd_sludge_int1_2_corner_se",
+            "fd_sludge_int1_2_corner_sw"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int1_3_corner_nw",
+            "fd_sludge_int1_3_corner_ne",
+            "fd_sludge_int1_3_corner_se",
+            "fd_sludge_int1_3_corner_sw"
+          ]
+        }
       ]
     },
     {
       "id": "t_connection",
       "fg": [
-        { "weight": 1, "sprite": [ "fd_sludge_int1_1_t_connection_n", "fd_sludge_int1_1_t_connection_w", "fd_sludge_int1_1_t_connection_s", "fd_sludge_int1_1_t_connection_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int1_2_t_connection_n", "fd_sludge_int1_2_t_connection_w", "fd_sludge_int1_2_t_connection_s", "fd_sludge_int1_2_t_connection_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int1_3_t_connection_n", "fd_sludge_int1_3_t_connection_w", "fd_sludge_int1_3_t_connection_s", "fd_sludge_int1_3_t_connection_e" ] }
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int1_1_t_connection_n",
+            "fd_sludge_int1_1_t_connection_e",
+            "fd_sludge_int1_1_t_connection_s",
+            "fd_sludge_int1_1_t_connection_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int1_2_t_connection_n",
+            "fd_sludge_int1_2_t_connection_e",
+            "fd_sludge_int1_2_t_connection_s",
+            "fd_sludge_int1_2_t_connection_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int1_3_t_connection_n",
+            "fd_sludge_int1_3_t_connection_e",
+            "fd_sludge_int1_3_t_connection_s",
+            "fd_sludge_int1_3_t_connection_w"
+          ]
+        }
       ]
     },
     {
@@ -38,17 +86,41 @@
     {
       "id": "end_piece",
       "fg": [
-        { "weight": 1, "sprite": [ "fd_sludge_int1_1_end_piece_n", "fd_sludge_int1_1_end_piece_w", "fd_sludge_int1_1_end_piece_s", "fd_sludge_int1_1_end_piece_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int1_2_end_piece_n", "fd_sludge_int1_2_end_piece_w", "fd_sludge_int1_2_end_piece_s", "fd_sludge_int1_2_end_piece_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int1_3_end_piece_n", "fd_sludge_int1_3_end_piece_w", "fd_sludge_int1_3_end_piece_s", "fd_sludge_int1_3_end_piece_e" ] }
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int1_1_end_piece_n",
+            "fd_sludge_int1_1_end_piece_e",
+            "fd_sludge_int1_1_end_piece_s",
+            "fd_sludge_int1_1_end_piece_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int1_2_end_piece_n",
+            "fd_sludge_int1_2_end_piece_e",
+            "fd_sludge_int1_2_end_piece_s",
+            "fd_sludge_int1_2_end_piece_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int1_3_end_piece_n",
+            "fd_sludge_int1_3_end_piece_e",
+            "fd_sludge_int1_3_end_piece_s",
+            "fd_sludge_int1_3_end_piece_w"
+          ]
+        }
       ]
     },
     {
       "id": "unconnected",
       "fg": [
-        {"weight": 1, "sprite": ["fd_sludge_int1_1_unconnected", "fd_sludge_int1_1_unconnected"]},
-        {"weight": 1, "sprite": ["fd_sludge_int1_2_unconnected", "fd_sludge_int1_2_unconnected"]},
-        {"weight": 1, "sprite": ["fd_sludge_int1_3_unconnected", "fd_sludge_int1_3_unconnected"]}
+        { "weight": 1, "sprite": [ "fd_sludge_int1_1_unconnected", "fd_sludge_int1_1_unconnected" ] },
+        { "weight": 1, "sprite": [ "fd_sludge_int1_2_unconnected", "fd_sludge_int1_2_unconnected" ] },
+        { "weight": 1, "sprite": [ "fd_sludge_int1_3_unconnected", "fd_sludge_int1_3_unconnected" ] }
       ]
     }
   ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_sludge_int2/fd_sludge_int2.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_sludge_int2/fd_sludge_int2.json
@@ -6,25 +6,73 @@
     {
       "id": "center",
       "fg": [
-        {"weight": 1, "sprite": "fd_sludge_int2_1_center"},
-        {"weight": 1, "sprite": "fd_sludge_int2_2_center"},
-        {"weight": 1, "sprite": "fd_sludge_int2_3_center"}
+        { "weight": 1, "sprite": "fd_sludge_int2_1_center" },
+        { "weight": 1, "sprite": "fd_sludge_int2_2_center" },
+        { "weight": 1, "sprite": "fd_sludge_int2_3_center" }
       ]
     },
     {
       "id": "corner",
       "fg": [
-        { "weight": 1, "sprite": [ "fd_sludge_int2_1_corner_nw", "fd_sludge_int2_1_corner_sw", "fd_sludge_int2_1_corner_se", "fd_sludge_int2_1_corner_ne" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int2_2_corner_nw", "fd_sludge_int2_2_corner_sw", "fd_sludge_int2_2_corner_se", "fd_sludge_int2_2_corner_ne" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int2_3_corner_nw", "fd_sludge_int2_3_corner_sw", "fd_sludge_int2_3_corner_se", "fd_sludge_int2_3_corner_ne" ] }
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int2_1_corner_nw",
+            "fd_sludge_int2_1_corner_ne",
+            "fd_sludge_int2_1_corner_se",
+            "fd_sludge_int2_1_corner_sw"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int2_2_corner_nw",
+            "fd_sludge_int2_2_corner_ne",
+            "fd_sludge_int2_2_corner_se",
+            "fd_sludge_int2_2_corner_sw"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int2_3_corner_nw",
+            "fd_sludge_int2_3_corner_ne",
+            "fd_sludge_int2_3_corner_se",
+            "fd_sludge_int2_3_corner_sw"
+          ]
+        }
       ]
     },
     {
       "id": "t_connection",
       "fg": [
-        { "weight": 1, "sprite": [ "fd_sludge_int2_1_t_connection_n", "fd_sludge_int2_1_t_connection_w", "fd_sludge_int2_1_t_connection_s", "fd_sludge_int2_1_t_connection_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int2_2_t_connection_n", "fd_sludge_int2_2_t_connection_w", "fd_sludge_int2_2_t_connection_s", "fd_sludge_int2_2_t_connection_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int2_3_t_connection_n", "fd_sludge_int2_3_t_connection_w", "fd_sludge_int2_3_t_connection_s", "fd_sludge_int2_3_t_connection_e" ] }
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int2_1_t_connection_n",
+            "fd_sludge_int2_1_t_connection_e",
+            "fd_sludge_int2_1_t_connection_s",
+            "fd_sludge_int2_1_t_connection_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int2_2_t_connection_n",
+            "fd_sludge_int2_2_t_connection_e",
+            "fd_sludge_int2_2_t_connection_s",
+            "fd_sludge_int2_2_t_connection_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int2_3_t_connection_n",
+            "fd_sludge_int2_3_t_connection_e",
+            "fd_sludge_int2_3_t_connection_s",
+            "fd_sludge_int2_3_t_connection_w"
+          ]
+        }
       ]
     },
     {
@@ -38,17 +86,41 @@
     {
       "id": "end_piece",
       "fg": [
-        { "weight": 1, "sprite": [ "fd_sludge_int2_1_end_piece_n", "fd_sludge_int2_1_end_piece_w", "fd_sludge_int2_1_end_piece_s", "fd_sludge_int2_1_end_piece_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int2_2_end_piece_n", "fd_sludge_int2_2_end_piece_w", "fd_sludge_int2_2_end_piece_s", "fd_sludge_int2_2_end_piece_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int2_3_end_piece_n", "fd_sludge_int2_3_end_piece_w", "fd_sludge_int2_3_end_piece_s", "fd_sludge_int2_3_end_piece_e" ] }
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int2_1_end_piece_n",
+            "fd_sludge_int2_1_end_piece_e",
+            "fd_sludge_int2_1_end_piece_s",
+            "fd_sludge_int2_1_end_piece_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int2_2_end_piece_n",
+            "fd_sludge_int2_2_end_piece_e",
+            "fd_sludge_int2_2_end_piece_s",
+            "fd_sludge_int2_2_end_piece_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int2_3_end_piece_n",
+            "fd_sludge_int2_3_end_piece_e",
+            "fd_sludge_int2_3_end_piece_s",
+            "fd_sludge_int2_3_end_piece_w"
+          ]
+        }
       ]
     },
     {
       "id": "unconnected",
       "fg": [
-        {"weight": 1, "sprite": ["fd_sludge_int2_1_unconnected", "fd_sludge_int2_1_unconnected"]},
-        {"weight": 1, "sprite": ["fd_sludge_int2_2_unconnected", "fd_sludge_int2_2_unconnected"]},
-        {"weight": 1, "sprite": ["fd_sludge_int2_3_unconnected", "fd_sludge_int2_3_unconnected"]}
+        { "weight": 1, "sprite": [ "fd_sludge_int2_1_unconnected", "fd_sludge_int2_1_unconnected" ] },
+        { "weight": 1, "sprite": [ "fd_sludge_int2_2_unconnected", "fd_sludge_int2_2_unconnected" ] },
+        { "weight": 1, "sprite": [ "fd_sludge_int2_3_unconnected", "fd_sludge_int2_3_unconnected" ] }
       ]
     }
   ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_sludge_int3/fd_sludge_int3.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/fields/fd_sludge_int3/fd_sludge_int3.json
@@ -6,25 +6,73 @@
     {
       "id": "center",
       "fg": [
-        {"weight": 1, "sprite": "fd_sludge_int3_1_center"},
-        {"weight": 1, "sprite": "fd_sludge_int3_2_center"},
-        {"weight": 1, "sprite": "fd_sludge_int3_3_center"}
+        { "weight": 1, "sprite": "fd_sludge_int3_1_center" },
+        { "weight": 1, "sprite": "fd_sludge_int3_2_center" },
+        { "weight": 1, "sprite": "fd_sludge_int3_3_center" }
       ]
     },
     {
       "id": "corner",
       "fg": [
-        { "weight": 1, "sprite": [ "fd_sludge_int3_1_corner_nw", "fd_sludge_int3_1_corner_sw", "fd_sludge_int3_1_corner_se", "fd_sludge_int3_1_corner_ne" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int3_2_corner_nw", "fd_sludge_int3_2_corner_sw", "fd_sludge_int3_2_corner_se", "fd_sludge_int3_2_corner_ne" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int3_3_corner_nw", "fd_sludge_int3_3_corner_sw", "fd_sludge_int3_3_corner_se", "fd_sludge_int3_3_corner_ne" ] }
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int3_1_corner_nw",
+            "fd_sludge_int3_1_corner_ne",
+            "fd_sludge_int3_1_corner_se",
+            "fd_sludge_int3_1_corner_sw"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int3_2_corner_nw",
+            "fd_sludge_int3_2_corner_ne",
+            "fd_sludge_int3_2_corner_se",
+            "fd_sludge_int3_2_corner_sw"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int3_3_corner_nw",
+            "fd_sludge_int3_3_corner_ne",
+            "fd_sludge_int3_3_corner_se",
+            "fd_sludge_int3_3_corner_sw"
+          ]
+        }
       ]
     },
     {
       "id": "t_connection",
       "fg": [
-        { "weight": 1, "sprite": [ "fd_sludge_int3_1_t_connection_n", "fd_sludge_int3_1_t_connection_w", "fd_sludge_int3_1_t_connection_s", "fd_sludge_int3_1_t_connection_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int3_2_t_connection_n", "fd_sludge_int3_2_t_connection_w", "fd_sludge_int3_2_t_connection_s", "fd_sludge_int3_2_t_connection_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int3_3_t_connection_n", "fd_sludge_int3_3_t_connection_w", "fd_sludge_int3_3_t_connection_s", "fd_sludge_int3_3_t_connection_e" ] }
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int3_1_t_connection_n",
+            "fd_sludge_int3_1_t_connection_e",
+            "fd_sludge_int3_1_t_connection_s",
+            "fd_sludge_int3_1_t_connection_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int3_2_t_connection_n",
+            "fd_sludge_int3_2_t_connection_e",
+            "fd_sludge_int3_2_t_connection_s",
+            "fd_sludge_int3_2_t_connection_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int3_3_t_connection_n",
+            "fd_sludge_int3_3_t_connection_e",
+            "fd_sludge_int3_3_t_connection_s",
+            "fd_sludge_int3_3_t_connection_w"
+          ]
+        }
       ]
     },
     {
@@ -38,17 +86,41 @@
     {
       "id": "end_piece",
       "fg": [
-        { "weight": 1, "sprite": [ "fd_sludge_int3_1_end_piece_n", "fd_sludge_int3_1_end_piece_w", "fd_sludge_int3_1_end_piece_s", "fd_sludge_int3_1_end_piece_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int3_2_end_piece_n", "fd_sludge_int3_2_end_piece_w", "fd_sludge_int3_2_end_piece_s", "fd_sludge_int3_2_end_piece_e" ] },
-        { "weight": 1, "sprite": [ "fd_sludge_int3_3_end_piece_n", "fd_sludge_int3_3_end_piece_w", "fd_sludge_int3_3_end_piece_s", "fd_sludge_int3_3_end_piece_e" ] }
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int3_1_end_piece_n",
+            "fd_sludge_int3_1_end_piece_e",
+            "fd_sludge_int3_1_end_piece_s",
+            "fd_sludge_int3_1_end_piece_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int3_2_end_piece_n",
+            "fd_sludge_int3_2_end_piece_e",
+            "fd_sludge_int3_2_end_piece_s",
+            "fd_sludge_int3_2_end_piece_w"
+          ]
+        },
+        {
+          "weight": 1,
+          "sprite": [
+            "fd_sludge_int3_3_end_piece_n",
+            "fd_sludge_int3_3_end_piece_e",
+            "fd_sludge_int3_3_end_piece_s",
+            "fd_sludge_int3_3_end_piece_w"
+          ]
+        }
       ]
     },
     {
       "id": "unconnected",
       "fg": [
-        {"weight": 1, "sprite": ["fd_sludge_int3_1_unconnected", "fd_sludge_int3_1_unconnected"]},
-        {"weight": 1, "sprite": ["fd_sludge_int3_2_unconnected", "fd_sludge_int3_2_unconnected"]},
-        {"weight": 1, "sprite": ["fd_sludge_int3_3_unconnected", "fd_sludge_int3_3_unconnected"]}
+        { "weight": 1, "sprite": [ "fd_sludge_int3_1_unconnected", "fd_sludge_int3_1_unconnected" ] },
+        { "weight": 1, "sprite": [ "fd_sludge_int3_2_unconnected", "fd_sludge_int3_2_unconnected" ] },
+        { "weight": 1, "sprite": [ "fd_sludge_int3_3_unconnected", "fd_sludge_int3_3_unconnected" ] }
       ]
     }
   ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_armchair/f_armchair.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_armchair/f_armchair.json
@@ -1,6 +1,11 @@
 {
   "id": "f_armchair",
   "rotates": true,
-  "fg": ["f_armchair_faceS", "f_armchair_faceW", "f_armchair_faceN", "f_armchair_faceE"],
+  "fg": [
+    "f_armchair_faceS",
+    "f_armchair_faceE",
+    "f_armchair_faceN",
+    "f_armchair_faceW"
+  ],
   "bg": ""
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_bathtub/f_bathtub.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_bathtub/f_bathtub.json
@@ -4,53 +4,23 @@
   "fg": "f_bathtub_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_bathtub_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_bathtub_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_bathtub_corner_nw",
-        "f_bathtub_corner_sw",
-        "f_bathtub_corner_se",
-        "f_bathtub_corner_ne"
-      ]
+      "fg": [ "f_bathtub_corner_nw", "f_bathtub_corner_ne", "f_bathtub_corner_se", "f_bathtub_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "f_bathtub_t_connection_n",
-        "f_bathtub_t_connection_w",
-        "f_bathtub_t_connection_s",
-        "f_bathtub_t_connection_e"
-      ]
+      "fg": [ "f_bathtub_t_connection_n", "f_bathtub_t_connection_e", "f_bathtub_t_connection_s", "f_bathtub_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_bathtub_edge_ns",
-        "f_bathtub_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_bathtub_edge_ns", "f_bathtub_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_bathtub_end_piece_n",
-        "f_bathtub_end_piece_w",
-        "f_bathtub_end_piece_s",
-        "f_bathtub_end_piece_e"
-      ]
+      "fg": [ "f_bathtub_end_piece_n", "f_bathtub_end_piece_e", "f_bathtub_end_piece_s", "f_bathtub_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_bathtub_unconnected", "f_bathtub_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_bathtub_unconnected", "f_bathtub_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_bed/f_bed.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_bed/f_bed.json
@@ -4,53 +4,19 @@
   "fg": "f_bed_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_bed_center"
-    },
-    {
-      "id": "corner",
-      "bg": "",
-      "fg": [
-        "f_bed_corner_nw",
-        "f_bed_corner_sw",
-        "f_bed_corner_se",
-        "f_bed_corner_ne"
-      ]
-    },
+    { "id": "center", "bg": "", "fg": "f_bed_center" },
+    { "id": "corner", "bg": "", "fg": [ "f_bed_corner_nw", "f_bed_corner_ne", "f_bed_corner_se", "f_bed_corner_sw" ] },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "f_bed_t_connection_n",
-        "f_bed_t_connection_w",
-        "f_bed_t_connection_s",
-        "f_bed_t_connection_e"
-      ]
+      "fg": [ "f_bed_t_connection_n", "f_bed_t_connection_e", "f_bed_t_connection_s", "f_bed_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_bed_edge_ns",
-        "f_bed_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_bed_edge_ns", "f_bed_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_bed_end_piece_n",
-        "f_bed_end_piece_w",
-        "f_bed_end_piece_s",
-        "f_bed_end_piece_e"
-      ]
+      "fg": [ "f_bed_end_piece_n", "f_bed_end_piece_e", "f_bed_end_piece_s", "f_bed_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_bed_unconnected",  "f_bed_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_bed_unconnected", "f_bed_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_bench/f_bench.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_bench/f_bench.json
@@ -4,53 +4,23 @@
   "fg": "f_bench_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_bench_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_bench_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_bench_corner_nw",
-        "f_bench_corner_sw",
-        "f_bench_corner_se",
-        "f_bench_corner_ne"
-      ]
+      "fg": [ "f_bench_corner_nw", "f_bench_corner_ne", "f_bench_corner_se", "f_bench_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "f_bench_t_connection_n",
-        "f_bench_t_connection_w",
-        "f_bench_t_connection_s",
-        "f_bench_t_connection_e"
-      ]
+      "fg": [ "f_bench_t_connection_n", "f_bench_t_connection_e", "f_bench_t_connection_s", "f_bench_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_bench_edge_ns",
-        "f_bench_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_bench_edge_ns", "f_bench_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_bench_end_piece_n",
-        "f_bench_end_piece_w",
-        "f_bench_end_piece_s",
-        "f_bench_end_piece_e"
-      ]
+      "fg": [ "f_bench_end_piece_n", "f_bench_end_piece_e", "f_bench_end_piece_s", "f_bench_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_bench_unconnected", "f_bench_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_bench_unconnected", "f_bench_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_canvas_wall/f_canvas_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_canvas_wall/f_canvas_wall.json
@@ -1,56 +1,34 @@
 {
-  "id": [ "f_canvas_wall", "f_large_canvas_wall" ],
+  "id": [
+    "f_canvas_wall",
+    "f_large_canvas_wall"
+  ],
   "multitile": true,
   "fg": "f_canvas_wall_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_canvas_wall_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_canvas_wall_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_canvas_wall_corner_nw",
-        "f_canvas_wall_corner_sw",
-        "f_canvas_wall_corner_se",
-        "f_canvas_wall_corner_ne"
-      ]
+      "fg": [ "f_canvas_wall_corner_nw", "f_canvas_wall_corner_ne", "f_canvas_wall_corner_se", "f_canvas_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "f_canvas_wall_t_connection_n",
-        "f_canvas_wall_t_connection_w",
+        "f_canvas_wall_t_connection_e",
         "f_canvas_wall_t_connection_s",
-        "f_canvas_wall_t_connection_e"
+        "f_canvas_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_canvas_wall_edge_ns",
-        "f_canvas_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_canvas_wall_edge_ns", "f_canvas_wall_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_canvas_wall_end_piece_n",
-        "f_canvas_wall_end_piece_w",
-        "f_canvas_wall_end_piece_s",
-        "f_canvas_wall_end_piece_e"
-      ]
+      "fg": [ "f_canvas_wall_end_piece_n", "f_canvas_wall_end_piece_e", "f_canvas_wall_end_piece_s", "f_canvas_wall_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "f_canvas_wall_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "f_canvas_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_chair/f_chair.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_chair/f_chair.json
@@ -1,6 +1,11 @@
 {
   "id": "f_chair",
   "rotates": true,
-  "fg": ["f_chair_faceS", "f_chair_faceW", "f_chair_faceN", "f_chair_faceE"],
+  "fg": [
+    "f_chair_faceS",
+    "f_chair_faceE",
+    "f_chair_faceN",
+    "f_chair_faceW"
+  ],
   "bg": ""
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_counter/f_counter.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_counter/f_counter.json
@@ -4,53 +4,23 @@
   "fg": "f_counter_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_counter_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_counter_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_counter_corner_nw",
-        "f_counter_corner_sw",
-        "f_counter_corner_se",
-        "f_counter_corner_ne"
-      ]
+      "fg": [ "f_counter_corner_nw", "f_counter_corner_ne", "f_counter_corner_se", "f_counter_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "f_counter_t_connection_n",
-        "f_counter_t_connection_w",
-        "f_counter_t_connection_s",
-        "f_counter_t_connection_e"
-      ]
+      "fg": [ "f_counter_t_connection_n", "f_counter_t_connection_e", "f_counter_t_connection_s", "f_counter_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_counter_edge_ns",
-        "f_counter_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_counter_edge_ns", "f_counter_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_counter_end_piece_n",
-        "f_counter_end_piece_w",
-        "f_counter_end_piece_s",
-        "f_counter_end_piece_e"
-      ]
+      "fg": [ "f_counter_end_piece_n", "f_counter_end_piece_e", "f_counter_end_piece_s", "f_counter_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_counter_unconnected",  "f_counter_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_counter_unconnected", "f_counter_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_cupboard/f_cupboard.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_cupboard/f_cupboard.json
@@ -4,53 +4,23 @@
   "fg": "f_cupboard_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_cupboard_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_cupboard_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_cupboard_corner_nw",
-        "f_cupboard_corner_sw",
-        "f_cupboard_corner_se",
-        "f_cupboard_corner_ne"
-      ]
+      "fg": [ "f_cupboard_corner_nw", "f_cupboard_corner_ne", "f_cupboard_corner_se", "f_cupboard_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "f_cupboard_t_connection_n",
-        "f_cupboard_t_connection_w",
-        "f_cupboard_t_connection_s",
-        "f_cupboard_t_connection_e"
-      ]
+      "fg": [ "f_cupboard_t_connection_n", "f_cupboard_t_connection_e", "f_cupboard_t_connection_s", "f_cupboard_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_cupboard_edge_ns",
-        "f_cupboard_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_cupboard_edge_ns", "f_cupboard_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_cupboard_end_piece_n",
-        "f_cupboard_end_piece_w",
-        "f_cupboard_end_piece_s",
-        "f_cupboard_end_piece_e"
-      ]
+      "fg": [ "f_cupboard_end_piece_n", "f_cupboard_end_piece_e", "f_cupboard_end_piece_s", "f_cupboard_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_cupboard_unconnected", "f_cupboard_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_cupboard_unconnected", "f_cupboard_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_desk/f_desk.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_desk/f_desk.json
@@ -4,53 +4,23 @@
   "fg": "f_desk_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_desk_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_desk_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_desk_corner_nw",
-        "f_desk_corner_sw",
-        "f_desk_corner_se",
-        "f_desk_corner_ne"
-      ]
+      "fg": [ "f_desk_corner_nw", "f_desk_corner_ne", "f_desk_corner_se", "f_desk_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "f_desk_t_connection_n",
-        "f_desk_t_connection_w",
-        "f_desk_t_connection_s",
-        "f_desk_t_connection_e"
-      ]
+      "fg": [ "f_desk_t_connection_n", "f_desk_t_connection_e", "f_desk_t_connection_s", "f_desk_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_desk_edge_ns",
-        "f_desk_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_desk_edge_ns", "f_desk_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_desk_end_piece_n",
-        "f_desk_end_piece_w",
-        "f_desk_end_piece_s",
-        "f_desk_end_piece_e"
-      ]
+      "fg": [ "f_desk_end_piece_n", "f_desk_end_piece_e", "f_desk_end_piece_s", "f_desk_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_desk_unconnected", "f_desk_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_desk_unconnected", "f_desk_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_fungal_clump/f_fungal_clump.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_fungal_clump/f_fungal_clump.json
@@ -1,5 +1,7 @@
 {
-  "id": ["f_fungal_clump"],
+  "id": [
+    "f_fungal_clump"
+  ],
   "fg": "tfc00_unconnected",
   "multitile": true,
   "additional_tiles": [
@@ -27,40 +29,82 @@
       "id": "corner",
       "animated": true,
       "fg": [
-        { "weight": 64, "sprite": [ "tfc00_corner_nw", "tfc00_corner_sw", "tfc00_corner_se", "tfc00_corner_ne" ] },
-        { "weight": 8, "sprite": [ "tfc01_corner_nw", "tfc01_corner_sw", "tfc01_corner_se", "tfc01_corner_ne" ] },
-        { "weight": 8, "sprite": [ "tfc02_corner_nw", "tfc02_corner_sw", "tfc02_corner_se", "tfc02_corner_ne" ] },
-        { "weight": 8, "sprite": [ "tfc03_corner_nw", "tfc03_corner_sw", "tfc03_corner_se", "tfc03_corner_ne" ] },
-        { "weight": 8, "sprite": [ "tfc04_corner_nw", "tfc04_corner_sw", "tfc04_corner_se", "tfc04_corner_ne" ] },
-        { "weight": 8, "sprite": [ "tfc05_corner_nw", "tfc05_corner_sw", "tfc05_corner_se", "tfc05_corner_ne" ] },
-        { "weight": 8, "sprite": [ "tfc06_corner_nw", "tfc06_corner_sw", "tfc06_corner_se", "tfc06_corner_ne" ] },
-        { "weight": 64, "sprite": [ "tfc07_corner_nw", "tfc07_corner_sw", "tfc07_corner_se", "tfc07_corner_ne" ] },
-        { "weight": 8, "sprite": [ "tfc08_corner_nw", "tfc08_corner_sw", "tfc08_corner_se", "tfc08_corner_ne" ] },
-        { "weight": 8, "sprite": [ "tfc09_corner_nw", "tfc09_corner_sw", "tfc09_corner_se", "tfc09_corner_ne" ] },
-        { "weight": 8, "sprite": [ "tfc10_corner_nw", "tfc10_corner_sw", "tfc10_corner_se", "tfc10_corner_ne" ] },
-        { "weight": 8, "sprite": [ "tfc11_corner_nw", "tfc11_corner_sw", "tfc11_corner_se", "tfc11_corner_ne" ] },
-        { "weight": 8, "sprite": [ "tfc12_corner_nw", "tfc12_corner_sw", "tfc12_corner_se", "tfc12_corner_ne" ] },
-        { "weight": 8, "sprite": [ "tfc13_corner_nw", "tfc13_corner_sw", "tfc13_corner_se", "tfc13_corner_ne" ] }
+        { "weight": 64, "sprite": [ "tfc00_corner_nw", "tfc00_corner_ne", "tfc00_corner_se", "tfc00_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfc01_corner_nw", "tfc01_corner_ne", "tfc01_corner_se", "tfc01_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfc02_corner_nw", "tfc02_corner_ne", "tfc02_corner_se", "tfc02_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfc03_corner_nw", "tfc03_corner_ne", "tfc03_corner_se", "tfc03_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfc04_corner_nw", "tfc04_corner_ne", "tfc04_corner_se", "tfc04_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfc05_corner_nw", "tfc05_corner_ne", "tfc05_corner_se", "tfc05_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfc06_corner_nw", "tfc06_corner_ne", "tfc06_corner_se", "tfc06_corner_sw" ] },
+        { "weight": 64, "sprite": [ "tfc07_corner_nw", "tfc07_corner_ne", "tfc07_corner_se", "tfc07_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfc08_corner_nw", "tfc08_corner_ne", "tfc08_corner_se", "tfc08_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfc09_corner_nw", "tfc09_corner_ne", "tfc09_corner_se", "tfc09_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfc10_corner_nw", "tfc10_corner_ne", "tfc10_corner_se", "tfc10_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfc11_corner_nw", "tfc11_corner_ne", "tfc11_corner_se", "tfc11_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfc12_corner_nw", "tfc12_corner_ne", "tfc12_corner_se", "tfc12_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfc13_corner_nw", "tfc13_corner_ne", "tfc13_corner_se", "tfc13_corner_sw" ] }
       ]
     },
     {
       "id": "t_connection",
       "animated": true,
       "fg": [
-        { "weight": 64, "sprite": [ "tfc00_t_connection_n", "tfc00_t_connection_w", "tfc00_t_connection_s", "tfc00_t_connection_e" ] },
-        { "weight": 8, "sprite": [ "tfc01_t_connection_n", "tfc01_t_connection_w", "tfc01_t_connection_s", "tfc01_t_connection_e" ] },
-        { "weight": 8, "sprite": [ "tfc02_t_connection_n", "tfc02_t_connection_w", "tfc02_t_connection_s", "tfc02_t_connection_e" ] },
-        { "weight": 8, "sprite": [ "tfc03_t_connection_n", "tfc03_t_connection_w", "tfc03_t_connection_s", "tfc03_t_connection_e" ] },
-        { "weight": 8, "sprite": [ "tfc04_t_connection_n", "tfc04_t_connection_w", "tfc04_t_connection_s", "tfc04_t_connection_e" ] },
-        { "weight": 8, "sprite": [ "tfc05_t_connection_n", "tfc05_t_connection_w", "tfc05_t_connection_s", "tfc05_t_connection_e" ] },
-        { "weight": 8, "sprite": [ "tfc06_t_connection_n", "tfc06_t_connection_w", "tfc06_t_connection_s", "tfc06_t_connection_e" ] },
-        { "weight": 64, "sprite": [ "tfc07_t_connection_n", "tfc07_t_connection_w", "tfc07_t_connection_s", "tfc07_t_connection_e" ] },
-        { "weight": 8, "sprite": [ "tfc08_t_connection_n", "tfc08_t_connection_w", "tfc08_t_connection_s", "tfc08_t_connection_e" ] },
-        { "weight": 8, "sprite": [ "tfc09_t_connection_n", "tfc09_t_connection_w", "tfc09_t_connection_s", "tfc09_t_connection_e" ] },
-        { "weight": 8, "sprite": [ "tfc10_t_connection_n", "tfc10_t_connection_w", "tfc10_t_connection_s", "tfc10_t_connection_e" ] },
-        { "weight": 8, "sprite": [ "tfc11_t_connection_n", "tfc11_t_connection_w", "tfc11_t_connection_s", "tfc11_t_connection_e" ] },
-        { "weight": 8, "sprite": [ "tfc12_t_connection_n", "tfc12_t_connection_w", "tfc12_t_connection_s", "tfc12_t_connection_e" ] },
-        { "weight": 8, "sprite": [ "tfc13_t_connection_n", "tfc13_t_connection_w", "tfc13_t_connection_s", "tfc13_t_connection_e" ] }
+        {
+          "weight": 64,
+          "sprite": [ "tfc00_t_connection_n", "tfc00_t_connection_e", "tfc00_t_connection_s", "tfc00_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc01_t_connection_n", "tfc01_t_connection_e", "tfc01_t_connection_s", "tfc01_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc02_t_connection_n", "tfc02_t_connection_e", "tfc02_t_connection_s", "tfc02_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc03_t_connection_n", "tfc03_t_connection_e", "tfc03_t_connection_s", "tfc03_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc04_t_connection_n", "tfc04_t_connection_e", "tfc04_t_connection_s", "tfc04_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc05_t_connection_n", "tfc05_t_connection_e", "tfc05_t_connection_s", "tfc05_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc06_t_connection_n", "tfc06_t_connection_e", "tfc06_t_connection_s", "tfc06_t_connection_w" ]
+        },
+        {
+          "weight": 64,
+          "sprite": [ "tfc07_t_connection_n", "tfc07_t_connection_e", "tfc07_t_connection_s", "tfc07_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc08_t_connection_n", "tfc08_t_connection_e", "tfc08_t_connection_s", "tfc08_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc09_t_connection_n", "tfc09_t_connection_e", "tfc09_t_connection_s", "tfc09_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc10_t_connection_n", "tfc10_t_connection_e", "tfc10_t_connection_s", "tfc10_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc11_t_connection_n", "tfc11_t_connection_e", "tfc11_t_connection_s", "tfc11_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc12_t_connection_n", "tfc12_t_connection_e", "tfc12_t_connection_s", "tfc12_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc13_t_connection_n", "tfc13_t_connection_e", "tfc13_t_connection_s", "tfc13_t_connection_w" ]
+        }
       ]
     },
     {
@@ -87,20 +131,59 @@
       "id": "end_piece",
       "animated": true,
       "fg": [
-        { "weight": 64, "sprite": [ "tfc00_end_piece_n", "tfc00_end_piece_w", "tfc00_end_piece_s", "tfc00_end_piece_e" ] },
-        { "weight": 8, "sprite": [ "tfc01_end_piece_n", "tfc01_end_piece_w", "tfc01_end_piece_s", "tfc01_end_piece_e" ] },
-        { "weight": 8, "sprite": [ "tfc02_end_piece_n", "tfc02_end_piece_w", "tfc02_end_piece_s", "tfc02_end_piece_e" ] },
-        { "weight": 8, "sprite": [ "tfc03_end_piece_n", "tfc03_end_piece_w", "tfc03_end_piece_s", "tfc03_end_piece_e" ] },
-        { "weight": 8, "sprite": [ "tfc04_end_piece_n", "tfc04_end_piece_w", "tfc04_end_piece_s", "tfc04_end_piece_e" ] },
-        { "weight": 8, "sprite": [ "tfc05_end_piece_n", "tfc05_end_piece_w", "tfc05_end_piece_s", "tfc05_end_piece_e" ] },
-        { "weight": 8, "sprite": [ "tfc06_end_piece_n", "tfc06_end_piece_w", "tfc06_end_piece_s", "tfc06_end_piece_e" ] },
-        { "weight": 64, "sprite": [ "tfc07_end_piece_n", "tfc07_end_piece_w", "tfc07_end_piece_s", "tfc07_end_piece_e" ] },
-        { "weight": 8, "sprite": [ "tfc08_end_piece_n", "tfc08_end_piece_w", "tfc08_end_piece_s", "tfc08_end_piece_e" ] },
-        { "weight": 8, "sprite": [ "tfc09_end_piece_n", "tfc09_end_piece_w", "tfc09_end_piece_s", "tfc09_end_piece_e" ] },
-        { "weight": 8, "sprite": [ "tfc10_end_piece_n", "tfc10_end_piece_w", "tfc10_end_piece_s", "tfc10_end_piece_e" ] },
-        { "weight": 8, "sprite": [ "tfc11_end_piece_n", "tfc11_end_piece_w", "tfc11_end_piece_s", "tfc11_end_piece_e" ] },
-        { "weight": 8, "sprite": [ "tfc12_end_piece_n", "tfc12_end_piece_w", "tfc12_end_piece_s", "tfc12_end_piece_e" ] },
-        { "weight": 8, "sprite": [ "tfc13_end_piece_n", "tfc13_end_piece_w", "tfc13_end_piece_s", "tfc13_end_piece_e" ] }
+        { "weight": 64, "sprite": [ "tfc00_end_piece_n", "tfc00_end_piece_e", "tfc00_end_piece_s", "tfc00_end_piece_w" ] },
+        {
+          "weight": 8,
+          "sprite": [ "tfc01_end_piece_n", "tfc01_end_piece_e", "tfc01_end_piece_s", "tfc01_end_piece_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc02_end_piece_n", "tfc02_end_piece_e", "tfc02_end_piece_s", "tfc02_end_piece_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc03_end_piece_n", "tfc03_end_piece_e", "tfc03_end_piece_s", "tfc03_end_piece_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc04_end_piece_n", "tfc04_end_piece_e", "tfc04_end_piece_s", "tfc04_end_piece_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc05_end_piece_n", "tfc05_end_piece_e", "tfc05_end_piece_s", "tfc05_end_piece_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc06_end_piece_n", "tfc06_end_piece_e", "tfc06_end_piece_s", "tfc06_end_piece_w" ]
+        },
+        {
+          "weight": 64,
+          "sprite": [ "tfc07_end_piece_n", "tfc07_end_piece_e", "tfc07_end_piece_s", "tfc07_end_piece_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc08_end_piece_n", "tfc08_end_piece_e", "tfc08_end_piece_s", "tfc08_end_piece_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc09_end_piece_n", "tfc09_end_piece_e", "tfc09_end_piece_s", "tfc09_end_piece_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc10_end_piece_n", "tfc10_end_piece_e", "tfc10_end_piece_s", "tfc10_end_piece_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc11_end_piece_n", "tfc11_end_piece_e", "tfc11_end_piece_s", "tfc11_end_piece_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc12_end_piece_n", "tfc12_end_piece_e", "tfc12_end_piece_s", "tfc12_end_piece_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfc13_end_piece_n", "tfc13_end_piece_e", "tfc13_end_piece_s", "tfc13_end_piece_w" ]
+        }
       ]
     },
     {

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_metal_table/f_metal_table.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_metal_table/f_metal_table.json
@@ -4,53 +4,28 @@
   "fg": "f_metal_table_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_metal_table_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_metal_table_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_metal_table_corner_nw",
-        "f_metal_table_corner_sw",
-        "f_metal_table_corner_se",
-        "f_metal_table_corner_ne"
-      ]
+      "fg": [ "f_metal_table_corner_nw", "f_metal_table_corner_ne", "f_metal_table_corner_se", "f_metal_table_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "f_metal_table_t_connection_n",
-        "f_metal_table_t_connection_w",
+        "f_metal_table_t_connection_e",
         "f_metal_table_t_connection_s",
-        "f_metal_table_t_connection_e"
+        "f_metal_table_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_metal_table_edge_ns",
-        "f_metal_table_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_metal_table_edge_ns", "f_metal_table_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_metal_table_end_piece_n",
-        "f_metal_table_end_piece_w",
-        "f_metal_table_end_piece_s",
-        "f_metal_table_end_piece_e"
-      ]
+      "fg": [ "f_metal_table_end_piece_n", "f_metal_table_end_piece_e", "f_metal_table_end_piece_s", "f_metal_table_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_metal_table_unconnected", "f_metal_table_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_metal_table_unconnected", "f_metal_table_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_planter/f_planter.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_planter/f_planter.json
@@ -4,53 +4,23 @@
   "fg": "f_planter_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_planter_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_planter_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_planter_corner_nw",
-        "f_planter_corner_sw",
-        "f_planter_corner_se",
-        "f_planter_corner_ne"
-      ]
+      "fg": [ "f_planter_corner_nw", "f_planter_corner_ne", "f_planter_corner_se", "f_planter_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "f_planter_t_connection_n",
-        "f_planter_t_connection_w",
-        "f_planter_t_connection_s",
-        "f_planter_t_connection_e"
-      ]
+      "fg": [ "f_planter_t_connection_n", "f_planter_t_connection_e", "f_planter_t_connection_s", "f_planter_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_planter_edge_ns",
-        "f_planter_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_planter_edge_ns", "f_planter_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_planter_end_piece_n",
-        "f_planter_end_piece_w",
-        "f_planter_end_piece_s",
-        "f_planter_end_piece_e"
-      ]
+      "fg": [ "f_planter_end_piece_n", "f_planter_end_piece_e", "f_planter_end_piece_s", "f_planter_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_planter_unconnected", "f_planter_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_planter_unconnected", "f_planter_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_planter_harvest/f_planter_harvest.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_planter_harvest/f_planter_harvest.json
@@ -4,19 +4,15 @@
   "fg": "f_planter_harvest_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_planter_harvest_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_planter_harvest_center" },
     {
       "id": "corner",
       "bg": "",
       "fg": [
         "f_planter_harvest_corner_nw",
-        "f_planter_harvest_corner_sw",
+        "f_planter_harvest_corner_ne",
         "f_planter_harvest_corner_se",
-        "f_planter_harvest_corner_ne"
+        "f_planter_harvest_corner_sw"
       ]
     },
     {
@@ -24,33 +20,22 @@
       "bg": "",
       "fg": [
         "f_planter_harvest_t_connection_n",
-        "f_planter_harvest_t_connection_w",
+        "f_planter_harvest_t_connection_e",
         "f_planter_harvest_t_connection_s",
-        "f_planter_harvest_t_connection_e"
+        "f_planter_harvest_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_planter_harvest_edge_ns",
-        "f_planter_harvest_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_planter_harvest_edge_ns", "f_planter_harvest_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "f_planter_harvest_end_piece_n",
-        "f_planter_harvest_end_piece_w",
+        "f_planter_harvest_end_piece_e",
         "f_planter_harvest_end_piece_s",
-        "f_planter_harvest_end_piece_e"
+        "f_planter_harvest_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_planter_harvest_unconnected", "f_planter_harvest_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_planter_harvest_unconnected", "f_planter_harvest_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_planter_mature/f_planter_mature.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_planter_mature/f_planter_mature.json
@@ -4,19 +4,15 @@
   "fg": "f_planter_mature_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_planter_mature_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_planter_mature_center" },
     {
       "id": "corner",
       "bg": "",
       "fg": [
         "f_planter_mature_corner_nw",
-        "f_planter_mature_corner_sw",
+        "f_planter_mature_corner_ne",
         "f_planter_mature_corner_se",
-        "f_planter_mature_corner_ne"
+        "f_planter_mature_corner_sw"
       ]
     },
     {
@@ -24,33 +20,22 @@
       "bg": "",
       "fg": [
         "f_planter_mature_t_connection_n",
-        "f_planter_mature_t_connection_w",
+        "f_planter_mature_t_connection_e",
         "f_planter_mature_t_connection_s",
-        "f_planter_mature_t_connection_e"
+        "f_planter_mature_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_planter_mature_edge_ns",
-        "f_planter_mature_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_planter_mature_edge_ns", "f_planter_mature_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "f_planter_mature_end_piece_n",
-        "f_planter_mature_end_piece_w",
+        "f_planter_mature_end_piece_e",
         "f_planter_mature_end_piece_s",
-        "f_planter_mature_end_piece_e"
+        "f_planter_mature_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_planter_mature_unconnected", "f_planter_mature_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_planter_mature_unconnected", "f_planter_mature_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_planter_seedling/f_planter_seedling.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_planter_seedling/f_planter_seedling.json
@@ -4,19 +4,15 @@
   "fg": "f_planter_seedling_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_planter_seedling_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_planter_seedling_center" },
     {
       "id": "corner",
       "bg": "",
       "fg": [
         "f_planter_seedling_corner_nw",
-        "f_planter_seedling_corner_sw",
+        "f_planter_seedling_corner_ne",
         "f_planter_seedling_corner_se",
-        "f_planter_seedling_corner_ne"
+        "f_planter_seedling_corner_sw"
       ]
     },
     {
@@ -24,33 +20,22 @@
       "bg": "",
       "fg": [
         "f_planter_seedling_t_connection_n",
-        "f_planter_seedling_t_connection_w",
+        "f_planter_seedling_t_connection_e",
         "f_planter_seedling_t_connection_s",
-        "f_planter_seedling_t_connection_e"
+        "f_planter_seedling_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_planter_seedling_edge_ns",
-        "f_planter_seedling_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_planter_seedling_edge_ns", "f_planter_seedling_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "f_planter_seedling_end_piece_n",
-        "f_planter_seedling_end_piece_w",
+        "f_planter_seedling_end_piece_e",
         "f_planter_seedling_end_piece_s",
-        "f_planter_seedling_end_piece_e"
+        "f_planter_seedling_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_planter_seedling_unconnected", "f_planter_seedling_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_planter_seedling_unconnected", "f_planter_seedling_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_pool_table/f_pool_table.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_pool_table/f_pool_table.json
@@ -4,53 +4,28 @@
   "fg": "f_pool_table_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_pool_table_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_pool_table_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_pool_table_corner_nw",
-        "f_pool_table_corner_sw",
-        "f_pool_table_corner_se",
-        "f_pool_table_corner_ne"
-      ]
+      "fg": [ "f_pool_table_corner_nw", "f_pool_table_corner_ne", "f_pool_table_corner_se", "f_pool_table_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "f_pool_table_t_connection_n",
-        "f_pool_table_t_connection_w",
+        "f_pool_table_t_connection_e",
         "f_pool_table_t_connection_s",
-        "f_pool_table_t_connection_e"
+        "f_pool_table_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_pool_table_edge_ns",
-        "f_pool_table_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_pool_table_edge_ns", "f_pool_table_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_pool_table_end_piece_n",
-        "f_pool_table_end_piece_w",
-        "f_pool_table_end_piece_s",
-        "f_pool_table_end_piece_e"
-      ]
+      "fg": [ "f_pool_table_end_piece_n", "f_pool_table_end_piece_e", "f_pool_table_end_piece_s", "f_pool_table_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "f_pool_table_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "f_pool_table_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_scrap_bridge/f_scrap_bridge.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_scrap_bridge/f_scrap_bridge.json
@@ -3,50 +3,30 @@
   "fg": "f_scrap_bridge_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_scrap_bridge_center"
-    },
+    { "id": "center", "fg": "f_scrap_bridge_center" },
     {
       "id": "corner",
-      "fg": [
-        "f_scrap_bridge_corner_nw",
-        "f_scrap_bridge_corner_sw",
-        "f_scrap_bridge_corner_se",
-        "f_scrap_bridge_corner_ne"
-      ]
+      "fg": [ "f_scrap_bridge_corner_nw", "f_scrap_bridge_corner_ne", "f_scrap_bridge_corner_se", "f_scrap_bridge_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_scrap_bridge_t_connection_n",
-        "f_scrap_bridge_t_connection_w",
+        "f_scrap_bridge_t_connection_e",
         "f_scrap_bridge_t_connection_s",
-        "f_scrap_bridge_t_connection_e"
+        "f_scrap_bridge_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_scrap_bridge_edge_ns",
-        "f_scrap_bridge_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_scrap_bridge_edge_ns", "f_scrap_bridge_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "f_scrap_bridge_end_piece_n",
-        "f_scrap_bridge_end_piece_w",
+        "f_scrap_bridge_end_piece_e",
         "f_scrap_bridge_end_piece_s",
-        "f_scrap_bridge_end_piece_e"
+        "f_scrap_bridge_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "f_scrap_bridge_unconnected",
-        "f_scrap_bridge_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "f_scrap_bridge_unconnected", "f_scrap_bridge_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_skin_wall/f_skin_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_skin_wall/f_skin_wall.json
@@ -3,47 +3,25 @@
   "fg": "f_skin_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "f_skin_wall_center"
-    },
+    { "id": "center", "fg": "f_skin_wall_center" },
     {
       "id": "corner",
-      "fg": [
-        "f_skin_wall_corner_nw",
-        "f_skin_wall_corner_sw",
-        "f_skin_wall_corner_se",
-        "f_skin_wall_corner_ne"
-      ]
+      "fg": [ "f_skin_wall_corner_nw", "f_skin_wall_corner_ne", "f_skin_wall_corner_se", "f_skin_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "f_skin_wall_t_connection_n",
-        "f_skin_wall_t_connection_w",
+        "f_skin_wall_t_connection_e",
         "f_skin_wall_t_connection_s",
-        "f_skin_wall_t_connection_e"
+        "f_skin_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "f_skin_wall_edge_ns",
-        "f_skin_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "f_skin_wall_edge_ns", "f_skin_wall_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "f_skin_wall_end_piece_n",
-        "f_skin_wall_end_piece_w",
-        "f_skin_wall_end_piece_s",
-        "f_skin_wall_end_piece_e"
-      ]
+      "fg": [ "f_skin_wall_end_piece_n", "f_skin_wall_end_piece_e", "f_skin_wall_end_piece_s", "f_skin_wall_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "f_skin_wall_unconnected"
-    }
+    { "id": "unconnected", "fg": "f_skin_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_sofa/f_sofa.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_sofa/f_sofa.json
@@ -4,53 +4,23 @@
   "fg": "f_sofa_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_sofa_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_sofa_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_sofa_corner_nw",
-        "f_sofa_corner_sw",
-        "f_sofa_corner_se",
-        "f_sofa_corner_ne"
-      ]
+      "fg": [ "f_sofa_corner_nw", "f_sofa_corner_ne", "f_sofa_corner_se", "f_sofa_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "f_sofa_t_connection_n",
-        "f_sofa_t_connection_w",
-        "f_sofa_t_connection_s",
-        "f_sofa_t_connection_e"
-      ]
+      "fg": [ "f_sofa_t_connection_n", "f_sofa_t_connection_e", "f_sofa_t_connection_s", "f_sofa_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_sofa_edge_ns",
-        "f_sofa_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_sofa_edge_ns", "f_sofa_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_sofa_end_piece_n",
-        "f_sofa_end_piece_w",
-        "f_sofa_end_piece_s",
-        "f_sofa_end_piece_e"
-      ]
+      "fg": [ "f_sofa_end_piece_n", "f_sofa_end_piece_e", "f_sofa_end_piece_s", "f_sofa_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_sofa_unconnected", "f_sofa_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_sofa_unconnected", "f_sofa_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_table/f_table.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/f_table/f_table.json
@@ -4,53 +4,23 @@
   "fg": "f_table_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_table_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_table_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_table_corner_nw",
-        "f_table_corner_sw",
-        "f_table_corner_se",
-        "f_table_corner_ne"
-      ]
+      "fg": [ "f_table_corner_nw", "f_table_corner_ne", "f_table_corner_se", "f_table_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "f_table_t_connection_n",
-        "f_table_t_connection_w",
-        "f_table_t_connection_s",
-        "f_table_t_connection_e"
-      ]
+      "fg": [ "f_table_t_connection_n", "f_table_t_connection_e", "f_table_t_connection_s", "f_table_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_table_edge_ns",
-        "f_table_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_table_edge_ns", "f_table_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_table_end_piece_n",
-        "f_table_end_piece_w",
-        "f_table_end_piece_s",
-        "f_table_end_piece_e"
-      ]
+      "fg": [ "f_table_end_piece_n", "f_table_end_piece_e", "f_table_end_piece_s", "f_table_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [ "f_table_unconnected", "f_table_unconnected" ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_table_unconnected", "f_table_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/sandbag_barricade/f_sandbag_half/f_sandbag_half.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/furniture/sandbag_barricade/f_sandbag_half/f_sandbag_half.json
@@ -4,56 +4,33 @@
   "fg": "f_sandbag_half_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_sandbag_half_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_sandbag_half_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_sandbag_half_corner_nw",
-        "f_sandbag_half_corner_sw",
-        "f_sandbag_half_corner_se",
-        "f_sandbag_half_corner_ne"
-      ]
+      "fg": [ "f_sandbag_half_corner_nw", "f_sandbag_half_corner_ne", "f_sandbag_half_corner_se", "f_sandbag_half_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "f_sandbag_half_t_connection_n",
-        "f_sandbag_half_t_connection_w",
+        "f_sandbag_half_t_connection_e",
         "f_sandbag_half_t_connection_s",
-        "f_sandbag_half_t_connection_e"
+        "f_sandbag_half_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_sandbag_half_edge_ns",
-        "f_sandbag_half_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_sandbag_half_edge_ns", "f_sandbag_half_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "f_sandbag_half_end_piece_n",
-        "f_sandbag_half_end_piece_w",
+        "f_sandbag_half_end_piece_e",
         "f_sandbag_half_end_piece_s",
-        "f_sandbag_half_end_piece_e"
+        "f_sandbag_half_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [
-        "f_sandbag_half_unconnected",
-        "f_sandbag_half_unconnected"
-      ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_sandbag_half_unconnected", "f_sandbag_half_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/mods/aftershock/terrain/t_ice/t_ice.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/mods/aftershock/terrain/t_ice/t_ice.json
@@ -16,47 +16,21 @@
       },
       {
         "id": "corner",
-        "fg": [
-          "t_ice_corner_nw",
-          "t_ice_corner_sw",
-          "t_ice_corner_se",
-          "t_ice_corner_ne"
-        ],
+        "fg": [ "t_ice_corner_nw", "t_ice_corner_ne", "t_ice_corner_se", "t_ice_corner_sw" ],
         "bg": "t_deaddirt_center"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_ice_t_connection_n",
-          "t_ice_t_connection_w",
-          "t_ice_t_connection_s",
-          "t_ice_t_connection_e"
-        ],
+        "fg": [ "t_ice_t_connection_n", "t_ice_t_connection_e", "t_ice_t_connection_s", "t_ice_t_connection_w" ],
         "bg": "t_deaddirt_center"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_ice_edge_ns",
-          "t_ice_edge_ew"
-        ],
-        "bg": "t_deaddirt_center"
-      },
+      { "id": "edge", "fg": [ "t_ice_edge_ns", "t_ice_edge_ew" ], "bg": "t_deaddirt_center" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_ice_end_piece_n",
-          "t_ice_end_piece_w",
-          "t_ice_end_piece_s",
-          "t_ice_end_piece_e"
-        ],
+        "fg": [ "t_ice_end_piece_n", "t_ice_end_piece_e", "t_ice_end_piece_s", "t_ice_end_piece_w" ],
         "bg": "t_deaddirt_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_ice_unconnected",
-        "bg": "t_deaddirt_center"
-      }
+      { "id": "unconnected", "fg": "t_ice_unconnected", "bg": "t_deaddirt_center" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/mods/aftershock/terrain/t_ice_wall/t_ice_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/mods/aftershock/terrain/t_ice_wall/t_ice_wall.json
@@ -3,47 +3,20 @@
   "fg": "t_ice_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_ice_wall_center"
-    },
+    { "id": "center", "fg": "t_ice_wall_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_ice_wall_corner_nw",
-        "t_ice_wall_corner_sw",
-        "t_ice_wall_corner_se",
-        "t_ice_wall_corner_ne"
-      ]
+      "fg": [ "t_ice_wall_corner_nw", "t_ice_wall_corner_ne", "t_ice_wall_corner_se", "t_ice_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_ice_wall_t_connection_n",
-        "t_ice_wall_t_connection_w",
-        "t_ice_wall_t_connection_s",
-        "t_ice_wall_t_connection_e"
-      ]
+      "fg": [ "t_ice_wall_t_connection_n", "t_ice_wall_t_connection_e", "t_ice_wall_t_connection_s", "t_ice_wall_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_ice_wall_edge_ns",
-        "t_ice_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_ice_wall_edge_ns", "t_ice_wall_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_ice_wall_end_piece_n",
-        "t_ice_wall_end_piece_w",
-        "t_ice_wall_end_piece_s",
-        "t_ice_wall_end_piece_e"
-      ]
+      "fg": [ "t_ice_wall_end_piece_n", "t_ice_wall_end_piece_e", "t_ice_wall_end_piece_s", "t_ice_wall_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_ice_wall_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_ice_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/mods/aftershock/terrain/t_snow/t_snow.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/mods/aftershock/terrain/t_snow/t_snow.json
@@ -15,46 +15,20 @@
     },
     {
       "id": "corner",
-      "fg": [
-        "t_snow_corner_nw",
-        "t_snow_corner_sw",
-        "t_snow_corner_se",
-        "t_snow_corner_ne"
-      ],
+      "fg": [ "t_snow_corner_nw", "t_snow_corner_ne", "t_snow_corner_se", "t_snow_corner_sw" ],
       "bg": "t_deaddirt_center"
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_snow_t_connection_n",
-        "t_snow_t_connection_w",
-        "t_snow_t_connection_s",
-        "t_snow_t_connection_e"
-      ],
+      "fg": [ "t_snow_t_connection_n", "t_snow_t_connection_e", "t_snow_t_connection_s", "t_snow_t_connection_w" ],
       "bg": "t_deaddirt_center"
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_snow_edge_ns",
-        "t_snow_edge_ew"
-      ],
-      "bg": "t_deaddirt_center"
-    },
+    { "id": "edge", "fg": [ "t_snow_edge_ns", "t_snow_edge_ew" ], "bg": "t_deaddirt_center" },
     {
       "id": "end_piece",
-      "fg": [
-        "t_snow_end_piece_n",
-        "t_snow_end_piece_w",
-        "t_snow_end_piece_s",
-        "t_snow_end_piece_e"
-      ],
+      "fg": [ "t_snow_end_piece_n", "t_snow_end_piece_e", "t_snow_end_piece_s", "t_snow_end_piece_w" ],
       "bg": "t_deaddirt_center"
     },
-    {
-      "id": "unconnected",
-      "fg": "t_snow_unconnected",
-      "bg": "t_deaddirt_center"
-    }
+    { "id": "unconnected", "fg": "t_snow_unconnected", "bg": "t_deaddirt_center" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/mods/aftershock/terrain/t_wall_prefab_metal/t_wall_prefab_metal.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/mods/aftershock/terrain/t_wall_prefab_metal/t_wall_prefab_metal.json
@@ -3,47 +3,35 @@
   "fg": "t_wall_prefab_metal_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_prefab_metal_center"
-    },
+    { "id": "center", "fg": "t_wall_prefab_metal_center" },
     {
       "id": "corner",
       "fg": [
         "t_wall_prefab_metal_corner_nw",
-        "t_wall_prefab_metal_corner_sw",
+        "t_wall_prefab_metal_corner_ne",
         "t_wall_prefab_metal_corner_se",
-        "t_wall_prefab_metal_corner_ne"
+        "t_wall_prefab_metal_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_prefab_metal_t_connection_n",
-        "t_wall_prefab_metal_t_connection_w",
+        "t_wall_prefab_metal_t_connection_e",
         "t_wall_prefab_metal_t_connection_s",
-        "t_wall_prefab_metal_t_connection_e"
+        "t_wall_prefab_metal_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_prefab_metal_edge_ns",
-        "t_wall_prefab_metal_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_prefab_metal_edge_ns", "t_wall_prefab_metal_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wall_prefab_metal_end_piece_n",
-        "t_wall_prefab_metal_end_piece_w",
+        "t_wall_prefab_metal_end_piece_e",
         "t_wall_prefab_metal_end_piece_s",
-        "t_wall_prefab_metal_end_piece_e"
+        "t_wall_prefab_metal_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_prefab_metal_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_prefab_metal_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cabin/cabin.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cabin/cabin.json
@@ -1,41 +1,44 @@
-[{
-  "id": [
-    "cabin",
-    "cabin_1",
-    "cabin_2",
-    "cabin_3",
-    "cabin_4",
-    "cabin_5",
-    "cabin_6",
-    "cabin_7",
-    "cabin_lapin",
-    "bandit_cabin",
-    "cabin_isherwood",
-    "cabin_lake",
-    "lake_cabin_boathouse",
-    "cabin_strange",
-    "cabin_strange_b",
-    "riverside_dwelling"
-  ],
-  "fg": [ "cabin_faceN", "cabin_faceW", "cabin_faceS", "cabin_faceE" ],
-  "bg": "field",
-  "rotates": true
-},{
-  "id": [
-    "cabin_roof",
-    "cabin_roof_1",
-    "cabin_roof_2",
-    "cabin_roof_3",
-    "cabin_roof_4",
-    "cabin_roof_5",
-    "cabin_roof_6",
-    "cabin_roof_7",
-    "cabin_strange_roof",
-    "cabin_roof_lapin",
-    "cabin_lake_roof",
-    "lake_cabin_boathouse_roof"
-  ],
-  "fg": [ "cabin_faceN", "cabin_faceW", "cabin_faceS", "cabin_faceE" ],
-  "bg": "open_air",
-  "rotates": true
-}]
+[
+  {
+    "id": [
+      "cabin",
+      "cabin_1",
+      "cabin_2",
+      "cabin_3",
+      "cabin_4",
+      "cabin_5",
+      "cabin_6",
+      "cabin_7",
+      "cabin_lapin",
+      "bandit_cabin",
+      "cabin_isherwood",
+      "cabin_lake",
+      "lake_cabin_boathouse",
+      "cabin_strange",
+      "cabin_strange_b",
+      "riverside_dwelling"
+    ],
+    "fg": [ "cabin_faceN", "cabin_faceE", "cabin_faceS", "cabin_faceW" ],
+    "bg": "field",
+    "rotates": true
+  },
+  {
+    "id": [
+      "cabin_roof",
+      "cabin_roof_1",
+      "cabin_roof_2",
+      "cabin_roof_3",
+      "cabin_roof_4",
+      "cabin_roof_5",
+      "cabin_roof_6",
+      "cabin_roof_7",
+      "cabin_strange_roof",
+      "cabin_roof_lapin",
+      "cabin_lake_roof",
+      "lake_cabin_boathouse_roof"
+    ],
+    "fg": [ "cabin_faceN", "cabin_faceE", "cabin_faceS", "cabin_faceW" ],
+    "bg": "open_air",
+    "rotates": true
+  }
+]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cs_private_park/cs_private_park.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cs_private_park/cs_private_park.json
@@ -1,24 +1,14 @@
 [
   {
-	"id": "cs_private_park_roof",
-	"fg": [
-	  "cs_private_park_rot_N",
-	  "cs_private_park_rot_W",
-	  "cs_private_park_rot_S",
-	  "cs_private_park_rot_E"
-	],
-	"bg": "open_air",
-	"rotates": true
+    "id": "cs_private_park_roof",
+    "fg": [ "cs_private_park_rot_N", "cs_private_park_rot_E", "cs_private_park_rot_S", "cs_private_park_rot_W" ],
+    "bg": "open_air",
+    "rotates": true
   },
   {
-	"id": "cs_private_park",
-	"fg": [
-	  "cs_private_park_rot_N",
-	  "cs_private_park_rot_W",
-	  "cs_private_park_rot_S",
-	  "cs_private_park_rot_E"
-	],
-	"bg": "field",
-	"rotates": true
+    "id": "cs_private_park",
+    "fg": [ "cs_private_park_rot_N", "cs_private_park_rot_E", "cs_private_park_rot_S", "cs_private_park_rot_W" ],
+    "bg": "field",
+    "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cs_public_art_piece/cs_public_art_piece.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cs_public_art_piece/cs_public_art_piece.json
@@ -1,13 +1,8 @@
 [
   {
-	"id": "cs_public_art_piece",
-	"fg": [
-	  "cs_public_art_piece_rot_N",
-	  "cs_public_art_piece_rot_W",
-	  "cs_public_art_piece_rot_S",
-	  "cs_public_art_piece_rot_E"
-	],
-	"bg": "field",
-	"rotates": true
+    "id": "cs_public_art_piece",
+    "fg": [ "cs_public_art_piece_rot_N", "cs_public_art_piece_rot_E", "cs_public_art_piece_rot_S", "cs_public_art_piece_rot_W" ],
+    "bg": "field",
+    "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cs_public_space/cs_public_space.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/cs_public_space/cs_public_space.json
@@ -1,13 +1,8 @@
 [
   {
-	"id": "cs_public_space",
-	"fg": [
-	  "cs_public_space_rot_N",
-	  "cs_public_space_rot_W",
-	  "cs_public_space_rot_S",
-	  "cs_public_space_rot_E"
-	],
-	"bg": "field",
-	"rotates": true
+    "id": "cs_public_space",
+    "fg": [ "cs_public_space_rot_N", "cs_public_space_rot_E", "cs_public_space_rot_S", "cs_public_space_rot_W" ],
+    "bg": "field",
+    "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/dirt_road/dirt_road.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/dirt_road/dirt_road.json
@@ -8,17 +8,17 @@
       { "id": "center", "fg": "dirt_road_center" },
       {
         "id": "corner",
-        "fg": [ "dirt_road_corner_nw", "dirt_road_corner_sw", "dirt_road_corner_se", "dirt_road_corner_ne" ],
+        "fg": [ "dirt_road_corner_nw", "dirt_road_corner_ne", "dirt_road_corner_se", "dirt_road_corner_sw" ],
         "bg": "field"
       },
       {
         "id": "t_connection",
-        "fg": [ "dirt_road_t_connection_n", "dirt_road_t_connection_w", "dirt_road_t_connection_s", "dirt_road_t_connection_e" ]
+        "fg": [ "dirt_road_t_connection_n", "dirt_road_t_connection_e", "dirt_road_t_connection_s", "dirt_road_t_connection_w" ]
       },
       { "id": "edge", "fg": [ "dirt_road_edge_ns", "dirt_road_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [ "dirt_road_end_piece_n", "dirt_road_end_piece_w", "dirt_road_end_piece_s", "dirt_road_end_piece_e" ]
+        "fg": [ "dirt_road_end_piece_n", "dirt_road_end_piece_e", "dirt_road_end_piece_s", "dirt_road_end_piece_w" ]
       },
       { "id": "unconnected", "fg": "dirt_road_unconnected", "bg": "field" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/evac_shelters/evac_shelters.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/evac_shelters/evac_shelters.json
@@ -1,30 +1,27 @@
 [
   {
     "id": [
-	    "shelter",
-	    "shelter_2",
-	    "shelter_vandal",
-	    "shelter_2_vandal",
+      "shelter",
+      "shelter_2",
+      "shelter_vandal",
+      "shelter_2_vandal",
       "shelter_infested",
       "shelter_2_infested",
       "shelter_survivor",
       "shelter_2_survivor"
-	  ],
-    "fg": [ "otr_evac_shelter_1_faceN", "otr_evac_shelter_1_faceW", "otr_evac_shelter_1_faceS", "otr_evac_shelter_1_faceE" ],
+    ],
+    "fg": [ "otr_evac_shelter_1_faceN", "otr_evac_shelter_1_faceE", "otr_evac_shelter_1_faceS", "otr_evac_shelter_1_faceW" ],
     "bg": "field",
     "rotates": true
   },
   {
-	  "id": [
-	   "shelter_roof",
-		 "shelter_roof_2"
-		],
-	  "fg": [ "otr_evac_shelter_1_faceN", "otr_evac_shelter_1_faceW", "otr_evac_shelter_1_faceS", "otr_evac_shelter_1_faceE" ],
-	  "bg": "open_air",
-	  "rotates": true
+    "id": [ "shelter_roof", "shelter_roof_2" ],
+    "fg": [ "otr_evac_shelter_1_faceN", "otr_evac_shelter_1_faceE", "otr_evac_shelter_1_faceS", "otr_evac_shelter_1_faceW" ],
+    "bg": "open_air",
+    "rotates": true
   },
   {
-	  "id": [
+    "id": [
       "shelter_under",
       "shelter_under_2",
       "shelter_under_vandal",
@@ -32,9 +29,9 @@
       "shelter_under_infested",
       "shelter_under_2_infested"
     ],
-	  "fg": [ "otr_evac_shelter_1_faceN", "otr_evac_shelter_1_faceW", "otr_evac_shelter_1_faceS", "otr_evac_shelter_1_faceE" ],
+    "fg": [ "otr_evac_shelter_1_faceN", "otr_evac_shelter_1_faceE", "otr_evac_shelter_1_faceS", "otr_evac_shelter_1_faceW" ],
     "bg": "t_soil_center",
-	  "rotates": true
+    "rotates": true
   },
   {
     "id": [
@@ -51,12 +48,12 @@
     "bg": "field"
   },
   {
-	  "id": [ "shelter_roof_1", "shelter_roof_1b" ],
-	  "fg": "evac_shelter_1",
-	  "bg": "open_air"
+    "id": [ "shelter_roof_1", "shelter_roof_1b" ],
+    "fg": "evac_shelter_1",
+    "bg": "open_air"
   },
   {
-	  "id": [
+    "id": [
       "shelter_under_1",
       "shelter_under_1b",
       "shelter_under_1_vandal",
@@ -64,7 +61,7 @@
       "shelter_under_1_infested",
       "shelter_under_1b_infested"
     ],
-	  "fg": "evac_shelter_1",
+    "fg": "evac_shelter_1",
     "bg": "t_soil_center"
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/forest_trail/forest_trail.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/forest_trail/forest_trail.json
@@ -3,50 +3,25 @@
   "fg": "forest_trail_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "forest_trail_center"
-    },
+    { "id": "center", "fg": "forest_trail_center" },
     {
       "id": "corner",
-      "fg": [
-        "forest_trail_corner_nw",
-        "forest_trail_corner_sw",
-        "forest_trail_corner_se",
-        "forest_trail_corner_ne"
-      ]
+      "fg": [ "forest_trail_corner_nw", "forest_trail_corner_ne", "forest_trail_corner_se", "forest_trail_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "forest_trail_t_connection_n",
-        "forest_trail_t_connection_w",
+        "forest_trail_t_connection_e",
         "forest_trail_t_connection_s",
-        "forest_trail_t_connection_e"
+        "forest_trail_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "forest_trail_edge_ns",
-        "forest_trail_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "forest_trail_edge_ns", "forest_trail_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "forest_trail_end_piece_n",
-        "forest_trail_end_piece_w",
-        "forest_trail_end_piece_s",
-        "forest_trail_end_piece_e"
-      ]
+      "fg": [ "forest_trail_end_piece_n", "forest_trail_end_piece_e", "forest_trail_end_piece_s", "forest_trail_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "forest_trail_unconnected",
-        "forest_trail_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "forest_trail_unconnected", "forest_trail_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/gas/omt_gasstations.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/gas/omt_gasstations.json
@@ -1,12 +1,19 @@
 [
   {
     "id": [
-      "s_gas", "s_gas_1", "s_gas_rural",
-      "s_gas_roof_1", "s_gas_rural_roof",
-      "garage_gas_1", "garage_gas_2", "garage_gas_3",
-      "garage_gas_roof_1", "garage_gas_roof_2", "garage_gas_roof_3"
+      "s_gas",
+      "s_gas_1",
+      "s_gas_rural",
+      "s_gas_roof_1",
+      "s_gas_rural_roof",
+      "garage_gas_1",
+      "garage_gas_2",
+      "garage_gas_3",
+      "garage_gas_roof_1",
+      "garage_gas_roof_2",
+      "garage_gas_roof_3"
     ],
-    "fg": [ "gas_small_faceN", "gas_small_faceW", "gas_small_faceS", "gas_small_faceE" ], 
+    "fg": [ "gas_small_faceN", "gas_small_faceE", "gas_small_faceS", "gas_small_faceW" ],
     "bg": "field"
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/generic_special/ranch_camp.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/generic_special/ranch_camp.json
@@ -1,13 +1,17 @@
-[{
+[
+  {
     "id": "ranch_camp_17",
     "fg": "t_water_sh_unconnected",
-	"bg": "pasture_center"
-},{
+    "bg": "pasture_center"
+  },
+  {
     "id": "ranch_camp_76",
     "fg": "forest_trail_center"
-},{
+  },
+  {
     "id": "ranch_camp_77",
-    "fg": [ "road_end_piece_n", "road_end_piece_w", "road_end_piece_s", "road_end_piece_e" ], 
+    "fg": [ "road_end_piece_n", "road_end_piece_e", "road_end_piece_s", "road_end_piece_w" ],
     "bg": "field",
     "rotates": true
-}]
+  }
+]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/luna_park/luna_park.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/luna_park/luna_park.json
@@ -1,133 +1,73 @@
 [
   {
     "id": [ "luna_park_0_0_0", "miniaturerailway_0_0_0" ],
-    "fg": [
-      "luna_park_bot_left_faceN",
-      "luna_park_bot_left_faceW",
-      "luna_park_bot_left_faceS",
-      "luna_park_bot_left_faceE"
-    ],
+    "fg": [ "luna_park_bot_left_faceN", "luna_park_bot_left_faceE", "luna_park_bot_left_faceS", "luna_park_bot_left_faceW" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "luna_park_1_0_0",
-    "fg": [
-      "luna_park_mid_left_faceN",
-      "luna_park_mid_left_faceW",
-      "luna_park_mid_left_faceS",
-      "luna_park_mid_left_faceE"
-    ],
+    "fg": [ "luna_park_mid_left_faceN", "luna_park_mid_left_faceE", "luna_park_mid_left_faceS", "luna_park_mid_left_faceW" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": [ "luna_park_2_0_0", "miniaturerailway_1_0_0" ],
-    "fg": [
-      "luna_park_top_left_faceN",
-      "luna_park_top_left_faceW",
-      "luna_park_top_left_faceS",
-      "luna_park_top_left_faceE"
-    ],
+    "fg": [ "luna_park_top_left_faceN", "luna_park_top_left_faceE", "luna_park_top_left_faceS", "luna_park_top_left_faceW" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": [ "luna_park_0_1_0", "miniaturerailway_0_1_0" ],
-    "fg": [
-      "luna_park_bot_right_faceN",
-      "luna_park_bot_right_faceW",
-      "luna_park_bot_right_faceS",
-      "luna_park_bot_right_faceE"
-    ],
+    "fg": [ "luna_park_bot_right_faceN", "luna_park_bot_right_faceE", "luna_park_bot_right_faceS", "luna_park_bot_right_faceW" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "luna_park_1_1_0",
-    "fg": [
-      "luna_park_mid_right_faceN",
-      "luna_park_mid_right_faceW",
-      "luna_park_mid_right_faceS",
-      "luna_park_mid_right_faceE"
-    ],
+    "fg": [ "luna_park_mid_right_faceN", "luna_park_mid_right_faceE", "luna_park_mid_right_faceS", "luna_park_mid_right_faceW" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": [ "luna_park_2_1_0", "miniaturerailway_1_1_0" ],
-    "fg": [
-      "luna_park_top_right_faceN",
-      "luna_park_top_right_faceW",
-      "luna_park_top_right_faceS",
-      "luna_park_top_right_faceE"
-    ],
+    "fg": [ "luna_park_top_right_faceN", "luna_park_top_right_faceE", "luna_park_top_right_faceS", "luna_park_top_right_faceW" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": [ "luna_park_0_0_1", "miniaturerailway_0_0_1" ],
-    "fg": [
-      "luna_park_bot_left_faceN",
-      "luna_park_bot_left_faceW",
-      "luna_park_bot_left_faceS",
-      "luna_park_bot_left_faceE"
-    ],
+    "fg": [ "luna_park_bot_left_faceN", "luna_park_bot_left_faceE", "luna_park_bot_left_faceS", "luna_park_bot_left_faceW" ],
     "bg": "open_air",
     "rotates": true
   },
   {
     "id": "luna_park_1_0_1",
-    "fg": [
-      "luna_park_mid_left_faceN",
-      "luna_park_mid_left_faceW",
-      "luna_park_mid_left_faceS",
-      "luna_park_mid_left_faceE"
-    ],
+    "fg": [ "luna_park_mid_left_faceN", "luna_park_mid_left_faceE", "luna_park_mid_left_faceS", "luna_park_mid_left_faceW" ],
     "bg": "open_air",
     "rotates": true
   },
   {
     "id": [ "luna_park_2_0_1", "miniaturerailway_1_0_1" ],
-    "fg": [
-      "luna_park_top_left_faceN",
-      "luna_park_top_left_faceW",
-      "luna_park_top_left_faceS",
-      "luna_park_top_left_faceE"
-    ],
+    "fg": [ "luna_park_top_left_faceN", "luna_park_top_left_faceE", "luna_park_top_left_faceS", "luna_park_top_left_faceW" ],
     "bg": "open_air",
     "rotates": true
   },
   {
     "id": [ "luna_park_0_1_1", "miniaturerailway_0_1_1" ],
-    "fg": [
-      "luna_park_bot_right_faceN",
-      "luna_park_bot_right_faceW",
-      "luna_park_bot_right_faceS",
-      "luna_park_bot_right_faceE"
-    ],
+    "fg": [ "luna_park_bot_right_faceN", "luna_park_bot_right_faceE", "luna_park_bot_right_faceS", "luna_park_bot_right_faceW" ],
     "bg": "open_air",
     "rotates": true
   },
   {
     "id": "luna_park_1_1_1",
-    "fg": [
-      "luna_park_mid_right_faceN",
-      "luna_park_mid_right_faceW",
-      "luna_park_mid_right_faceS",
-      "luna_park_mid_right_faceE"
-    ],
+    "fg": [ "luna_park_mid_right_faceN", "luna_park_mid_right_faceE", "luna_park_mid_right_faceS", "luna_park_mid_right_faceW" ],
     "bg": "open_air",
     "rotates": true
   },
   {
     "id": [ "luna_park_2_1_1", "miniaturerailway_1_1_1" ],
-    "fg": [
-      "luna_park_top_right_faceN",
-      "luna_park_top_right_faceW",
-      "luna_park_top_right_faceS",
-      "luna_park_top_right_faceE"
-    ],
+    "fg": [ "luna_park_top_right_faceN", "luna_park_top_right_faceE", "luna_park_top_right_faceS", "luna_park_top_right_faceW" ],
     "bg": "open_air",
     "rotates": true
   }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/mine/mine.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/mine/mine.json
@@ -1,45 +1,25 @@
 [
   {
     "id": "mine_entrance_loading_zone",
-    "fg": [
-      "mine_N_2",
-      "mine_W_2",
-      "mine_S_2",
-      "mine_E_2"
-    ],
+    "fg": [ "mine_N_2", "mine_E_2", "mine_S_2", "mine_W_2" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "mine_entrance_loading_zone_roof",
-    "fg": [
-      "mine_N_2",
-      "mine_W_2",
-      "mine_S_2",
-      "mine_E_2"
-    ],
+    "fg": [ "mine_N_2", "mine_E_2", "mine_S_2", "mine_W_2" ],
     "bg": "open_air",
     "rotates": true
   },
   {
     "id": "mine_shaft_middle_east",
-    "fg": [
-      "mine_N_2",
-      "mine_W_2",
-      "mine_S_2",
-      "mine_E_2"
-    ],
+    "fg": [ "mine_N_2", "mine_E_2", "mine_S_2", "mine_W_2" ],
     "bg": "t_dirt_center3",
     "rotates": true
   },
   {
     "id": "mine_shaft_lower_east",
-    "fg": [
-      "mine_N_2",
-      "mine_W_2",
-      "mine_S_2",
-      "mine_E_2"
-    ],
+    "fg": [ "mine_N_2", "mine_E_2", "mine_S_2", "mine_W_2" ],
     "bg": "t_rock_floor_center",
     "rotates": true
   }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/missile_silo/missile_silo.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/missile_silo/missile_silo.json
@@ -1,20 +1,20 @@
 [
   {
-	"id": "silo",
-	"fg": [ "silo_rot_N", "silo_rot_W", "silo_rot_S", "silo_rot_E" ],
-	"bg": "field",
-	"rotates": true
+    "id": "silo",
+    "fg": [ "silo_rot_N", "silo_rot_E", "silo_rot_S", "silo_rot_W" ],
+    "bg": "field",
+    "rotates": true
   },
   {
-	"id": "silo_1",
-	"fg": [ "silo_rot_N", "silo_rot_W", "silo_rot_S", "silo_rot_E" ],
-	"bg": "t_soil_center",
-	"rotates": true
+    "id": "silo_1",
+    "fg": [ "silo_rot_N", "silo_rot_E", "silo_rot_S", "silo_rot_W" ],
+    "bg": "t_soil_center",
+    "rotates": true
   },
   {
-  "id": [ "silo_2", "silo_3", "silo_4", "silo_finale" ],
-	"fg": [ "silo_rot_N", "silo_rot_W", "silo_rot_S", "silo_rot_E" ],
-	"bg": "t_rock_center",
-	"rotates": true
+    "id": [ "silo_2", "silo_3", "silo_4", "silo_finale" ],
+    "fg": [ "silo_rot_N", "silo_rot_E", "silo_rot_S", "silo_rot_W" ],
+    "bg": "t_rock_center",
+    "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/natural.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/natural.json
@@ -25,12 +25,22 @@
       {
         "id": "corner",
         "bg": "field",
-        "fg": [ "t_water_moving_sh_corner_se", "t_water_moving_sh_corner_ne", "t_water_moving_sh_corner_nw", "t_water_moving_sh_corner_sw" ]
+        "fg": [
+          "t_water_moving_sh_corner_se",
+          "t_water_moving_sh_corner_sw",
+          "t_water_moving_sh_corner_nw",
+          "t_water_moving_sh_corner_ne"
+        ]
       },
       {
         "id": "end",
         "bg": "field",
-        "fg": [ "t_water_moving_sh_end_piece_n", "t_water_moving_sh_end_piece_w", "t_water_moving_sh_end_piece_s", "t_water_moving_sh_end_piece_e" ]
+        "fg": [
+          "t_water_moving_sh_end_piece_n",
+          "t_water_moving_sh_end_piece_e",
+          "t_water_moving_sh_end_piece_s",
+          "t_water_moving_sh_end_piece_w"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/pasture/pasture.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/pasture/pasture.json
@@ -1,6 +1,6 @@
 [
   {
-	  "id": [
+    "id": [
       "ranch_camp_11",
       "ranch_camp_12",
       "ranch_camp_13",
@@ -43,62 +43,56 @@
       "ranch_camp_70",
       "ranch_camp_71"
     ],
-  	"fg": "pasture_center",
-  	"rotates": true
+    "fg": "pasture_center",
+    "rotates": true
   },
   {
-	  "id": "2farm_4",
-	  "fg": [ "pasture_end_n", "pasture_end_e", "pasture_end_s", "pasture_end_w" ],
-  	"rotates": true
+    "id": "2farm_4",
+    "fg": [ "pasture_end_n", "pasture_end_w", "pasture_end_s", "pasture_end_e" ],
+    "rotates": true
   },
   {
-	  "id": [
-      "paddock_d_U_gap",
-      "paddock_d_D_gap",
-      "paddock_special_3",
-      "paddock_special_4",
-      "paddock_d_U_butt"
-    ],
-	  "fg": [ "pasture_end_s", "pasture_end_e", "pasture_end_n", "pasture_end_w" ],
-  	"rotates": true
+    "id": [ "paddock_d_U_gap", "paddock_d_D_gap", "paddock_special_3", "paddock_special_4", "paddock_d_U_butt" ],
+    "fg": [ "pasture_end_s", "pasture_end_w", "pasture_end_n", "pasture_end_e" ],
+    "rotates": true
   },
   {
-	  "id": [ "2farm_8", "paddock_d_D_butt" ],
-	  "fg": [ "pasture_end_s", "pasture_end_e", "pasture_end_n", "pasture_end_w" ],
-  	"rotates": true
+    "id": [ "2farm_8", "paddock_d_D_butt" ],
+    "fg": [ "pasture_end_s", "pasture_end_w", "pasture_end_n", "pasture_end_e" ],
+    "rotates": true
   },
   {
-	  "id": [ "dairy_farm_NW", "paddock_L_butt", "paddock_L_gap" ],
-	  "fg": [ "pasture_end_w", "pasture_end_s", "pasture_end_e", "pasture_end_n" ],
-	  "rotates": true
+    "id": [ "dairy_farm_NW", "paddock_L_butt", "paddock_L_gap" ],
+    "fg": [ "pasture_end_w", "pasture_end_n", "pasture_end_e", "pasture_end_s" ],
+    "rotates": true
   },
   {
-	  "id": [ "dairy_farm_NE", "paddock_trailhead_5", "paddock_R_butt" ],
-	  "fg": [ "pasture_end_e", "pasture_end_n", "pasture_end_w", "pasture_end_s" ],
-	  "rotates": true
+    "id": [ "dairy_farm_NE", "paddock_trailhead_5", "paddock_R_butt" ],
+    "fg": [ "pasture_end_e", "pasture_end_s", "pasture_end_w", "pasture_end_n" ],
+    "rotates": true
   },
   {
-	  "id": [ "ranch_camp_9", "splitrail_fence_UR", "paddock_trailhead_9" ],
-	  "fg": [ "pasture_corner_ne", "pasture_corner_nw", "pasture_corner_sw", "pasture_corner_se" ],
-	  "rotates": true
+    "id": [ "ranch_camp_9", "splitrail_fence_UR", "paddock_trailhead_9" ],
+    "fg": [ "pasture_corner_ne", "pasture_corner_se", "pasture_corner_sw", "pasture_corner_nw" ],
+    "rotates": true
   },
   {
-	  "id": [ "ranch_camp_1", "splitrail_fence_UL" ],
-	  "fg": [ "pasture_corner_nw", "pasture_corner_sw", "pasture_corner_se", "pasture_corner_ne" ],
-	  "rotates": true
+    "id": [ "ranch_camp_1", "splitrail_fence_UL" ],
+    "fg": [ "pasture_corner_nw", "pasture_corner_nw", "pasture_corner_se", "pasture_corner_sw" ],
+    "rotates": true
   },
   {
-	  "id": [ "ranch_camp_73", "ranch_camp_78", "paddock_special_1", "splitrail_fence_DL" ],
-	  "fg": [ "pasture_corner_sw", "pasture_corner_se", "pasture_corner_ne", "pasture_corner_nw" ],
-  	"rotates": true
+    "id": [ "ranch_camp_73", "ranch_camp_78", "paddock_special_1", "splitrail_fence_DL" ],
+    "fg": [ "pasture_corner_sw", "pasture_corner_nw", "pasture_corner_ne", "pasture_corner_se" ],
+    "rotates": true
   },
   {
-  	"id": [ "ranch_camp_75", "ranch_camp_81", "paddock_DR", "paddock_trailhead_7" ],
-  	"fg": [ "pasture_corner_se", "pasture_corner_nw", "pasture_corner_ne", "pasture_corner_sw" ],
-  	"rotates": true
+    "id": [ "ranch_camp_75", "ranch_camp_81", "paddock_DR", "paddock_trailhead_7" ],
+    "fg": [ "pasture_corner_se", "pasture_corner_sw", "pasture_corner_ne", "pasture_corner_nw" ],
+    "rotates": true
   },
   {
-  	"id": [
+    "id": [
       "ranch_camp_10",
       "ranch_camp_19",
       "ranch_camp_28",
@@ -107,11 +101,11 @@
       "ranch_camp_55",
       "ranch_camp_64"
     ],
-  	"fg": [ "pasture_not_w", "pasture_not_s", "pasture_not_e", "pasture_not_n" ],
-	  "rotates": true
+    "fg": [ "pasture_not_w", "pasture_not_n", "pasture_not_e", "pasture_not_s" ],
+    "rotates": true
   },
   {
-	  "id": [
+    "id": [
       "ranch_camp_2",
       "ranch_camp_3",
       "ranch_camp_4",
@@ -122,11 +116,11 @@
       "splitrail_fence_gap",
       "splitrail_fence_butt"
     ],
-	  "fg": [ "pasture_not_n", "pasture_not_w", "pasture_not_s", "pasture_not_e" ],
-	  "rotates": true
+    "fg": [ "pasture_not_n", "pasture_not_e", "pasture_not_s", "pasture_not_w" ],
+    "rotates": true
   },
   {
-  	"id": [
+    "id": [
       "ranch_camp_18",
       "ranch_camp_27",
       "ranch_camp_36",
@@ -135,23 +129,23 @@
       "ranch_camp_63",
       "ranch_camp_72"
     ],
-  	"fg": [ "pasture_not_e", "pasture_not_n", "pasture_not_w", "pasture_not_s" ],
-  	"rotates": true
-  },
-  {
-    "id": "splitrail_fence_inner",
-    "fg": [ "pasture_not_s", "pasture_not_n", "pasture_not_e", "pasture_not_w" ],
-    "rotates": true
-  },
-  {
-    "id": "ranch_camp_69",
     "fg": [ "pasture_not_e", "pasture_not_s", "pasture_not_w", "pasture_not_n" ],
     "rotates": true
   },
   {
-  	"id": [ "ranch_camp_58", "ranch_camp_59", "ranch_camp_74", "ranch_camp_79", "ranch_camp_80" ],
-  	"fg": [ "pasture_not_s", "pasture_not_e", "pasture_not_n", "pasture_not_w" ],
-  	"rotates": true
+    "id": "splitrail_fence_inner",
+    "fg": [ "pasture_not_s", "pasture_not_w", "pasture_not_e", "pasture_not_n" ],
+    "rotates": true
+  },
+  {
+    "id": "ranch_camp_69",
+    "fg": [ "pasture_not_e", "pasture_not_n", "pasture_not_w", "pasture_not_s" ],
+    "rotates": true
+  },
+  {
+    "id": [ "ranch_camp_58", "ranch_camp_59", "ranch_camp_74", "ranch_camp_79", "ranch_camp_80" ],
+    "fg": [ "pasture_not_s", "pasture_not_w", "pasture_not_n", "pasture_not_e" ],
+    "rotates": true
   },
   {
     "id": [ "paddock", "paddock_R_gap", "paddock_C", "paddock_end_DL", "paddock_end_UL", "paddock_end_DR", "paddock_end_UR" ],
@@ -183,16 +177,16 @@
   },
   {
     "id": "splitrail_fence_DR",
-    "fg": [ "pasture_corner_se", "pasture_corner_ne", "pasture_corner_nw", "pasture_corner_sw" ],
+    "fg": [ "pasture_corner_se", "pasture_corner_sw", "pasture_corner_nw", "pasture_corner_ne" ],
     "rotates": true
   },
   {
     "id": "farm_horse_track_large_1",
     "fg": [
       "t_railroad_rubble_corner_ne",
-      "t_railroad_rubble_corner_sw",
+      "t_railroad_rubble_corner_se",
       "t_railroad_rubble_corner_nw",
-      "t_railroad_rubble_corner_se"
+      "t_railroad_rubble_corner_sw"
     ],
     "bg": "field",
     "rotates": true
@@ -201,9 +195,9 @@
     "id": "farm_horse_track_large_2",
     "fg": [
       "t_railroad_rubble_corner_se",
-      "t_railroad_rubble_corner_nw",
+      "t_railroad_rubble_corner_ne",
       "t_railroad_rubble_corner_sw",
-      "t_railroad_rubble_corner_ne"
+      "t_railroad_rubble_corner_nw"
     ],
     "bg": "field",
     "rotates": true
@@ -212,9 +206,9 @@
     "id": "farm_horse_track_large_3",
     "fg": [
       "t_railroad_rubble_corner_nw",
-      "t_railroad_rubble_corner_se",
+      "t_railroad_rubble_corner_sw",
       "t_railroad_rubble_corner_ne",
-      "t_railroad_rubble_corner_sw"
+      "t_railroad_rubble_corner_se"
     ],
     "bg": "field",
     "rotates": true
@@ -223,9 +217,9 @@
     "id": "farm_horse_track_large_4",
     "fg": [
       "t_railroad_rubble_corner_sw",
-      "t_railroad_rubble_corner_ne",
+      "t_railroad_rubble_corner_nw",
       "t_railroad_rubble_corner_se",
-      "t_railroad_rubble_corner_nw"
+      "t_railroad_rubble_corner_ne"
     ],
     "bg": "field",
     "rotates": true
@@ -234,9 +228,9 @@
     "id": "farm_horse_track_1",
     "fg": [
       "t_railroad_rubble_end_piece_n",
-      "t_railroad_rubble_end_piece_w",
+      "t_railroad_rubble_end_piece_e",
       "t_railroad_rubble_end_piece_s",
-      "t_railroad_rubble_end_piece_e"
+      "t_railroad_rubble_end_piece_w"
     ],
     "bg": "field",
     "rotates": true
@@ -245,9 +239,9 @@
     "id": "farm_horse_track_2",
     "fg": [
       "t_railroad_rubble_end_piece_s",
-      "t_railroad_rubble_end_piece_e",
+      "t_railroad_rubble_end_piece_w",
       "t_railroad_rubble_end_piece_n",
-      "t_railroad_rubble_end_piece_w"
+      "t_railroad_rubble_end_piece_e"
     ],
     "bg": "field",
     "rotates": true

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/pools/pools.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/pools/pools.json
@@ -1,30 +1,20 @@
 [
-{
-	"id": [
-	  "pool",
-	  "pool_1",
-	  "pool_2",
-	  "pool_3",
-	  "pool_4"
-	],
-	"fg": [ "pool_2_faceN", "pool_2_faceW", "pool_2_faceS", "pool_2_faceE" ],
-	"bg": "field",
-	"rotates": true
-},{
-	"id": [ "pool_5", "pool_6" ],
-	"fg": [ "pool_5_faceN", "pool_5_faceW", "pool_5_faceS", "pool_5_faceE" ],
-	"bg": "field",
-	"rotates": true
-},{
-	"id": [
-	  "pool_roof",
-	  "pool_roof_1",
-	  "pool_roof_2",
-	  "pool_roof_3",
-	  "pool_roof_4"
-	],
-	"fg": [ "pool_2_faceN", "pool_2_faceW", "pool_2_faceS", "pool_2_faceE" ],
-	"bg": "open_air",
-	"rotates": true
-}
+  {
+    "id": [ "pool", "pool_1", "pool_2", "pool_3", "pool_4" ],
+    "fg": [ "pool_2_faceN", "pool_2_faceE", "pool_2_faceS", "pool_2_faceW" ],
+    "bg": "field",
+    "rotates": true
+  },
+  {
+    "id": [ "pool_5", "pool_6" ],
+    "fg": [ "pool_5_faceN", "pool_5_faceE", "pool_5_faceS", "pool_5_faceW" ],
+    "bg": "field",
+    "rotates": true
+  },
+  {
+    "id": [ "pool_roof", "pool_roof_1", "pool_roof_2", "pool_roof_3", "pool_roof_4" ],
+    "fg": [ "pool_2_faceN", "pool_2_faceE", "pool_2_faceS", "pool_2_faceW" ],
+    "bg": "open_air",
+    "rotates": true
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/public_pond/public_pond.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/public_pond/public_pond.json
@@ -1,12 +1,12 @@
 [
   {
-  	"id": "PublicPond_1a",
-	  "fg": [ "public_pond_w", "public_pond_s", "public_pond_e", "public_pond_n" ],
-  	"rotates": true
+    "id": "PublicPond_1a",
+    "fg": [ "public_pond_w", "public_pond_n", "public_pond_e", "public_pond_s" ],
+    "rotates": true
   },
   {
-  	"id": "PublicPond_1b",
-  	"fg": [ "public_pond_e", "public_pond_n", "public_pond_w", "public_pond_s" ],
-  	"rotates": true
+    "id": "PublicPond_1b",
+    "fg": [ "public_pond_e", "public_pond_s", "public_pond_w", "public_pond_n" ],
+    "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/railroad.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/railroad.json
@@ -1,61 +1,51 @@
 [
-{
-  "id": "railroad",
-  "fg": "t_railroad_track_small_edge_ns",
-  "bg": "t_railroad_rubble_center",
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "t_railroad_rubble_center",
-      "fg": "t_railroad_track_small_center"
-    },
-    {
-      "id": "corner",
-      "bg": "t_railroad_rubble_center",
-      "fg": [
-        "t_railroad_track_small_corner_nw",
-        "t_railroad_track_small_corner_sw",
-        "t_railroad_track_small_corner_se",
-        "t_railroad_track_small_corner_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "bg": "t_railroad_rubble_center",
-      "fg": [
-        "t_railroad_track_small_t_connection_n",
-        "t_railroad_track_small_t_connection_w",
-        "t_railroad_track_small_t_connection_s",
-        "t_railroad_track_small_t_connection_e"
-      ]
-    },
-    {
-      "id": "edge",
-      "bg": "t_railroad_rubble_center",
-      "fg": [
-        "t_railroad_track_small_edge_ns",
-        "t_railroad_track_small_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "bg": "t_railroad_rubble_center",
-      "fg": [
-        "t_railroad_track_small_edge_ns",
-        "t_railroad_track_small_edge_ew",
-        "t_railroad_track_small_edge_ns",
-        "t_railroad_track_small_edge_ew"
-      ]
-    },
-    {
-      "id": "unconnected",
-      "bg": "t_railroad_rubble_center",
-      "fg": [
-        "t_railroad_track_small_edge_ns",
-        "t_railroad_track_small_edge_ew"
-      ]
-    }
-  ]
-}
+  {
+    "id": "railroad",
+    "fg": "t_railroad_track_small_edge_ns",
+    "bg": "t_railroad_rubble_center",
+    "multitile": true,
+    "additional_tiles": [
+      { "id": "center", "bg": "t_railroad_rubble_center", "fg": "t_railroad_track_small_center" },
+      {
+        "id": "corner",
+        "bg": "t_railroad_rubble_center",
+        "fg": [
+          "t_railroad_track_small_corner_nw",
+          "t_railroad_track_small_corner_ne",
+          "t_railroad_track_small_corner_se",
+          "t_railroad_track_small_corner_sw"
+        ]
+      },
+      {
+        "id": "t_connection",
+        "bg": "t_railroad_rubble_center",
+        "fg": [
+          "t_railroad_track_small_t_connection_n",
+          "t_railroad_track_small_t_connection_e",
+          "t_railroad_track_small_t_connection_s",
+          "t_railroad_track_small_t_connection_w"
+        ]
+      },
+      {
+        "id": "edge",
+        "bg": "t_railroad_rubble_center",
+        "fg": [ "t_railroad_track_small_edge_ns", "t_railroad_track_small_edge_ew" ]
+      },
+      {
+        "id": "end_piece",
+        "bg": "t_railroad_rubble_center",
+        "fg": [
+          "t_railroad_track_small_edge_ns",
+          "t_railroad_track_small_edge_ew",
+          "t_railroad_track_small_edge_ns",
+          "t_railroad_track_small_edge_ew"
+        ]
+      },
+      {
+        "id": "unconnected",
+        "bg": "t_railroad_rubble_center",
+        "fg": [ "t_railroad_track_small_edge_ns", "t_railroad_track_small_edge_ew" ]
+      }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/residential.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/residential.json
@@ -171,44 +171,25 @@
       "urban_13_11",
       "urban_13_12"
     ],
-    "fg": [ "otr_house_1_faceN", "otr_house_1_faceW", "otr_house_1_faceS", "otr_house_1_faceE" ], 
-    "bg": "field",
-    "rotates": true
-  },
-  {
-    "id": [ "urban_1_2", "urban_4_3", "urban_4_4", "urban_2_1", "urban_2_2" ],
-    "fg": [ "otr_house_1_faceS", "otr_house_1_faceE", "otr_house_1_faceN", "otr_house_1_faceW" ],
-    "bg": "field",
-    "rotates": true
-  },
-  {
-    "id": [
-      "urban_3_1",
-      "urban_3_2",
-      "urban_5_1",
-      "urban_5_2",
-      "urban_6_1",
-      "urban_6_2",
-      "urban_13_3",
-      "urban_13_4"
-    ],
     "fg": [ "otr_house_1_faceN", "otr_house_1_faceE", "otr_house_1_faceS", "otr_house_1_faceW" ],
     "bg": "field",
     "rotates": true
   },
   {
-    "id": [
-      "urban_1_4",
-      "urban_4_5",
-      "urban_4_6",
-      "urban_4_7",
-      "urban_4_8",
-      "urban_2_3",
-      "urban_2_4",
-      "urban_2_5",
-      "urban_2_6"
-    ],
-    "fg": [ "otr_house_1_faceS", "otr_house_1_faceE", "otr_house_1_faceN", "otr_house_1_faceW" ],
+    "id": [ "urban_1_2", "urban_4_3", "urban_4_4", "urban_2_1", "urban_2_2" ],
+    "fg": [ "otr_house_1_faceS", "otr_house_1_faceW", "otr_house_1_faceN", "otr_house_1_faceE" ],
+    "bg": "field",
+    "rotates": true
+  },
+  {
+    "id": [ "urban_3_1", "urban_3_2", "urban_5_1", "urban_5_2", "urban_6_1", "urban_6_2", "urban_13_3", "urban_13_4" ],
+    "fg": [ "otr_house_1_faceN", "otr_house_1_faceW", "otr_house_1_faceS", "otr_house_1_faceE" ],
+    "bg": "field",
+    "rotates": true
+  },
+  {
+    "id": [ "urban_1_4", "urban_4_5", "urban_4_6", "urban_4_7", "urban_4_8", "urban_2_3", "urban_2_4", "urban_2_5", "urban_2_6" ],
+    "fg": [ "otr_house_1_faceS", "otr_house_1_faceW", "otr_house_1_faceN", "otr_house_1_faceE" ],
     "bg": "open_air",
     "rotates": true
   },
@@ -227,7 +208,7 @@
       "urban_6_5",
       "urban_6_6"
     ],
-    "fg": [ "otr_house_1_faceN", "otr_house_1_faceE", "otr_house_1_faceS", "otr_house_1_faceW" ],
+    "fg": [ "otr_house_1_faceN", "otr_house_1_faceW", "otr_house_1_faceS", "otr_house_1_faceE" ],
     "bg": "open_air",
     "rotates": true
   }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/residential_park.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/residential_park.json
@@ -14,7 +14,7 @@
       "house_gardener",
       "house_toolshed"
     ],
-    "fg": [ "house_park_faceN", "house_park_faceW", "house_park_faceS", "house_park_faceE" ],
+    "fg": [ "house_park_faceN", "house_park_faceE", "house_park_faceS", "house_park_faceW" ],
     "bg": "field",
     "rotates": true
   },
@@ -33,7 +33,7 @@
       "house_gardener_roof",
       "house_toolshed_roof"
     ],
-    "fg": [ "house_park_faceN", "house_park_faceW", "house_park_faceS", "house_park_faceE" ],
+    "fg": [ "house_park_faceN", "house_park_faceE", "house_park_faceS", "house_park_faceW" ],
     "bg": "open_air",
     "rotates": true
   },
@@ -50,7 +50,7 @@
       "house_gardener_basement",
       "house_toolshed_basement"
     ],
-    "fg": [ "house_park_faceN", "house_park_faceW", "house_park_faceS", "house_park_faceE" ],
+    "fg": [ "house_park_faceN", "house_park_faceE", "house_park_faceS", "house_park_faceW" ],
     "bg": "t_soil_center",
     "rotates": true
   }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/river/river.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/river/river.json
@@ -31,7 +31,7 @@
   },
   {
     "id": "river",
-    "fg": ["river_north", "river_west", "river_south", "river_east"],
+    "fg": [ "river_north", "river_east", "river_south", "river_west" ],
     "bg": "field",
     "rotates": true
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/road/road.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/road/road.json
@@ -5,50 +5,19 @@
     "bg": "field",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "road_center"
-      },
+      { "id": "center", "fg": "road_center" },
       {
         "id": "corner",
-        "fg": [
-          "road_corner_nw",
-          "road_corner_sw",
-          "road_corner_se",
-          "road_corner_ne"
-        ],
+        "fg": [ "road_corner_nw", "road_corner_ne", "road_corner_se", "road_corner_sw" ],
         "bg": "field"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "road_t_connection_n",
-          "road_t_connection_w",
-          "road_t_connection_s",
-          "road_t_connection_e"
-        ]
+        "fg": [ "road_t_connection_n", "road_t_connection_e", "road_t_connection_s", "road_t_connection_w" ]
       },
-      {
-        "id": "edge",
-        "fg": [
-          "road_edge_ns",
-          "road_edge_ew"
-        ]
-      },
-      {
-        "id": "end_piece",
-        "fg": [
-          "road_end_piece_n",
-          "road_end_piece_w",
-          "road_end_piece_s",
-          "road_end_piece_e"
-        ]
-      },
-      {
-        "id": "unconnected",
-        "fg": "road_unconnected",
-        "bg": "field"
-      }
+      { "id": "edge", "fg": [ "road_edge_ns", "road_edge_ew" ] },
+      { "id": "end_piece", "fg": [ "road_end_piece_n", "road_end_piece_e", "road_end_piece_s", "road_end_piece_w" ] },
+      { "id": "unconnected", "fg": "road_unconnected", "bg": "field" }
     ]
   },
   {
@@ -67,18 +36,13 @@
   },
   {
     "id": "trailer_road_turn",
-    "fg": [ "road_corner_ne", "road_corner_nw", "road_corner_sw", "road_corner_se" ],
+    "fg": [ "road_corner_ne", "road_corner_se", "road_corner_sw", "road_corner_nw" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "trailer_road_3way",
-    "fg": [
-      "road_t_connection_n",
-      "road_t_connection_w",
-      "road_t_connection_s",
-      "road_t_connection_e"
-    ],
+    "fg": [ "road_t_connection_n", "road_t_connection_e", "road_t_connection_s", "road_t_connection_w" ],
     "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/rural_house/rural_house.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/rural_house/rural_house.json
@@ -1,53 +1,37 @@
 [
   {
-    "id": [
-      "house_farm",
-      "farm_2",
-      "farm_isherwood_2",
-      "2farm_11"
-    ],
-    "fg": [ "rural_house_faceN", "rural_house_faceW", "rural_house_faceS", "rural_house_faceE" ],
+    "id": [ "house_farm", "farm_2", "farm_isherwood_2", "2farm_11" ],
+    "fg": [ "rural_house_faceN", "rural_house_faceE", "rural_house_faceS", "rural_house_faceW" ],
     "bg": "field",
     "rotates": true
   },
   {
-    "id": [
-      "dairy_farm_SW",
-      "ranch_camp_68"
-    ],
-    "fg": [ "rural_house_faceS", "rural_house_faceE", "rural_house_faceN", "rural_house_faceW" ],
+    "id": [ "dairy_farm_SW", "ranch_camp_68" ],
+    "fg": [ "rural_house_faceS", "rural_house_faceW", "rural_house_faceN", "rural_house_faceE" ],
     "bg": "field",
     "rotates": true
   },
   {
-    "id": [
-      "house_farm_roof",
-      "farm_2_roof",
-      "farm_isherwood_2_roof",
-      "2farm_roof_11"
-    ],
-    "fg": [ "rural_house_faceN", "rural_house_faceW", "rural_house_faceS", "rural_house_faceE" ],
+    "id": [ "house_farm_roof", "farm_2_roof", "farm_isherwood_2_roof", "2farm_roof_11" ],
+    "fg": [ "rural_house_faceN", "rural_house_faceE", "rural_house_faceS", "rural_house_faceW" ],
     "bg": "open_air",
     "rotates": true
   },
   {
-    "id": [
-      "dairy_farm_SW_roof",
-      "ranch_camp_68_roof"
-    ],
-    "fg": [ "rural_house_faceS", "rural_house_faceE", "rural_house_faceN", "rural_house_faceW" ],
+    "id": [ "dairy_farm_SW_roof", "ranch_camp_68_roof" ],
+    "fg": [ "rural_house_faceS", "rural_house_faceW", "rural_house_faceN", "rural_house_faceE" ],
     "bg": "open_air",
     "rotates": true
   },
   {
     "id": "farm_isherwood_2_cellar",
-    "fg": [ "rural_house_faceN", "rural_house_faceW", "rural_house_faceS", "rural_house_faceE" ],
+    "fg": [ "rural_house_faceN", "rural_house_faceE", "rural_house_faceS", "rural_house_faceW" ],
     "bg": "t_soil_center",
     "rotates": true
   },
-    {
+  {
     "id": "ranch_camp_68_basement",
-    "fg": [ "rural_house_faceS", "rural_house_faceE", "rural_house_faceN", "rural_house_faceW" ],
+    "fg": [ "rural_house_faceS", "rural_house_faceW", "rural_house_faceN", "rural_house_faceE" ],
     "bg": "t_soil_center",
     "rotates": true
   }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/s_lightindustry/s_lightindustry.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/s_lightindustry/s_lightindustry.json
@@ -1,22 +1,12 @@
 [
   {
     "id": [ "s_lightindustry_road_0", "s_lightindustry_scen_road_0" ],
-    "fg": [
-      "industry_light_road_W",
-      "industry_light_road_S",
-      "industry_light_road_E",
-      "industry_light_road_N"
-    ],
+    "fg": [ "industry_light_road_W", "industry_light_road_N", "industry_light_road_E", "industry_light_road_S" ],
     "rotates": true
   },
   {
     "id": [ "s_lightindustry_road_1", "s_lightindustry_scen_road_1" ],
-    "fg": [
-      "industry_light_road_E",
-      "industry_light_road_N",
-      "industry_light_road_W",
-      "industry_light_road_S"
-    ],
+    "fg": [ "industry_light_road_E", "industry_light_road_S", "industry_light_road_W", "industry_light_road_N" ],
     "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/sand_pit/sand_pit.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/sand_pit/sand_pit.json
@@ -1,177 +1,97 @@
 [
   {
     "id": "sand_pit_NW",
-    "fg": [
-      "sandpit_nw",
-      "sandpit_sw",
-      "sandpit_se",
-      "sandpit_ne"
-    ],
+    "fg": [ "sandpit_nw", "sandpit_ne", "sandpit_se", "sandpit_sw" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "sand_pit_N",
-    "fg": [
-      "sandpit_n",
-      "sandpit_w",
-      "sandpit_s",
-      "sandpit_e"
-    ],
+    "fg": [ "sandpit_n", "sandpit_e", "sandpit_s", "sandpit_w" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "sand_pit_NE",
-    "fg": [
-      "sandpit_ne",
-      "sandpit_nw",
-      "sandpit_sw",
-      "sandpit_se"
-    ],
+    "fg": [ "sandpit_ne", "sandpit_se", "sandpit_sw", "sandpit_nw" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "sand_pit_W",
-    "fg": [
-      "sandpit_w",
-      "sandpit_s",
-      "sandpit_e",
-      "sandpit_n"
-    ],
+    "fg": [ "sandpit_w", "sandpit_n", "sandpit_e", "sandpit_s" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "sand_pit_E",
-    "fg": [
-      "sandpit_e",
-      "sandpit_n",
-      "sandpit_w",
-      "sandpit_s"
-    ],
+    "fg": [ "sandpit_e", "sandpit_s", "sandpit_w", "sandpit_n" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "sand_pit_SW",
-    "fg": [
-      "sandpit_sw",
-      "sandpit_se",
-      "sandpit_ne",
-      "sandpit_nw"
-    ],
+    "fg": [ "sandpit_sw", "sandpit_nw", "sandpit_ne", "sandpit_se" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "sand_pit_S",
-    "fg": [
-      "sandpit_s",
-      "sandpit_e",
-      "sandpit_n",
-      "sandpit_w"
-    ],
+    "fg": [ "sandpit_s", "sandpit_w", "sandpit_n", "sandpit_e" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "sand_pit_SE",
-    "fg": [
-      "sandpit_se",
-      "sandpit_ne",
-      "sandpit_nw",
-      "sandpit_sw"
-    ],
+    "fg": [ "sandpit_se", "sandpit_sw", "sandpit_nw", "sandpit_ne" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "sand_pit_NW_down",
-    "fg": [
-      "sandpit_nw",
-      "sandpit_sw",
-      "sandpit_se",
-      "sandpit_ne"
-    ],
+    "fg": [ "sandpit_nw", "sandpit_ne", "sandpit_se", "sandpit_sw" ],
     "bg": "t_dirt_center3",
     "rotates": true
   },
   {
     "id": "sand_pit_N_down",
-    "fg": [
-      "sandpit_n",
-      "sandpit_w",
-      "sandpit_s",
-      "sandpit_e"
-    ],
+    "fg": [ "sandpit_n", "sandpit_e", "sandpit_s", "sandpit_w" ],
     "bg": "t_dirt_center3",
     "rotates": true
   },
   {
     "id": "sand_pit_NE_down",
-    "fg": [
-      "sandpit_ne",
-      "sandpit_nw",
-      "sandpit_sw",
-      "sandpit_se"
-    ],
+    "fg": [ "sandpit_ne", "sandpit_se", "sandpit_sw", "sandpit_nw" ],
     "bg": "t_dirt_center3",
     "rotates": true
   },
   {
     "id": "sand_pit_W_down",
-    "fg": [
-      "sandpit_w",
-      "sandpit_s",
-      "sandpit_e",
-      "sandpit_n"
-    ],
+    "fg": [ "sandpit_w", "sandpit_n", "sandpit_e", "sandpit_s" ],
     "bg": "t_dirt_center3",
     "rotates": true
   },
   {
     "id": "sand_pit_E_down",
-    "fg": [
-      "sandpit_e",
-      "sandpit_n",
-      "sandpit_w",
-      "sandpit_s"
-    ],
+    "fg": [ "sandpit_e", "sandpit_s", "sandpit_w", "sandpit_n" ],
     "bg": "t_dirt_center3",
     "rotates": true
   },
   {
     "id": "sand_pit_SW_down",
-    "fg": [
-      "sandpit_sw",
-      "sandpit_se",
-      "sandpit_ne",
-      "sandpit_nw"
-    ],
+    "fg": [ "sandpit_sw", "sandpit_nw", "sandpit_ne", "sandpit_se" ],
     "bg": "t_dirt_center3",
     "rotates": true
   },
   {
     "id": "sand_pit_S_down",
-    "fg": [
-      "sandpit_s",
-      "sandpit_e",
-      "sandpit_n",
-      "sandpit_w"
-    ],
+    "fg": [ "sandpit_s", "sandpit_w", "sandpit_n", "sandpit_e" ],
     "bg": "t_dirt_center3",
     "rotates": true
   },
   {
     "id": "sand_pit_SE_down",
-    "fg": [
-      "sandpit_se",
-      "sandpit_ne",
-      "sandpit_nw",
-      "sandpit_sw"
-    ],
+    "fg": [ "sandpit_se", "sandpit_sw", "sandpit_nw", "sandpit_ne" ],
     "bg": "t_dirt_center3",
     "rotates": true
   },

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/sewage_treatment_plant/sewage_treatment_plant.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/sewage_treatment_plant/sewage_treatment_plant.json
@@ -1,154 +1,84 @@
 [
   {
     "id": "sewage_treatment_0_0_0",
-    "fg": [
-      "sewagetreatmentplant_n_1",
-      "sewagetreatmentplant_w_1",
-      "sewagetreatmentplant_s_1",
-      "sewagetreatmentplant_e_1"
-    ],
+    "fg": [ "sewagetreatmentplant_n_1", "sewagetreatmentplant_e_1", "sewagetreatmentplant_s_1", "sewagetreatmentplant_w_1" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "sewage_treatment_1_0_0",
-    "fg": [
-      "sewagetreatmentplant_n_2",
-      "sewagetreatmentplant_w_2",
-      "sewagetreatmentplant_s_2",
-      "sewagetreatmentplant_e_2"
-    ],
+    "fg": [ "sewagetreatmentplant_n_2", "sewagetreatmentplant_e_2", "sewagetreatmentplant_s_2", "sewagetreatmentplant_w_2" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "sewage_treatment_0_1_0",
-    "fg": [
-      "sewagetreatmentplant_n_3",
-      "sewagetreatmentplant_w_3",
-      "sewagetreatmentplant_s_3",
-      "sewagetreatmentplant_e_3"
-    ],
+    "fg": [ "sewagetreatmentplant_n_3", "sewagetreatmentplant_e_3", "sewagetreatmentplant_s_3", "sewagetreatmentplant_w_3" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "sewage_treatment_1_1_0",
-    "fg": [
-      "sewagetreatmentplant_n_4",
-      "sewagetreatmentplant_w_4",
-      "sewagetreatmentplant_s_4",
-      "sewagetreatmentplant_e_4"
-    ],
+    "fg": [ "sewagetreatmentplant_n_4", "sewagetreatmentplant_e_4", "sewagetreatmentplant_s_4", "sewagetreatmentplant_w_4" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "sewage_treatment_0_0_roof",
-    "fg": [
-      "sewagetreatmentplant_n_1",
-      "sewagetreatmentplant_w_1",
-      "sewagetreatmentplant_s_1",
-      "sewagetreatmentplant_e_1"
-    ],
+    "fg": [ "sewagetreatmentplant_n_1", "sewagetreatmentplant_e_1", "sewagetreatmentplant_s_1", "sewagetreatmentplant_w_1" ],
     "bg": "open_air",
     "rotates": true
   },
   {
     "id": "sewage_treatment_1_0_roof",
-    "fg": [
-      "sewagetreatmentplant_n_2",
-      "sewagetreatmentplant_w_2",
-      "sewagetreatmentplant_s_2",
-      "sewagetreatmentplant_e_2"
-    ],
+    "fg": [ "sewagetreatmentplant_n_2", "sewagetreatmentplant_e_2", "sewagetreatmentplant_s_2", "sewagetreatmentplant_w_2" ],
     "bg": "open_air",
     "rotates": true
   },
   {
     "id": "sewage_treatment_0_1_roof",
-    "fg": [
-      "sewagetreatmentplant_n_3",
-      "sewagetreatmentplant_w_3",
-      "sewagetreatmentplant_s_3",
-      "sewagetreatmentplant_e_3"
-    ],
+    "fg": [ "sewagetreatmentplant_n_3", "sewagetreatmentplant_e_3", "sewagetreatmentplant_s_3", "sewagetreatmentplant_w_3" ],
     "bg": "open_air",
     "rotates": true
   },
   {
     "id": "sewage_treatment_1_1_roof",
-    "fg": [
-      "sewagetreatmentplant_n_4",
-      "sewagetreatmentplant_w_4",
-      "sewagetreatmentplant_s_4",
-      "sewagetreatmentplant_e_4"
-    ],
+    "fg": [ "sewagetreatmentplant_n_4", "sewagetreatmentplant_e_4", "sewagetreatmentplant_s_4", "sewagetreatmentplant_w_4" ],
     "bg": "open_air",
     "rotates": true
   },
   {
     "id": "sewage_treatment_0_0_-1",
-    "fg": [
-      "sewagetreatmentplant_n_1",
-      "sewagetreatmentplant_w_1",
-      "sewagetreatmentplant_s_1",
-      "sewagetreatmentplant_e_1"
-    ],
+    "fg": [ "sewagetreatmentplant_n_1", "sewagetreatmentplant_e_1", "sewagetreatmentplant_s_1", "sewagetreatmentplant_w_1" ],
     "bg": "t_sewage_center",
     "rotates": true
   },
   {
     "id": "sewage_treatment_1_0_-1",
-    "fg": [
-      "sewagetreatmentplant_n_2",
-      "sewagetreatmentplant_w_2",
-      "sewagetreatmentplant_s_2",
-      "sewagetreatmentplant_e_2"
-    ],
+    "fg": [ "sewagetreatmentplant_n_2", "sewagetreatmentplant_e_2", "sewagetreatmentplant_s_2", "sewagetreatmentplant_w_2" ],
     "bg": "t_sewage_center",
     "rotates": true
   },
   {
     "id": "sewage_treatment_0_1_-1",
-    "fg": [
-      "sewagetreatmentplant_n_3",
-      "sewagetreatmentplant_w_3",
-      "sewagetreatmentplant_s_3",
-      "sewagetreatmentplant_e_3"
-    ],
+    "fg": [ "sewagetreatmentplant_n_3", "sewagetreatmentplant_e_3", "sewagetreatmentplant_s_3", "sewagetreatmentplant_w_3" ],
     "bg": "t_sewage_center",
     "rotates": true
   },
   {
     "id": "sewage_treatment_1_1_-1",
-    "fg": [
-      "sewagetreatmentplant_n_4",
-      "sewagetreatmentplant_w_4",
-      "sewagetreatmentplant_s_4",
-      "sewagetreatmentplant_e_4"
-    ],
+    "fg": [ "sewagetreatmentplant_n_4", "sewagetreatmentplant_e_4", "sewagetreatmentplant_s_4", "sewagetreatmentplant_w_4" ],
     "bg": "t_sewage_center",
     "rotates": true
   },
   {
     "id": "sewage_treatment_2_0_-1",
-    "fg": [
-      "t_sewage_pipe_corner_ne",
-      "t_sewage_pipe_corner_nw",
-      "t_sewage_pipe_corner_sw",
-      "t_sewage_pipe_corner_se"
-    ],
+    "fg": [ "t_sewage_pipe_corner_ne", "t_sewage_pipe_corner_se", "t_sewage_pipe_corner_sw", "t_sewage_pipe_corner_nw" ],
     "rotates": true
   },
   {
     "id": "sewage_treatment_2_1_-1",
-    "fg": [
-      "t_sewage_pipe_corner_se",
-      "t_sewage_pipe_corner_ne",
-      "t_sewage_pipe_corner_nw",
-      "t_sewage_pipe_corner_sw"
-    ],
+    "fg": [ "t_sewage_pipe_corner_se", "t_sewage_pipe_corner_sw", "t_sewage_pipe_corner_nw", "t_sewage_pipe_corner_ne" ],
     "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/strip_mall/strip_mall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/strip_mall/strip_mall.json
@@ -1,37 +1,37 @@
 [
   {
     "id": "strip_mall_1",
-    "fg": [ "strip_mall_S_1", "strip_mall_E_1", "strip_mall_N_3", "strip_mall_W_3" ],
+    "fg": [ "strip_mall_S_1", "strip_mall_W_3", "strip_mall_N_3", "strip_mall_E_1" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": [ "strip_mall_2", "strip_mall_3", "strip_mall_4" ],
-    "fg": [ "strip_mall_S_2", "strip_mall_E_2", "strip_mall_N_2", "strip_mall_W_2" ],
+    "fg": [ "strip_mall_S_2", "strip_mall_W_2", "strip_mall_N_2", "strip_mall_E_2" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "strip_mall_5",
-    "fg": [ "strip_mall_S_3", "strip_mall_E_3", "strip_mall_N_1", "strip_mall_W_1" ],
+    "fg": [ "strip_mall_S_3", "strip_mall_W_1", "strip_mall_N_1", "strip_mall_E_3" ],
     "bg": "field",
     "rotates": true
   },
   {
     "id": "strip_mall_roof_1",
-    "fg": [ "strip_mall_S_1", "strip_mall_E_1", "strip_mall_N_3", "strip_mall_W_3" ],
+    "fg": [ "strip_mall_S_1", "strip_mall_W_3", "strip_mall_N_3", "strip_mall_E_1" ],
     "bg": "open_air",
     "rotates": true
   },
   {
     "id": [ "strip_mall_roof_2", "strip_mall_roof_3", "strip_mall_roof_4" ],
-    "fg": [ "strip_mall_S_2", "strip_mall_E_2", "strip_mall_N_2", "strip_mall_W_2" ],
+    "fg": [ "strip_mall_S_2", "strip_mall_W_2", "strip_mall_N_2", "strip_mall_E_2" ],
     "bg": "open_air",
     "rotates": true
   },
   {
     "id": "strip_mall_roof_5",
-    "fg": [ "strip_mall_S_3", "strip_mall_E_3", "strip_mall_N_1", "strip_mall_W_1" ],
+    "fg": [ "strip_mall_S_3", "strip_mall_W_1", "strip_mall_N_1", "strip_mall_E_3" ],
     "bg": "open_air",
     "rotates": true
   }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/sub_station/sub_station.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/sub_station/sub_station.json
@@ -1,7 +1,7 @@
 [
   {
-	"id": [ "sub_station_roof", "sub_station", "sewer_sub_station", "underground_sub_station" ],
-	"fg": [ "sub_station_rot_N", "sub_station_rot_W", "sub_station_rot_S", "sub_station_rot_E" ],
-	"rotates": true
+    "id": [ "sub_station_roof", "sub_station", "sewer_sub_station", "underground_sub_station" ],
+    "fg": [ "sub_station_rot_N", "sub_station_rot_E", "sub_station_rot_S", "sub_station_rot_W" ],
+    "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/swamp_shack/swamp_shacks.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/swamp_shack/swamp_shacks.json
@@ -1,21 +1,26 @@
-[{
-	"id": "hunter_shack",
-	"fg": [ "hunter_shack_faceS", "hunter_shack_faceE", "hunter_shack_faceN", "hunter_shack_faceW" ],
-	"bg": "field",
-	"rotates": true
-},{
-	"id": "hunter_shack_1",
-	"fg": [ "hunter_shack_1_faceS", "hunter_shack_1_faceW", "hunter_shack_1_faceN", "hunter_shack_1_faceE" ],
-	"bg": "field",
-	"rotates": true
-},{
-	"id": "hunter_shack_roof",
-	"fg": [ "hunter_shack_faceS", "hunter_shack_faceE", "hunter_shack_faceN", "hunter_shack_faceW" ],
-	"bg": "open_air",
-	"rotates": true
-},{
-	"id": "hunter_shack_roof_1",
-	"fg": [ "hunter_shack_1_faceS", "hunter_shack_1_faceW", "hunter_shack_1_faceN", "hunter_shack_1_faceE" ],
-	"bg": "open_air",
-	"rotates": true
-}]
+[
+  {
+    "id": "hunter_shack",
+    "fg": [ "hunter_shack_faceS", "hunter_shack_faceW", "hunter_shack_faceN", "hunter_shack_faceE" ],
+    "bg": "field",
+    "rotates": true
+  },
+  {
+    "id": "hunter_shack_1",
+    "fg": [ "hunter_shack_1_faceS", "hunter_shack_1_faceE", "hunter_shack_1_faceN", "hunter_shack_1_faceW" ],
+    "bg": "field",
+    "rotates": true
+  },
+  {
+    "id": "hunter_shack_roof",
+    "fg": [ "hunter_shack_faceS", "hunter_shack_faceW", "hunter_shack_faceN", "hunter_shack_faceE" ],
+    "bg": "open_air",
+    "rotates": true
+  },
+  {
+    "id": "hunter_shack_roof_1",
+    "fg": [ "hunter_shack_1_faceS", "hunter_shack_1_faceE", "hunter_shack_1_faceN", "hunter_shack_1_faceW" ],
+    "bg": "open_air",
+    "rotates": true
+  }
+]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/trail_small/trail_small.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/trail_small/trail_small.json
@@ -1,24 +1,19 @@
 [
   {
-	"id": "small_wooded_trail",
-	"fg": [
-	  "small_wooded_trail_rot_N",
-	  "small_wooded_trail_rot_W",
-	  "small_wooded_trail_rot_S",
-	  "small_wooded_trail_rot_E"
-	],
-	"bg": "field",
-	"rotates": true
+    "id": "small_wooded_trail",
+    "fg": [ "small_wooded_trail_rot_N", "small_wooded_trail_rot_E", "small_wooded_trail_rot_S", "small_wooded_trail_rot_W" ],
+    "bg": "field",
+    "rotates": true
   },
   {
-	"id": "small_wooded_trail_2",
-	"fg": [
-	  "small_wooded_trail_2_rot_N",
-	  "small_wooded_trail_2_rot_W",
-	  "small_wooded_trail_2_rot_S",
-	  "small_wooded_trail_2_rot_E"
-	],
-	"bg": "field",
-	"rotates": true
+    "id": "small_wooded_trail_2",
+    "fg": [
+      "small_wooded_trail_2_rot_N",
+      "small_wooded_trail_2_rot_E",
+      "small_wooded_trail_2_rot_S",
+      "small_wooded_trail_2_rot_W"
+    ],
+    "bg": "field",
+    "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/underground.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/underground.json
@@ -13,18 +13,14 @@
     "bg": "t_railroad_rubble_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_railroad_track_small_edge_ew",
-        "bg": "t_railroad_rubble_center"
-      },
+      { "id": "center", "fg": "t_railroad_track_small_edge_ew", "bg": "t_railroad_rubble_center" },
       {
         "id": "corner",
         "fg": [
           "t_railroad_track_small_corner_nw",
-          "t_railroad_track_small_corner_sw",
+          "t_railroad_track_small_corner_ne",
           "t_railroad_track_small_corner_se",
-          "t_railroad_track_small_corner_ne"
+          "t_railroad_track_small_corner_sw"
         ],
         "bg": "t_railroad_rubble_center"
       },
@@ -32,33 +28,23 @@
         "id": "t_connection",
         "fg": [
           "t_railroad_track_small_t_connection_n",
-          "t_railroad_track_small_t_connection_w",
+          "t_railroad_track_small_t_connection_e",
           "t_railroad_track_small_t_connection_s",
-          "t_railroad_track_small_t_connection_e"
+          "t_railroad_track_small_t_connection_w"
         ],
         "bg": "t_railroad_rubble_center"
       },
       {
         "id": "edge",
-        "fg": [
-          "t_railroad_track_small_edge_ns",
-          "t_railroad_track_small_edge_ew"
-          ],
-          "bg": "t_railroad_rubble_center"
+        "fg": [ "t_railroad_track_small_edge_ns", "t_railroad_track_small_edge_ew" ],
+        "bg": "t_railroad_rubble_center"
       },
       {
         "id": "end_piece",
-        "fg": [
-          "t_railroad_track_small_edge_ns",
-          "t_railroad_track_small_edge_ew"
-        ],
+        "fg": [ "t_railroad_track_small_edge_ns", "t_railroad_track_small_edge_ew" ],
         "bg": "t_railroad_rubble_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_railroad_track_small_edge_ew",
-        "bg": "t_railroad_rubble_center"
-      }
+      { "id": "unconnected", "fg": "t_railroad_track_small_edge_ew", "bg": "t_railroad_rubble_center" }
     ]
   },
   {
@@ -66,48 +52,21 @@
     "fg": "t_sewage_unconnected",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_sewage_center"
-      },
+      { "id": "center", "fg": "t_sewage_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_sewage_corner_nw",
-          "t_sewage_corner_sw",
-          "t_sewage_corner_se",
-          "t_sewage_corner_ne"
-        ]
+        "fg": [ "t_sewage_corner_nw", "t_sewage_corner_ne", "t_sewage_corner_se", "t_sewage_corner_sw" ]
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_sewage_t_connection_n",
-          "t_sewage_t_connection_w",
-          "t_sewage_t_connection_s",
-          "t_sewage_t_connection_e"
-        ]
+        "fg": [ "t_sewage_t_connection_n", "t_sewage_t_connection_e", "t_sewage_t_connection_s", "t_sewage_t_connection_w" ]
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_sewage_edge_ns",
-          "t_sewage_edge_ew"
-          ]
-      },
+      { "id": "edge", "fg": [ "t_sewage_edge_ns", "t_sewage_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [
-          "t_sewage_end_piece_n",
-          "t_sewage_end_piece_w",
-          "t_sewage_end_piece_s",
-          "t_sewage_end_piece_e"
-        ]
+        "fg": [ "t_sewage_end_piece_n", "t_sewage_end_piece_e", "t_sewage_end_piece_s", "t_sewage_end_piece_w" ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_sewage_unconnected"
-      }
+      { "id": "unconnected", "fg": "t_sewage_unconnected" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/f_earthbag_half/f_earthbag_half.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/f_earthbag_half/f_earthbag_half.json
@@ -4,56 +4,33 @@
   "fg": "f_earthbag_half_unconnected",
   "bg": "t_grass",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_earthbag_half_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_earthbag_half_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_earthbag_half_corner_nw",
-        "f_earthbag_half_corner_sw",
-        "f_earthbag_half_corner_se",
-        "f_earthbag_half_corner_ne"
-      ]
+      "fg": [ "f_earthbag_half_corner_nw", "f_earthbag_half_corner_ne", "f_earthbag_half_corner_se", "f_earthbag_half_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "f_earthbag_half_t_connection_n",
-        "f_earthbag_half_t_connection_w",
+        "f_earthbag_half_t_connection_e",
         "f_earthbag_half_t_connection_s",
-        "f_earthbag_half_t_connection_e"
+        "f_earthbag_half_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_earthbag_half_edge_ns",
-        "f_earthbag_half_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_earthbag_half_edge_ns", "f_earthbag_half_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "f_earthbag_half_end_piece_n",
-        "f_earthbag_half_end_piece_w",
+        "f_earthbag_half_end_piece_e",
         "f_earthbag_half_end_piece_s",
-        "f_earthbag_half_end_piece_e"
+        "f_earthbag_half_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [
-        "f_earthbag_half_unconnected",
-        "f_earthbag_half_unconnected"
-      ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_earthbag_half_unconnected", "f_earthbag_half_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/netherum/t_nl_catwalk/t_nl_catwalk.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/netherum/t_nl_catwalk/t_nl_catwalk.json
@@ -21,15 +21,15 @@
       "fg": [
         {
           "weight": 2,
-          "sprite": [ "t_nl_catwalk_corner_nw_1", "t_nl_catwalk_corner_sw_1", "t_nl_catwalk_corner_ne_1", "t_nl_catwalk_corner_se_1" ]
+          "sprite": [ "t_nl_catwalk_corner_nw_1", "t_nl_catwalk_corner_se_1", "t_nl_catwalk_corner_ne_1", "t_nl_catwalk_corner_sw_1" ]
         },
         {
           "weight": 2,
-          "sprite": [ "t_nl_catwalk_corner_nw_2", "t_nl_catwalk_corner_sw_2", "t_nl_catwalk_corner_ne_2", "t_nl_catwalk_corner_se_2" ]
+          "sprite": [ "t_nl_catwalk_corner_nw_2", "t_nl_catwalk_corner_se_2", "t_nl_catwalk_corner_ne_2", "t_nl_catwalk_corner_sw_2" ]
         },
         {
           "weight": 1,
-          "sprite": [ "t_nl_catwalk_corner_nw_3", "t_nl_catwalk_corner_sw_3", "t_nl_catwalk_corner_ne_3", "t_nl_catwalk_corner_se_3" ]
+          "sprite": [ "t_nl_catwalk_corner_nw_3", "t_nl_catwalk_corner_se_3", "t_nl_catwalk_corner_ne_3", "t_nl_catwalk_corner_sw_3" ]
         }
       ]
     },
@@ -41,18 +41,18 @@
           "weight": 1,
           "sprite": [
             "t_nl_catwalk_t_connection_n_1",
-            "t_nl_catwalk_t_connection_w_1",
+            "t_nl_catwalk_t_connection_e_1",
             "t_nl_catwalk_t_connection_s_1",
-            "t_nl_catwalk_t_connection_e_1"
+            "t_nl_catwalk_t_connection_w_1"
           ]
         },
         {
           "weight": 1,
           "sprite": [
             "t_nl_catwalk_t_connection_n_2",
-            "t_nl_catwalk_t_connection_w_2",
+            "t_nl_catwalk_t_connection_e_2",
             "t_nl_catwalk_t_connection_s_2",
-            "t_nl_catwalk_t_connection_e_2"
+            "t_nl_catwalk_t_connection_w_2"
           ]
         }
       ]
@@ -73,18 +73,18 @@
           "weight": 1,
           "sprite": [
             "t_nl_catwalk_end_piece_n_1",
-            "t_nl_catwalk_end_piece_w_1",
+            "t_nl_catwalk_end_piece_e_1",
             "t_nl_catwalk_end_piece_s_1",
-            "t_nl_catwalk_end_piece_e_1"
+            "t_nl_catwalk_end_piece_w_1"
           ]
         },
         {
           "weight": 1,
           "sprite": [
             "t_nl_catwalk_end_piece_n_2",
-            "t_nl_catwalk_end_piece_w_2",
+            "t_nl_catwalk_end_piece_e_2",
             "t_nl_catwalk_end_piece_s_2",
-            "t_nl_catwalk_end_piece_e_2"
+            "t_nl_catwalk_end_piece_w_2"
           ]
         }
       ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/netherum/t_nl_chasm/t_nl_chasm.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/netherum/t_nl_chasm/t_nl_chasm.json
@@ -23,49 +23,21 @@
       },
       {
         "id": "corner",
-        "fg": [
-          "t_nl_chasm_corner_nw",
-          "t_nl_chasm_center1",
-          "t_nl_chasm_center2",
-          "t_nl_chasm_corner_ne"
-        ],
+        "fg": [ "t_nl_chasm_corner_nw", "t_nl_chasm_corner_ne", "t_nl_chasm_center2", "t_nl_chasm_center1" ],
         "bg": ""
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_nl_chasm_t_connection_n",
-          "t_nl_chasm_center3",
-          "t_nl_chasm_center4",
-          "t_nl_chasm_center5"
-        ],
+        "fg": [ "t_nl_chasm_t_connection_n", "t_nl_chasm_center5", "t_nl_chasm_center4", "t_nl_chasm_center3" ],
         "bg": ""
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_nl_chasm_center6",
-          "t_nl_chasm_edge_ew"
-        ],
-        "bg": ""
-      },
+      { "id": "edge", "fg": [ "t_nl_chasm_center6", "t_nl_chasm_edge_ew" ], "bg": "" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_nl_chasm_end_piece_n",
-          "t_nl_chasm_end_piece_w",
-          "t_nl_chasm_center7",
-          "t_nl_chasm_end_piece_e"
-        ],
+        "fg": [ "t_nl_chasm_end_piece_n", "t_nl_chasm_end_piece_e", "t_nl_chasm_center7", "t_nl_chasm_end_piece_w" ],
         "bg": ""
       },
-      {
-        "id": "unconnected",
-        "fg": [
-          "t_nl_chasm_edge_ew"
-        ],
-        "bg": ""
-      }
+      { "id": "unconnected", "fg": [ "t_nl_chasm_edge_ew" ], "bg": "" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/splitrail/t_splitrail_fence/t_splitrail_fence.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/splitrail/t_splitrail_fence/t_splitrail_fence.json
@@ -1,235 +1,186 @@
 [
-{
-  "id": "t_splitrail_fence",
-  "multitile": true,
-  "fg": "t_splitrail_fence_unconnected",
-  "bg": "t_grass",
-  "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "t_grass",
-      "fg": "t_splitrail_fence_center"
-    },
-    {
-      "id": "corner",
-      "bg": "t_grass",
-      "fg": [
-        "t_splitrail_fence_corner_nw",
-        "t_splitrail_fence_corner_sw",
-        "t_splitrail_fence_corner_se",
-        "t_splitrail_fence_corner_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "bg": "t_grass",
-      "fg": [
-        "t_splitrail_fence_t_connection_n",
-        "t_splitrail_fence_t_connection_w",
-        "t_splitrail_fence_t_connection_s",
-        "t_splitrail_fence_t_connection_e"
-      ]
-    },
-    {
-      "id": "edge",
-      "bg": "t_grass",
-      "fg": [
-        "t_splitrail_fence_edge_ns",
-        "t_splitrail_fence_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "bg": "t_grass",
-      "fg": [
-        "t_splitrail_fence_end_piece_n",
-        "t_splitrail_fence_end_piece_w",
-        "t_splitrail_fence_end_piece_s",
-        "t_splitrail_fence_end_piece_e"
-      ]
-    },
-    {
-      "bg": "t_grass",
-      "id": "unconnected",
-      "fg": [
-        "t_splitrail_fence_unconnected",
-        "t_splitrail_fence_unconnected"
-      ]
-    }
-  ]
-},{
-  "id": "t_splitrail_fence_season_summer",
-  "multitile": true,
-  "fg": "t_splitrail_fence_unconnected",
-  "bg": "t_grass_summer",
-  "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "t_grass_summer",
-      "fg": "t_splitrail_fence_center"
-    },
-    {
-      "id": "corner",
-      "bg": "t_grass_summer",
-      "fg": [
-        "t_splitrail_fence_corner_nw",
-        "t_splitrail_fence_corner_sw",
-        "t_splitrail_fence_corner_se",
-        "t_splitrail_fence_corner_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "bg": "t_grass_summer",
-      "fg": [
-        "t_splitrail_fence_t_connection_n",
-        "t_splitrail_fence_t_connection_w",
-        "t_splitrail_fence_t_connection_s",
-        "t_splitrail_fence_t_connection_e"
-      ]
-    },
-    {
-      "id": "edge",
-      "bg": "t_grass_summer",
-      "fg": [
-        "t_splitrail_fence_edge_ns",
-        "t_splitrail_fence_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "bg": "t_grass_summer",
-      "fg": [
-        "t_splitrail_fence_end_piece_n",
-        "t_splitrail_fence_end_piece_w",
-        "t_splitrail_fence_end_piece_s",
-        "t_splitrail_fence_end_piece_e"
-      ]
-    },
-    {
-      "bg": "t_grass_summer",
-      "id": "unconnected",
-      "fg": [
-        "t_splitrail_fence_unconnected",
-        "t_splitrail_fence_unconnected"
-      ]
-    }
-  ]
-},{
-  "id": "t_splitrail_fence_season_autumn",
-  "multitile": true,
-  "fg": "t_splitrail_fence_unconnected",
-  "bg": "t_grass_autumn",
-  "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "t_grass_autumn",
-      "fg": "t_splitrail_fence_center"
-    },
-    {
-      "id": "corner",
-      "bg": "t_grass_autumn",
-      "fg": [
-        "t_splitrail_fence_corner_nw",
-        "t_splitrail_fence_corner_sw",
-        "t_splitrail_fence_corner_se",
-        "t_splitrail_fence_corner_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "bg": "t_grass_autumn",
-      "fg": [
-        "t_splitrail_fence_t_connection_n",
-        "t_splitrail_fence_t_connection_w",
-        "t_splitrail_fence_t_connection_s",
-        "t_splitrail_fence_t_connection_e"
-      ]
-    },
-    {
-      "id": "edge",
-      "bg": "t_grass_autumn",
-      "fg": [
-        "t_splitrail_fence_edge_ns",
-        "t_splitrail_fence_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "bg": "t_grass_autumn",
-      "fg": [
-        "t_splitrail_fence_end_piece_n",
-        "t_splitrail_fence_end_piece_w",
-        "t_splitrail_fence_end_piece_s",
-        "t_splitrail_fence_end_piece_e"
-      ]
-    },
-    {
-      "bg": "t_grass_autumn",
-      "id": "unconnected",
-      "fg": [
-        "t_splitrail_fence_unconnected",
-        "t_splitrail_fence_unconnected"
-      ]
-    }
-  ]
-},{
-  "id": "t_splitrail_fence_season_winter",
-  "multitile": true,
-  "fg": "t_splitrail_fence_unconnected",
-  "bg": "snow_shallow_center",
-  "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "snow_shallow_center",
-      "fg": "t_splitrail_fence_center"
-    },
-    {
-      "id": "corner",
-      "bg": "snow_shallow_center",
-      "fg": [
-        "t_splitrail_fence_corner_nw",
-        "t_splitrail_fence_corner_sw",
-        "t_splitrail_fence_corner_se",
-        "t_splitrail_fence_corner_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "bg": "snow_shallow_center",
-      "fg": [
-        "t_splitrail_fence_t_connection_n",
-        "t_splitrail_fence_t_connection_w",
-        "t_splitrail_fence_t_connection_s",
-        "t_splitrail_fence_t_connection_e"
-      ]
-    },
-    {
-      "id": "edge",
-      "bg": "snow_shallow_center",
-      "fg": [
-        "t_splitrail_fence_edge_ns",
-        "t_splitrail_fence_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "bg": "snow_shallow_center",
-      "fg": [
-        "t_splitrail_fence_end_piece_n",
-        "t_splitrail_fence_end_piece_w",
-        "t_splitrail_fence_end_piece_s",
-        "t_splitrail_fence_end_piece_e"
-      ]
-    },
-    {
-      "bg": "snow_shallow_center",
-      "id": "unconnected",
-      "fg": [
-        "t_splitrail_fence_unconnected",
-        "t_splitrail_fence_unconnected"
-      ]
-    }
-  ]
-}
+  {
+    "id": "t_splitrail_fence",
+    "multitile": true,
+    "fg": "t_splitrail_fence_unconnected",
+    "bg": "t_grass",
+    "additional_tiles": [
+      { "id": "center", "bg": "t_grass", "fg": "t_splitrail_fence_center" },
+      {
+        "id": "corner",
+        "bg": "t_grass",
+        "fg": [
+          "t_splitrail_fence_corner_nw",
+          "t_splitrail_fence_corner_ne",
+          "t_splitrail_fence_corner_se",
+          "t_splitrail_fence_corner_sw"
+        ]
+      },
+      {
+        "id": "t_connection",
+        "bg": "t_grass",
+        "fg": [
+          "t_splitrail_fence_t_connection_n",
+          "t_splitrail_fence_t_connection_e",
+          "t_splitrail_fence_t_connection_s",
+          "t_splitrail_fence_t_connection_w"
+        ]
+      },
+      { "id": "edge", "bg": "t_grass", "fg": [ "t_splitrail_fence_edge_ns", "t_splitrail_fence_edge_ew" ] },
+      {
+        "id": "end_piece",
+        "bg": "t_grass",
+        "fg": [
+          "t_splitrail_fence_end_piece_n",
+          "t_splitrail_fence_end_piece_e",
+          "t_splitrail_fence_end_piece_s",
+          "t_splitrail_fence_end_piece_w"
+        ]
+      },
+      {
+        "bg": "t_grass",
+        "id": "unconnected",
+        "fg": [ "t_splitrail_fence_unconnected", "t_splitrail_fence_unconnected" ]
+      }
+    ]
+  },
+  {
+    "id": "t_splitrail_fence_season_summer",
+    "multitile": true,
+    "fg": "t_splitrail_fence_unconnected",
+    "bg": "t_grass_summer",
+    "additional_tiles": [
+      { "id": "center", "bg": "t_grass_summer", "fg": "t_splitrail_fence_center" },
+      {
+        "id": "corner",
+        "bg": "t_grass_summer",
+        "fg": [
+          "t_splitrail_fence_corner_nw",
+          "t_splitrail_fence_corner_ne",
+          "t_splitrail_fence_corner_se",
+          "t_splitrail_fence_corner_sw"
+        ]
+      },
+      {
+        "id": "t_connection",
+        "bg": "t_grass_summer",
+        "fg": [
+          "t_splitrail_fence_t_connection_n",
+          "t_splitrail_fence_t_connection_e",
+          "t_splitrail_fence_t_connection_s",
+          "t_splitrail_fence_t_connection_w"
+        ]
+      },
+      { "id": "edge", "bg": "t_grass_summer", "fg": [ "t_splitrail_fence_edge_ns", "t_splitrail_fence_edge_ew" ] },
+      {
+        "id": "end_piece",
+        "bg": "t_grass_summer",
+        "fg": [
+          "t_splitrail_fence_end_piece_n",
+          "t_splitrail_fence_end_piece_e",
+          "t_splitrail_fence_end_piece_s",
+          "t_splitrail_fence_end_piece_w"
+        ]
+      },
+      {
+        "bg": "t_grass_summer",
+        "id": "unconnected",
+        "fg": [ "t_splitrail_fence_unconnected", "t_splitrail_fence_unconnected" ]
+      }
+    ]
+  },
+  {
+    "id": "t_splitrail_fence_season_autumn",
+    "multitile": true,
+    "fg": "t_splitrail_fence_unconnected",
+    "bg": "t_grass_autumn",
+    "additional_tiles": [
+      { "id": "center", "bg": "t_grass_autumn", "fg": "t_splitrail_fence_center" },
+      {
+        "id": "corner",
+        "bg": "t_grass_autumn",
+        "fg": [
+          "t_splitrail_fence_corner_nw",
+          "t_splitrail_fence_corner_ne",
+          "t_splitrail_fence_corner_se",
+          "t_splitrail_fence_corner_sw"
+        ]
+      },
+      {
+        "id": "t_connection",
+        "bg": "t_grass_autumn",
+        "fg": [
+          "t_splitrail_fence_t_connection_n",
+          "t_splitrail_fence_t_connection_e",
+          "t_splitrail_fence_t_connection_s",
+          "t_splitrail_fence_t_connection_w"
+        ]
+      },
+      { "id": "edge", "bg": "t_grass_autumn", "fg": [ "t_splitrail_fence_edge_ns", "t_splitrail_fence_edge_ew" ] },
+      {
+        "id": "end_piece",
+        "bg": "t_grass_autumn",
+        "fg": [
+          "t_splitrail_fence_end_piece_n",
+          "t_splitrail_fence_end_piece_e",
+          "t_splitrail_fence_end_piece_s",
+          "t_splitrail_fence_end_piece_w"
+        ]
+      },
+      {
+        "bg": "t_grass_autumn",
+        "id": "unconnected",
+        "fg": [ "t_splitrail_fence_unconnected", "t_splitrail_fence_unconnected" ]
+      }
+    ]
+  },
+  {
+    "id": "t_splitrail_fence_season_winter",
+    "multitile": true,
+    "fg": "t_splitrail_fence_unconnected",
+    "bg": "snow_shallow_center",
+    "additional_tiles": [
+      { "id": "center", "bg": "snow_shallow_center", "fg": "t_splitrail_fence_center" },
+      {
+        "id": "corner",
+        "bg": "snow_shallow_center",
+        "fg": [
+          "t_splitrail_fence_corner_nw",
+          "t_splitrail_fence_corner_ne",
+          "t_splitrail_fence_corner_se",
+          "t_splitrail_fence_corner_sw"
+        ]
+      },
+      {
+        "id": "t_connection",
+        "bg": "snow_shallow_center",
+        "fg": [
+          "t_splitrail_fence_t_connection_n",
+          "t_splitrail_fence_t_connection_e",
+          "t_splitrail_fence_t_connection_s",
+          "t_splitrail_fence_t_connection_w"
+        ]
+      },
+      {
+        "id": "edge",
+        "bg": "snow_shallow_center",
+        "fg": [ "t_splitrail_fence_edge_ns", "t_splitrail_fence_edge_ew" ]
+      },
+      {
+        "id": "end_piece",
+        "bg": "snow_shallow_center",
+        "fg": [
+          "t_splitrail_fence_end_piece_n",
+          "t_splitrail_fence_end_piece_e",
+          "t_splitrail_fence_end_piece_s",
+          "t_splitrail_fence_end_piece_w"
+        ]
+      },
+      {
+        "bg": "snow_shallow_center",
+        "id": "unconnected",
+        "fg": [ "t_splitrail_fence_unconnected", "t_splitrail_fence_unconnected" ]
+      }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_LIXA_laser/t_LIXA_laser.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_LIXA_laser/t_LIXA_laser.json
@@ -4,53 +4,32 @@
   "fg": "t_LIXA_laser_t_connection_s",
   "bg": "t_metal_floor_center",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "t_metal_floor_center",
-      "fg": "t_LIXA_laser_center"
-    },
+    { "id": "center", "bg": "t_metal_floor_center", "fg": "t_LIXA_laser_center" },
     {
       "id": "corner",
       "bg": "t_metal_floor_center",
-      "fg": [
-        "t_LIXA_laser_corner_nw",
-        "t_LIXA_laser_corner_sw",
-        "t_LIXA_laser_corner_se",
-        "t_LIXA_laser_corner_ne"
-      ]
+      "fg": [ "t_LIXA_laser_corner_nw", "t_LIXA_laser_corner_ne", "t_LIXA_laser_corner_se", "t_LIXA_laser_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "t_metal_floor_center",
       "fg": [
         "t_LIXA_laser_t_connection_n",
-        "t_LIXA_laser_t_connection_w",
+        "t_LIXA_laser_t_connection_e",
         "t_LIXA_laser_t_connection_s",
-        "t_LIXA_laser_t_connection_e"
+        "t_LIXA_laser_t_connection_w"
       ]
     },
     {
       "id": "edge",
       "bg": "t_metal_floor_center",
-      "fg": [
-        "t_LIXA_laser_t_connection_w",
-        "t_LIXA_laser_t_connection_n"
-      ]
+      "fg": [ "t_LIXA_laser_t_connection_w", "t_LIXA_laser_t_connection_n" ]
     },
     {
       "id": "end_piece",
       "bg": "t_metal_floor_center",
-      "fg": [
-        "t_LIXA_laser_end_piece_n",
-        "t_LIXA_laser_end_piece_w",
-        "t_LIXA_laser_end_piece_s",
-        "t_LIXA_laser_end_piece_e"
-      ]
+      "fg": [ "t_LIXA_laser_end_piece_n", "t_LIXA_laser_end_piece_e", "t_LIXA_laser_end_piece_s", "t_LIXA_laser_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "bg": "t_metal_floor_center",
-      "fg": "t_LIXA_laser_center"
-    }
+    { "id": "unconnected", "bg": "t_metal_floor_center", "fg": "t_LIXA_laser_center" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_LIXA_tube/t_LIXA_tube.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_LIXA_tube/t_LIXA_tube.json
@@ -7,22 +7,12 @@
     {
       "id": "t_connection",
       "bg": "t_metal_floor_center",
-      "fg": [
-        "t_LIXA_tube_n",
-        "t_LIXA_tube_w",
-        "t_LIXA_tube_s",
-        "t_LIXA_tube_e"
-      ]
+      "fg": [ "t_LIXA_tube_n", "t_LIXA_tube_e", "t_LIXA_tube_s", "t_LIXA_tube_w" ]
     },
     {
       "id": "end_piece",
       "bg": "t_metal_floor_center",
-      "fg": [
-        "t_LIXA_tube_n",
-        "t_LIXA_tube_w",
-        "t_LIXA_tube_s",
-        "t_LIXA_tube_e"
-      ]
+      "fg": [ "t_LIXA_tube_n", "t_LIXA_tube_e", "t_LIXA_tube_s", "t_LIXA_tube_w" ]
     }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_LIXA_unfolded_tube/t_LIXA_unfolded_tube.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_LIXA_unfolded_tube/t_LIXA_unfolded_tube.json
@@ -7,22 +7,12 @@
     {
       "id": "t_connection",
       "bg": "t_thconc_floor_center",
-      "fg": [
-        "t_LIXA_unfolded_tube_n",
-        "t_LIXA_unfolded_tube_w",
-        "t_LIXA_unfolded_tube_s",
-        "t_LIXA_unfolded_tube_e"
-      ]
+      "fg": [ "t_LIXA_unfolded_tube_n", "t_LIXA_unfolded_tube_e", "t_LIXA_unfolded_tube_s", "t_LIXA_unfolded_tube_w" ]
     },
     {
       "id": "end_piece",
       "bg": "t_thconc_floor_center",
-      "fg": [
-        "t_LIXA_unfolded_tube_n",
-        "t_LIXA_unfolded_tube_w",
-        "t_LIXA_unfolded_tube_s",
-        "t_LIXA_unfolded_tube_e"
-      ]
+      "fg": [ "t_LIXA_unfolded_tube_n", "t_LIXA_unfolded_tube_e", "t_LIXA_unfolded_tube_s", "t_LIXA_unfolded_tube_w" ]
     }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_LIXA_unfolded_tube_broken/t_LIXA_unfolded_tube_broken.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_LIXA_unfolded_tube_broken/t_LIXA_unfolded_tube_broken.json
@@ -9,9 +9,9 @@
       "bg": "t_thconc_floor_center",
       "fg": [
         "t_LIXA_unfolded_tube_broken_n",
-        "t_LIXA_unfolded_tube_broken_w",
+        "t_LIXA_unfolded_tube_broken_e",
         "t_LIXA_unfolded_tube_broken_s",
-        "t_LIXA_unfolded_tube_broken_e"
+        "t_LIXA_unfolded_tube_broken_w"
       ]
     },
     {
@@ -19,9 +19,9 @@
       "bg": "t_thconc_floor_center",
       "fg": [
         "t_LIXA_unfolded_tube_broken_n",
-        "t_LIXA_unfolded_tube_broken_w",
+        "t_LIXA_unfolded_tube_broken_e",
         "t_LIXA_unfolded_tube_broken_s",
-        "t_LIXA_unfolded_tube_broken_e"
+        "t_LIXA_unfolded_tube_broken_w"
       ]
     }
   ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_adobe_brick_wall/t_adobe_brick_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_adobe_brick_wall/t_adobe_brick_wall.json
@@ -9,18 +9,18 @@
         "id": "corner",
         "fg": [
           "t_adobe_brick_wall_corner_nw",
-          "t_adobe_brick_wall_corner_sw",
+          "t_adobe_brick_wall_corner_ne",
           "t_adobe_brick_wall_corner_se",
-          "t_adobe_brick_wall_corner_ne"
+          "t_adobe_brick_wall_corner_sw"
         ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_adobe_brick_wall_t_connection_n",
-          "t_adobe_brick_wall_t_connection_w",
+          "t_adobe_brick_wall_t_connection_e",
           "t_adobe_brick_wall_t_connection_s",
-          "t_adobe_brick_wall_t_connection_e"
+          "t_adobe_brick_wall_t_connection_w"
         ]
       },
       { "id": "edge", "fg": [ "t_adobe_brick_wall_edge_ns", "t_adobe_brick_wall_edge_ew" ] },
@@ -28,9 +28,9 @@
         "id": "end_piece",
         "fg": [
           "t_adobe_brick_wall_end_piece_n",
-          "t_adobe_brick_wall_end_piece_w",
+          "t_adobe_brick_wall_end_piece_e",
           "t_adobe_brick_wall_end_piece_s",
-          "t_adobe_brick_wall_end_piece_e"
+          "t_adobe_brick_wall_end_piece_w"
         ]
       },
       { "id": "unconnected", "fg": [ "t_adobe_brick_wall_unconnected", "t_adobe_brick_wall_unconnected" ] }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_adobe_brick_wall_halfway/t_adobe_brick_wall_halfway.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_adobe_brick_wall_halfway/t_adobe_brick_wall_halfway.json
@@ -9,18 +9,18 @@
         "id": "corner",
         "fg": [
           "t_adobe_brick_wall_halfway_corner_nw",
-          "t_adobe_brick_wall_halfway_corner_sw",
+          "t_adobe_brick_wall_halfway_corner_ne",
           "t_adobe_brick_wall_halfway_corner_se",
-          "t_adobe_brick_wall_halfway_corner_ne"
+          "t_adobe_brick_wall_halfway_corner_sw"
         ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_adobe_brick_wall_halfway_t_connection_n",
-          "t_adobe_brick_wall_halfway_t_connection_w",
+          "t_adobe_brick_wall_halfway_t_connection_e",
           "t_adobe_brick_wall_halfway_t_connection_s",
-          "t_adobe_brick_wall_halfway_t_connection_e"
+          "t_adobe_brick_wall_halfway_t_connection_w"
         ]
       },
       { "id": "edge", "fg": [ "t_adobe_brick_wall_halfway_edge_ns", "t_adobe_brick_wall_halfway_edge_ew" ] },
@@ -28,9 +28,9 @@
         "id": "end_piece",
         "fg": [
           "t_adobe_brick_wall_halfway_end_piece_n",
-          "t_adobe_brick_wall_halfway_end_piece_w",
+          "t_adobe_brick_wall_halfway_end_piece_e",
           "t_adobe_brick_wall_halfway_end_piece_s",
-          "t_adobe_brick_wall_halfway_end_piece_e"
+          "t_adobe_brick_wall_halfway_end_piece_w"
         ]
       },
       {

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_brick_roof/t_brick_roof.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_brick_roof/t_brick_roof.json
@@ -3,47 +3,25 @@
   "fg": "t_brick_roof_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_brick_roof_center"
-    },
+    { "id": "center", "fg": "t_brick_roof_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_brick_roof_corner_nw",
-        "t_brick_roof_corner_sw",
-        "t_brick_roof_corner_se",
-        "t_brick_roof_corner_ne"
-      ]
+      "fg": [ "t_brick_roof_corner_nw", "t_brick_roof_corner_ne", "t_brick_roof_corner_se", "t_brick_roof_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_brick_roof_t_connection_n",
-        "t_brick_roof_t_connection_w",
+        "t_brick_roof_t_connection_e",
         "t_brick_roof_t_connection_s",
-        "t_brick_roof_t_connection_e"
+        "t_brick_roof_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_brick_roof_edge_ns",
-        "t_brick_roof_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_brick_roof_edge_ns", "t_brick_roof_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_brick_roof_end_piece_n",
-        "t_brick_roof_end_piece_w",
-        "t_brick_roof_end_piece_s",
-        "t_brick_roof_end_piece_e"
-      ]
+      "fg": [ "t_brick_roof_end_piece_n", "t_brick_roof_end_piece_e", "t_brick_roof_end_piece_s", "t_brick_roof_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_brick_roof_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_brick_roof_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_brick_wall/t_brick_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_brick_wall/t_brick_wall.json
@@ -4,53 +4,28 @@
   "fg": "t_brick_wall_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_brick_wall_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_brick_wall_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_brick_wall_corner_nw",
-        "t_brick_wall_corner_sw",
-        "t_brick_wall_corner_se",
-        "t_brick_wall_corner_ne"
-      ]
+      "fg": [ "t_brick_wall_corner_nw", "t_brick_wall_corner_ne", "t_brick_wall_corner_se", "t_brick_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_brick_wall_t_connection_n",
-        "t_brick_wall_t_connection_w",
+        "t_brick_wall_t_connection_e",
         "t_brick_wall_t_connection_s",
-        "t_brick_wall_t_connection_e"
+        "t_brick_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_brick_wall_edge_ns",
-        "t_brick_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_brick_wall_edge_ns", "t_brick_wall_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_brick_wall_end_piece_n",
-        "t_brick_wall_end_piece_w",
-        "t_brick_wall_end_piece_s",
-        "t_brick_wall_end_piece_e"
-      ]
+      "fg": [ "t_brick_wall_end_piece_n", "t_brick_wall_end_piece_e", "t_brick_wall_end_piece_s", "t_brick_wall_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_brick_wall_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_brick_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_brick_wall_halfway/t_brick_wall_halfway.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_brick_wall_halfway/t_brick_wall_halfway.json
@@ -9,18 +9,18 @@
         "id": "corner",
         "fg": [
           "t_brick_wall_halfway_corner_nw",
-          "t_brick_wall_halfway_corner_sw",
+          "t_brick_wall_halfway_corner_ne",
           "t_brick_wall_halfway_corner_se",
-          "t_brick_wall_halfway_corner_ne"
+          "t_brick_wall_halfway_corner_sw"
         ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_brick_wall_halfway_t_connection_n",
-          "t_brick_wall_halfway_t_connection_w",
+          "t_brick_wall_halfway_t_connection_e",
           "t_brick_wall_halfway_t_connection_s",
-          "t_brick_wall_halfway_t_connection_e"
+          "t_brick_wall_halfway_t_connection_w"
         ]
       },
       { "id": "edge", "fg": [ "t_brick_wall_halfway_edge_ns", "t_brick_wall_halfway_edge_ew" ] },
@@ -28,9 +28,9 @@
         "id": "end_piece",
         "fg": [
           "t_brick_wall_halfway_end_piece_n",
-          "t_brick_wall_halfway_end_piece_w",
+          "t_brick_wall_halfway_end_piece_e",
           "t_brick_wall_halfway_end_piece_s",
-          "t_brick_wall_halfway_end_piece_e"
+          "t_brick_wall_halfway_end_piece_w"
         ]
       },
       { "id": "unconnected", "fg": [ "t_brick_wall_halfway_unconnected", "t_brick_wall_halfway_unconnected" ] }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_bridge/t_bridge.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_bridge/t_bridge.json
@@ -4,56 +4,23 @@
   "fg": "t_bridge_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_bridge_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_bridge_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_bridge_corner_nw",
-        "t_bridge_corner_sw",
-        "t_bridge_corner_se",
-        "t_bridge_corner_ne"
-      ]
+      "fg": [ "t_bridge_corner_nw", "t_bridge_corner_ne", "t_bridge_corner_se", "t_bridge_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "t_bridge_t_connection_n",
-        "t_bridge_t_connection_w",
-        "t_bridge_t_connection_s",
-        "t_bridge_t_connection_e"
-      ]
+      "fg": [ "t_bridge_t_connection_n", "t_bridge_t_connection_e", "t_bridge_t_connection_s", "t_bridge_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_bridge_edge_ns",
-        "t_bridge_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_bridge_edge_ns", "t_bridge_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_bridge_end_piece_n",
-        "t_bridge_end_piece_w",
-        "t_bridge_end_piece_s",
-        "t_bridge_end_piece_e"
-      ]
+      "fg": [ "t_bridge_end_piece_n", "t_bridge_end_piece_e", "t_bridge_end_piece_s", "t_bridge_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [
-        "t_bridge_unconnected",
-        "t_bridge_unconnected"
-      ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "t_bridge_unconnected", "t_bridge_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_carpet_green/t_carpet_green.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_carpet_green/t_carpet_green.json
@@ -8,54 +8,38 @@
       "id": "center",
       "bg": "",
       "fg": [
-          { "weight": 1, "sprite": "t_carpet_green_center" },
-          { "weight": 1, "sprite": "t_carpet_green_center2" },
-          { "weight": 1, "sprite": "t_carpet_green_center3" },
-          { "weight": 1, "sprite": "t_carpet_green_center4" }
+        { "weight": 1, "sprite": "t_carpet_green_center" },
+        { "weight": 1, "sprite": "t_carpet_green_center2" },
+        { "weight": 1, "sprite": "t_carpet_green_center3" },
+        { "weight": 1, "sprite": "t_carpet_green_center4" }
       ]
     },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_carpet_green_corner_nw",
-        "t_carpet_green_corner_sw",
-        "t_carpet_green_corner_se",
-        "t_carpet_green_corner_ne"
-      ]
+      "fg": [ "t_carpet_green_corner_nw", "t_carpet_green_corner_ne", "t_carpet_green_corner_se", "t_carpet_green_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_carpet_green_t_connection_n",
-        "t_carpet_green_t_connection_w",
+        "t_carpet_green_t_connection_e",
         "t_carpet_green_t_connection_s",
-        "t_carpet_green_t_connection_e"
+        "t_carpet_green_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_carpet_green_edge_ns",
-        "t_carpet_green_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_carpet_green_edge_ns", "t_carpet_green_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "t_carpet_green_end_piece_n",
-        "t_carpet_green_end_piece_w",
+        "t_carpet_green_end_piece_e",
         "t_carpet_green_end_piece_s",
-        "t_carpet_green_end_piece_e"
+        "t_carpet_green_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_carpet_green_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_carpet_green_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_carpet_purple/t_carpet_purple.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_carpet_purple/t_carpet_purple.json
@@ -8,54 +8,38 @@
       "id": "center",
       "bg": "",
       "fg": [
-          { "weight": 1, "sprite": "t_carpet_purple_center" },
-          { "weight": 1, "sprite": "t_carpet_purple_center2" },
-          { "weight": 1, "sprite": "t_carpet_purple_center3" },
-          { "weight": 1, "sprite": "t_carpet_purple_center4" }
+        { "weight": 1, "sprite": "t_carpet_purple_center" },
+        { "weight": 1, "sprite": "t_carpet_purple_center2" },
+        { "weight": 1, "sprite": "t_carpet_purple_center3" },
+        { "weight": 1, "sprite": "t_carpet_purple_center4" }
       ]
     },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_carpet_purple_corner_nw",
-        "t_carpet_purple_corner_sw",
-        "t_carpet_purple_corner_se",
-        "t_carpet_purple_corner_ne"
-      ]
+      "fg": [ "t_carpet_purple_corner_nw", "t_carpet_purple_corner_ne", "t_carpet_purple_corner_se", "t_carpet_purple_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_carpet_purple_t_connection_n",
-        "t_carpet_purple_t_connection_w",
+        "t_carpet_purple_t_connection_e",
         "t_carpet_purple_t_connection_s",
-        "t_carpet_purple_t_connection_e"
+        "t_carpet_purple_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_carpet_purple_edge_ns",
-        "t_carpet_purple_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_carpet_purple_edge_ns", "t_carpet_purple_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "t_carpet_purple_end_piece_n",
-        "t_carpet_purple_end_piece_w",
+        "t_carpet_purple_end_piece_e",
         "t_carpet_purple_end_piece_s",
-        "t_carpet_purple_end_piece_e"
+        "t_carpet_purple_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_carpet_purple_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_carpet_purple_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_carpet_red/t_carpet_red.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_carpet_red/t_carpet_red.json
@@ -1,62 +1,40 @@
 [
   {
     "id": [
-    "t_carpet_red",
-    "t_carpet_base_linoleum_white",
-    "t_carpet_base_primitive",
-    "t_carpet_base_linoleum_gray",
-    "t_carpet_base",
-    "t_carpet_base_strconcrete",
-    "t_carpet_base_rock",
-    "t_carpet_base_concrete",
-    "t_carpet_base_metal",
-    "t_carpet_base_wood"
+      "t_carpet_red",
+      "t_carpet_base_linoleum_white",
+      "t_carpet_base_primitive",
+      "t_carpet_base_linoleum_gray",
+      "t_carpet_base",
+      "t_carpet_base_strconcrete",
+      "t_carpet_base_rock",
+      "t_carpet_base_concrete",
+      "t_carpet_base_metal",
+      "t_carpet_base_wood"
     ],
     "multitile": true,
     "fg": "t_carpet_red_unconnected",
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_carpet_red_center"
-      },
+      { "id": "center", "fg": "t_carpet_red_center" },
       {
         "id": "corner",
-        "fg": [
-        "t_carpet_red_corner_nw",
-        "t_carpet_red_corner_sw",
-        "t_carpet_red_corner_se",
-        "t_carpet_red_corner_ne"
-        ]
+        "fg": [ "t_carpet_red_corner_nw", "t_carpet_red_corner_ne", "t_carpet_red_corner_se", "t_carpet_red_corner_sw" ]
       },
       {
         "id": "t_connection",
         "fg": [
-        "t_carpet_red_t_connection_n",
-        "t_carpet_red_t_connection_w",
-        "t_carpet_red_t_connection_s",
-        "t_carpet_red_t_connection_e"
+          "t_carpet_red_t_connection_n",
+          "t_carpet_red_t_connection_e",
+          "t_carpet_red_t_connection_s",
+          "t_carpet_red_t_connection_w"
         ]
       },
-      {
-        "id": "edge",
-        "fg": [
-        "t_carpet_red_edge_ns",
-        "t_carpet_red_edge_ew"
-        ]
-      },
+      { "id": "edge", "fg": [ "t_carpet_red_edge_ns", "t_carpet_red_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [
-        "t_carpet_red_end_piece_n",
-        "t_carpet_red_end_piece_w",
-        "t_carpet_red_end_piece_s",
-        "t_carpet_red_end_piece_e"
-        ]
+        "fg": [ "t_carpet_red_end_piece_n", "t_carpet_red_end_piece_e", "t_carpet_red_end_piece_s", "t_carpet_red_end_piece_w" ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_carpet_red_unconnected"
-      }
+      { "id": "unconnected", "fg": "t_carpet_red_unconnected" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_carpet_yellow/t_carpet_yellow.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_carpet_yellow/t_carpet_yellow.json
@@ -4,53 +4,33 @@
   "fg": "t_carpet_yellow_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_carpet_yellow_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_carpet_yellow_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_carpet_yellow_corner_nw",
-        "t_carpet_yellow_corner_sw",
-        "t_carpet_yellow_corner_se",
-        "t_carpet_yellow_corner_ne"
-      ]
+      "fg": [ "t_carpet_yellow_corner_nw", "t_carpet_yellow_corner_ne", "t_carpet_yellow_corner_se", "t_carpet_yellow_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_carpet_yellow_t_connection_n",
-        "t_carpet_yellow_t_connection_w",
+        "t_carpet_yellow_t_connection_e",
         "t_carpet_yellow_t_connection_s",
-        "t_carpet_yellow_t_connection_e"
+        "t_carpet_yellow_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_carpet_yellow_edge_ns",
-        "t_carpet_yellow_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_carpet_yellow_edge_ns", "t_carpet_yellow_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "t_carpet_yellow_end_piece_n",
-        "t_carpet_yellow_end_piece_w",
+        "t_carpet_yellow_end_piece_e",
         "t_carpet_yellow_end_piece_s",
-        "t_carpet_yellow_end_piece_e"
+        "t_carpet_yellow_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_carpet_yellow_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_carpet_yellow_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_chainfence/t_chainfence.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_chainfence/t_chainfence.json
@@ -1,117 +1,68 @@
-[{
-  "id": "t_chainfence",
-  "fg": "t_chainfence_unconnected",
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_chainfence_center",
-      "bg": "t_pavement"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_chainfence_corner_nw",
-        "t_chainfence_corner_sw",
-        "t_chainfence_corner_se",
-        "t_chainfence_corner_ne"
-      ],
-      "bg": "t_pavement"
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "t_chainfence_t_connection_n",
-        "t_chainfence_t_connection_w",
-        "t_chainfence_t_connection_s",
-        "t_chainfence_t_connection_e"
-      ],
-      "bg": "t_pavement"
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "t_chainfence_edge_ns",
-        "t_chainfence_edge_ew"
-      ],
-      "bg": "t_pavement"
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "t_chainfence_end_piece_n",
-        "t_chainfence_end_piece_w",
-        "t_chainfence_end_piece_s",
-        "t_chainfence_end_piece_e"
-      ],
-      "bg": "t_pavement"
-    },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_chainfence_unconnected",
-        "t_chainfence_unconnected"
-      ],
-      "bg": "t_pavement"
-    }
-  ],
-  "bg": "t_pavement"
-}, {
-  "id": "t_chainfence_season_winter",
-  "fg": "t_chainfence_unconnected",
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_chainfence_center",
-      "bg": "snow_shallow_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_chainfence_corner_nw",
-        "t_chainfence_corner_sw",
-        "t_chainfence_corner_se",
-        "t_chainfence_corner_ne"
-      ],
-      "bg": "snow_shallow_center"
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "t_chainfence_t_connection_n",
-        "t_chainfence_t_connection_w",
-        "t_chainfence_t_connection_s",
-        "t_chainfence_t_connection_e"
-      ],
-      "bg": "snow_shallow_center"
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "t_chainfence_edge_ns",
-        "t_chainfence_edge_ew"
-      ],
-      "bg": "snow_shallow_center"
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "t_chainfence_end_piece_n",
-        "t_chainfence_end_piece_w",
-        "t_chainfence_end_piece_s",
-        "t_chainfence_end_piece_e"
-      ],
-      "bg": "snow_shallow_center"
-    },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_chainfence_unconnected",
-        "t_chainfence_unconnected"
-      ],
-      "bg": "snow_shallow_center"
-    }
-  ],
-  "bg": "snow_shallow_center"
-}]
+[
+  {
+    "id": "t_chainfence",
+    "fg": "t_chainfence_unconnected",
+    "multitile": true,
+    "additional_tiles": [
+      { "id": "center", "fg": "t_chainfence_center", "bg": "t_pavement" },
+      {
+        "id": "corner",
+        "fg": [ "t_chainfence_corner_nw", "t_chainfence_corner_ne", "t_chainfence_corner_se", "t_chainfence_corner_sw" ],
+        "bg": "t_pavement"
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_chainfence_t_connection_n",
+          "t_chainfence_t_connection_e",
+          "t_chainfence_t_connection_s",
+          "t_chainfence_t_connection_w"
+        ],
+        "bg": "t_pavement"
+      },
+      { "id": "edge", "fg": [ "t_chainfence_edge_ns", "t_chainfence_edge_ew" ], "bg": "t_pavement" },
+      {
+        "id": "end_piece",
+        "fg": [ "t_chainfence_end_piece_n", "t_chainfence_end_piece_e", "t_chainfence_end_piece_s", "t_chainfence_end_piece_w" ],
+        "bg": "t_pavement"
+      },
+      { "id": "unconnected", "fg": [ "t_chainfence_unconnected", "t_chainfence_unconnected" ], "bg": "t_pavement" }
+    ],
+    "bg": "t_pavement"
+  },
+  {
+    "id": "t_chainfence_season_winter",
+    "fg": "t_chainfence_unconnected",
+    "multitile": true,
+    "additional_tiles": [
+      { "id": "center", "fg": "t_chainfence_center", "bg": "snow_shallow_center" },
+      {
+        "id": "corner",
+        "fg": [ "t_chainfence_corner_nw", "t_chainfence_corner_ne", "t_chainfence_corner_se", "t_chainfence_corner_sw" ],
+        "bg": "snow_shallow_center"
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_chainfence_t_connection_n",
+          "t_chainfence_t_connection_e",
+          "t_chainfence_t_connection_s",
+          "t_chainfence_t_connection_w"
+        ],
+        "bg": "snow_shallow_center"
+      },
+      { "id": "edge", "fg": [ "t_chainfence_edge_ns", "t_chainfence_edge_ew" ], "bg": "snow_shallow_center" },
+      {
+        "id": "end_piece",
+        "fg": [ "t_chainfence_end_piece_n", "t_chainfence_end_piece_e", "t_chainfence_end_piece_s", "t_chainfence_end_piece_w" ],
+        "bg": "snow_shallow_center"
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_chainfence_unconnected", "t_chainfence_unconnected" ],
+        "bg": "snow_shallow_center"
+      }
+    ],
+    "bg": "snow_shallow_center"
+  }
+]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_chickenwire_fence/t_chickenwire_fence.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_chickenwire_fence/t_chickenwire_fence.json
@@ -5,18 +5,14 @@
     "bg": "t_grass",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_chickenwire_fence_center",
-        "bg": "t_grass"
-      },
+      { "id": "center", "fg": "t_chickenwire_fence_center", "bg": "t_grass" },
       {
         "id": "corner",
         "fg": [
           "t_chickenwire_fence_corner_nw",
-          "t_chickenwire_fence_corner_sw",
+          "t_chickenwire_fence_corner_ne",
           "t_chickenwire_fence_corner_se",
-          "t_chickenwire_fence_corner_ne"
+          "t_chickenwire_fence_corner_sw"
         ],
         "bg": "t_grass"
       },
@@ -24,35 +20,24 @@
         "id": "t_connection",
         "fg": [
           "t_chickenwire_fence_t_connection_n",
-          "t_chickenwire_fence_t_connection_w",
+          "t_chickenwire_fence_t_connection_e",
           "t_chickenwire_fence_t_connection_s",
-          "t_chickenwire_fence_t_connection_e"
+          "t_chickenwire_fence_t_connection_w"
         ],
         "bg": "t_grass"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_chickenwire_fence_edge_ns",
-          "t_chickenwire_fence_edge_ew"
-        ],
-        "bg": "t_grass"
-      },
+      { "id": "edge", "fg": [ "t_chickenwire_fence_edge_ns", "t_chickenwire_fence_edge_ew" ], "bg": "t_grass" },
       {
         "id": "end_piece",
         "fg": [
           "t_chickenwire_fence_end_piece_n",
-          "t_chickenwire_fence_end_piece_w",
+          "t_chickenwire_fence_end_piece_e",
           "t_chickenwire_fence_end_piece_s",
-          "t_chickenwire_fence_end_piece_e"
+          "t_chickenwire_fence_end_piece_w"
         ],
         "bg": "t_grass"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_chickenwire_fence_unconnected",
-        "bg": "t_grass"
-      }
+      { "id": "unconnected", "fg": "t_chickenwire_fence_unconnected", "bg": "t_grass" }
     ]
   },
   {
@@ -61,18 +46,14 @@
     "bg": "t_grass_summer",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_chickenwire_fence_center",
-        "bg": "t_grass_summer"
-      },
+      { "id": "center", "fg": "t_chickenwire_fence_center", "bg": "t_grass_summer" },
       {
         "id": "corner",
         "fg": [
           "t_chickenwire_fence_corner_nw",
-          "t_chickenwire_fence_corner_sw",
+          "t_chickenwire_fence_corner_ne",
           "t_chickenwire_fence_corner_se",
-          "t_chickenwire_fence_corner_ne"
+          "t_chickenwire_fence_corner_sw"
         ],
         "bg": "t_grass_summer"
       },
@@ -80,35 +61,24 @@
         "id": "t_connection",
         "fg": [
           "t_chickenwire_fence_t_connection_n",
-          "t_chickenwire_fence_t_connection_w",
+          "t_chickenwire_fence_t_connection_e",
           "t_chickenwire_fence_t_connection_s",
-          "t_chickenwire_fence_t_connection_e"
+          "t_chickenwire_fence_t_connection_w"
         ],
         "bg": "t_grass_summer"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_chickenwire_fence_edge_ns",
-          "t_chickenwire_fence_edge_ew"
-        ],
-        "bg": "t_grass_summer"
-      },
+      { "id": "edge", "fg": [ "t_chickenwire_fence_edge_ns", "t_chickenwire_fence_edge_ew" ], "bg": "t_grass_summer" },
       {
         "id": "end_piece",
         "fg": [
           "t_chickenwire_fence_end_piece_n",
-          "t_chickenwire_fence_end_piece_w",
+          "t_chickenwire_fence_end_piece_e",
           "t_chickenwire_fence_end_piece_s",
-          "t_chickenwire_fence_end_piece_e"
+          "t_chickenwire_fence_end_piece_w"
         ],
         "bg": "t_grass_summer"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_chickenwire_fence_unconnected",
-        "bg": "t_grass_summer"
-      }
+      { "id": "unconnected", "fg": "t_chickenwire_fence_unconnected", "bg": "t_grass_summer" }
     ]
   },
   {
@@ -117,18 +87,14 @@
     "bg": "t_grass_autumn",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_chickenwire_fence_center",
-        "bg": "t_grass_autumn"
-      },
+      { "id": "center", "fg": "t_chickenwire_fence_center", "bg": "t_grass_autumn" },
       {
         "id": "corner",
         "fg": [
           "t_chickenwire_fence_corner_nw",
-          "t_chickenwire_fence_corner_sw",
+          "t_chickenwire_fence_corner_ne",
           "t_chickenwire_fence_corner_se",
-          "t_chickenwire_fence_corner_ne"
+          "t_chickenwire_fence_corner_sw"
         ],
         "bg": "t_grass_autumn"
       },
@@ -136,35 +102,24 @@
         "id": "t_connection",
         "fg": [
           "t_chickenwire_fence_t_connection_n",
-          "t_chickenwire_fence_t_connection_w",
+          "t_chickenwire_fence_t_connection_e",
           "t_chickenwire_fence_t_connection_s",
-          "t_chickenwire_fence_t_connection_e"
+          "t_chickenwire_fence_t_connection_w"
         ],
         "bg": "t_grass_autumn"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_chickenwire_fence_edge_ns",
-          "t_chickenwire_fence_edge_ew"
-        ],
-        "bg": "t_grass_autumn"
-      },
+      { "id": "edge", "fg": [ "t_chickenwire_fence_edge_ns", "t_chickenwire_fence_edge_ew" ], "bg": "t_grass_autumn" },
       {
         "id": "end_piece",
         "fg": [
           "t_chickenwire_fence_end_piece_n",
-          "t_chickenwire_fence_end_piece_w",
+          "t_chickenwire_fence_end_piece_e",
           "t_chickenwire_fence_end_piece_s",
-          "t_chickenwire_fence_end_piece_e"
+          "t_chickenwire_fence_end_piece_w"
         ],
         "bg": "t_grass_autumn"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_chickenwire_fence_unconnected",
-        "bg": "t_grass_autumn"
-      }
+      { "id": "unconnected", "fg": "t_chickenwire_fence_unconnected", "bg": "t_grass_autumn" }
     ]
   },
   {
@@ -173,18 +128,14 @@
     "bg": "snow_shallow_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_chickenwire_fence_center",
-        "bg": "snow_shallow_center"
-      },
+      { "id": "center", "fg": "t_chickenwire_fence_center", "bg": "snow_shallow_center" },
       {
         "id": "corner",
         "fg": [
           "t_chickenwire_fence_corner_nw",
-          "t_chickenwire_fence_corner_sw",
+          "t_chickenwire_fence_corner_ne",
           "t_chickenwire_fence_corner_se",
-          "t_chickenwire_fence_corner_ne"
+          "t_chickenwire_fence_corner_sw"
         ],
         "bg": "snow_shallow_center"
       },
@@ -192,35 +143,28 @@
         "id": "t_connection",
         "fg": [
           "t_chickenwire_fence_t_connection_n",
-          "t_chickenwire_fence_t_connection_w",
+          "t_chickenwire_fence_t_connection_e",
           "t_chickenwire_fence_t_connection_s",
-          "t_chickenwire_fence_t_connection_e"
+          "t_chickenwire_fence_t_connection_w"
         ],
         "bg": "snow_shallow_center"
       },
       {
         "id": "edge",
-        "fg": [
-          "t_chickenwire_fence_edge_ns",
-          "t_chickenwire_fence_edge_ew"
-        ],
+        "fg": [ "t_chickenwire_fence_edge_ns", "t_chickenwire_fence_edge_ew" ],
         "bg": "snow_shallow_center"
       },
       {
         "id": "end_piece",
         "fg": [
           "t_chickenwire_fence_end_piece_n",
-          "t_chickenwire_fence_end_piece_w",
+          "t_chickenwire_fence_end_piece_e",
           "t_chickenwire_fence_end_piece_s",
-          "t_chickenwire_fence_end_piece_e"
+          "t_chickenwire_fence_end_piece_w"
         ],
         "bg": "snow_shallow_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_chickenwire_fence_unconnected",
-        "bg": "snow_shallow_center"
-      }
+      { "id": "unconnected", "fg": "t_chickenwire_fence_unconnected", "bg": "snow_shallow_center" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_clay/t_clay.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_clay/t_clay.json
@@ -8,18 +8,18 @@
       { "id": "center", "fg": "t_clay_center", "bg": "t_grass" },
       {
         "id": "corner",
-        "fg": [ "t_clay_corner_nw", "t_clay_corner_sw", "t_clay_corner_se", "t_clay_corner_ne" ],
+        "fg": [ "t_clay_corner_nw", "t_clay_corner_ne", "t_clay_corner_se", "t_clay_corner_sw" ],
         "bg": "t_grass"
       },
       {
         "id": "t_connection",
-        "fg": [ "t_clay_t_connection_n", "t_clay_t_connection_w", "t_clay_t_connection_s", "t_clay_t_connection_e" ],
+        "fg": [ "t_clay_t_connection_n", "t_clay_t_connection_e", "t_clay_t_connection_s", "t_clay_t_connection_w" ],
         "bg": "t_grass"
       },
       { "id": "edge", "fg": [ "t_clay_edge_ns", "t_clay_edge_ew" ], "bg": "t_grass" },
       {
         "id": "end_piece",
-        "fg": [ "t_clay_end_piece_n", "t_clay_end_piece_w", "t_clay_end_piece_s", "t_clay_end_piece_e" ],
+        "fg": [ "t_clay_end_piece_n", "t_clay_end_piece_e", "t_clay_end_piece_s", "t_clay_end_piece_w" ],
         "bg": "t_grass"
       },
       { "id": "unconnected", "fg": "t_clay_unconnected", "bg": "t_grass" }
@@ -34,18 +34,18 @@
       { "id": "center", "fg": "t_clay_center", "bg": "t_grass_summer" },
       {
         "id": "corner",
-        "fg": [ "t_clay_corner_nw", "t_clay_corner_sw", "t_clay_corner_se", "t_clay_corner_ne" ],
+        "fg": [ "t_clay_corner_nw", "t_clay_corner_ne", "t_clay_corner_se", "t_clay_corner_sw" ],
         "bg": "t_grass_summer"
       },
       {
         "id": "t_connection",
-        "fg": [ "t_clay_t_connection_n", "t_clay_t_connection_w", "t_clay_t_connection_s", "t_clay_t_connection_e" ],
+        "fg": [ "t_clay_t_connection_n", "t_clay_t_connection_e", "t_clay_t_connection_s", "t_clay_t_connection_w" ],
         "bg": "t_grass_summer"
       },
       { "id": "edge", "fg": [ "t_clay_edge_ns", "t_clay_edge_ew" ], "bg": "t_grass_summer" },
       {
         "id": "end_piece",
-        "fg": [ "t_clay_end_piece_n", "t_clay_end_piece_w", "t_clay_end_piece_s", "t_clay_end_piece_e" ],
+        "fg": [ "t_clay_end_piece_n", "t_clay_end_piece_e", "t_clay_end_piece_s", "t_clay_end_piece_w" ],
         "bg": "t_grass_summer"
       },
       { "id": "unconnected", "fg": "t_clay_unconnected", "bg": "t_grass_summer" }
@@ -60,18 +60,18 @@
       { "id": "center", "fg": "t_clay_center", "bg": "t_grass_autumn" },
       {
         "id": "corner",
-        "fg": [ "t_clay_corner_nw", "t_clay_corner_sw", "t_clay_corner_se", "t_clay_corner_ne" ],
+        "fg": [ "t_clay_corner_nw", "t_clay_corner_ne", "t_clay_corner_se", "t_clay_corner_sw" ],
         "bg": "t_grass_autumn"
       },
       {
         "id": "t_connection",
-        "fg": [ "t_clay_t_connection_n", "t_clay_t_connection_w", "t_clay_t_connection_s", "t_clay_t_connection_e" ],
+        "fg": [ "t_clay_t_connection_n", "t_clay_t_connection_e", "t_clay_t_connection_s", "t_clay_t_connection_w" ],
         "bg": "t_grass_autumn"
       },
       { "id": "edge", "fg": [ "t_clay_edge_ns", "t_clay_edge_ew" ], "bg": "t_grass_autumn" },
       {
         "id": "end_piece",
-        "fg": [ "t_clay_end_piece_n", "t_clay_end_piece_w", "t_clay_end_piece_s", "t_clay_end_piece_e" ],
+        "fg": [ "t_clay_end_piece_n", "t_clay_end_piece_e", "t_clay_end_piece_s", "t_clay_end_piece_w" ],
         "bg": "t_grass_autumn"
       },
       { "id": "unconnected", "fg": "t_clay_unconnected", "bg": "t_grass_autumn" }
@@ -86,24 +86,24 @@
       { "id": "center", "fg": "t_clay_center", "bg": "snow_shallow_center" },
       {
         "id": "corner",
-        "fg": [ "t_clay_corner_nw", "t_clay_corner_sw", "t_clay_corner_se", "t_clay_corner_ne" ],
+        "fg": [ "t_clay_corner_nw", "t_clay_corner_ne", "t_clay_corner_se", "t_clay_corner_sw" ],
         "bg": "snow_shallow_center"
       },
       {
         "id": "t_connection",
-        "fg": [ "t_clay_t_connection_n", "t_clay_t_connection_w", "t_clay_t_connection_s", "t_clay_t_connection_e" ],
+        "fg": [ "t_clay_t_connection_n", "t_clay_t_connection_e", "t_clay_t_connection_s", "t_clay_t_connection_w" ],
         "bg": "snow_shallow_center"
       },
       { "id": "edge", "fg": [ "t_clay_edge_ns", "t_clay_edge_ew" ], "bg": "snow_shallow_center" },
       {
         "id": "end_piece",
-        "fg": [ "t_clay_end_piece_n", "t_clay_end_piece_w", "t_clay_end_piece_s", "t_clay_end_piece_e" ],
+        "fg": [ "t_clay_end_piece_n", "t_clay_end_piece_e", "t_clay_end_piece_s", "t_clay_end_piece_w" ],
         "bg": "snow_shallow_center"
       },
       { "bg": "snow_shallow_center", "id": "unconnected", "fg": "t_clay_unconnected" }
     ]
   },
-   {
+  {
     "id": "t_clay_underground",
     "multitile": true,
     "fg": "t_clay_unconnected",
@@ -112,18 +112,18 @@
       { "id": "center", "fg": "t_clay_center", "bg": "t_rock_floor_center" },
       {
         "id": "corner",
-        "fg": [ "t_clay_corner_nw", "t_clay_corner_sw", "t_clay_corner_se", "t_clay_corner_ne" ],
+        "fg": [ "t_clay_corner_nw", "t_clay_corner_ne", "t_clay_corner_se", "t_clay_corner_sw" ],
         "bg": "t_rock_floor_center"
       },
       {
         "id": "t_connection",
-        "fg": [ "t_clay_t_connection_n", "t_clay_t_connection_w", "t_clay_t_connection_s", "t_clay_t_connection_e" ],
+        "fg": [ "t_clay_t_connection_n", "t_clay_t_connection_e", "t_clay_t_connection_s", "t_clay_t_connection_w" ],
         "bg": "t_rock_floor_center"
       },
       { "id": "edge", "fg": [ "t_clay_edge_ns", "t_clay_edge_ew" ], "bg": "t_rock_floor_center" },
       {
         "id": "end_piece",
-        "fg": [ "t_clay_end_piece_n", "t_clay_end_piece_w", "t_clay_end_piece_s", "t_clay_end_piece_e" ],
+        "fg": [ "t_clay_end_piece_n", "t_clay_end_piece_e", "t_clay_end_piece_s", "t_clay_end_piece_w" ],
         "bg": "t_rock_floor_center"
       },
       { "id": "unconnected", "fg": "t_clay_unconnected", "bg": "t_rock_floor_center" }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete/t_concrete.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete/t_concrete.json
@@ -9,18 +9,18 @@
       {
         "id": "corner",
         "bg": "",
-        "fg": [ "t_concrete_corner_nw", "t_concrete_corner_sw", "t_concrete_corner_se", "t_concrete_corner_ne" ]
+        "fg": [ "t_concrete_corner_nw", "t_concrete_corner_ne", "t_concrete_corner_se", "t_concrete_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "",
-        "fg": [ "t_concrete_t_connection_n", "t_concrete_t_connection_w", "t_concrete_t_connection_s", "t_concrete_t_connection_e" ]
+        "fg": [ "t_concrete_t_connection_n", "t_concrete_t_connection_e", "t_concrete_t_connection_s", "t_concrete_t_connection_w" ]
       },
       { "id": "edge", "bg": "", "fg": [ "t_concrete_edge_ns", "t_concrete_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "",
-        "fg": [ "t_concrete_end_piece_n", "t_concrete_end_piece_w", "t_concrete_end_piece_s", "t_concrete_end_piece_e" ]
+        "fg": [ "t_concrete_end_piece_n", "t_concrete_end_piece_e", "t_concrete_end_piece_s", "t_concrete_end_piece_w" ]
       },
       { "bg": "", "id": "unconnected", "fg": "t_concrete_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall/t_concrete_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall/t_concrete_wall.json
@@ -3,50 +3,30 @@
   "fg": "t_concrete_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_concrete_wall_corner_nw",
-        "t_concrete_wall_corner_sw",
-        "t_concrete_wall_corner_se",
-        "t_concrete_wall_corner_ne"
-      ]
+      "fg": [ "t_concrete_wall_corner_nw", "t_concrete_wall_corner_ne", "t_concrete_wall_corner_se", "t_concrete_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_t_connection_n",
-        "t_concrete_wall_t_connection_w",
+        "t_concrete_wall_t_connection_e",
         "t_concrete_wall_t_connection_s",
-        "t_concrete_wall_t_connection_e"
+        "t_concrete_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_edge_ns",
-        "t_concrete_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_edge_ns", "t_concrete_wall_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_end_piece_n",
-        "t_concrete_wall_end_piece_w",
+        "t_concrete_wall_end_piece_e",
         "t_concrete_wall_end_piece_s",
-        "t_concrete_wall_end_piece_e"
+        "t_concrete_wall_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_concrete_wall_unconnected",
-        "t_concrete_wall_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_concrete_wall_unconnected", "t_concrete_wall_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_Pi/t_concrete_wall_Pi.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_Pi/t_concrete_wall_Pi.json
@@ -3,47 +3,35 @@
   "fg": "t_concrete_wall_Pi_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_Pi_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_Pi_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_Pi_corner_nw",
-        "t_concrete_wall_Pi_corner_sw",
+        "t_concrete_wall_Pi_corner_ne",
         "t_concrete_wall_Pi_corner_se",
-        "t_concrete_wall_Pi_corner_ne"
+        "t_concrete_wall_Pi_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_Pi_t_connection_n",
-        "t_concrete_wall_Pi_t_connection_w",
+        "t_concrete_wall_Pi_t_connection_e",
         "t_concrete_wall_Pi_t_connection_s",
-        "t_concrete_wall_Pi_t_connection_e"
+        "t_concrete_wall_Pi_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_Pi_edge_ns",
-        "t_concrete_wall_Pi_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_Pi_edge_ns", "t_concrete_wall_Pi_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_Pi_end_piece_n",
-        "t_concrete_wall_Pi_end_piece_w",
+        "t_concrete_wall_Pi_end_piece_e",
         "t_concrete_wall_Pi_end_piece_s",
-        "t_concrete_wall_Pi_end_piece_e"
+        "t_concrete_wall_Pi_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_concrete_wall_Pi_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_concrete_wall_Pi_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_b/t_concrete_wall_b.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_b/t_concrete_wall_b.json
@@ -3,47 +3,35 @@
   "fg": "t_concrete_wall_b_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_b_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_b_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_b_corner_nw",
-        "t_concrete_wall_b_corner_sw",
+        "t_concrete_wall_b_corner_ne",
         "t_concrete_wall_b_corner_se",
-        "t_concrete_wall_b_corner_ne"
+        "t_concrete_wall_b_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_b_t_connection_n",
-        "t_concrete_wall_b_t_connection_w",
+        "t_concrete_wall_b_t_connection_e",
         "t_concrete_wall_b_t_connection_s",
-        "t_concrete_wall_b_t_connection_e"
+        "t_concrete_wall_b_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_b_edge_ns",
-        "t_concrete_wall_b_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_b_edge_ns", "t_concrete_wall_b_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_b_end_piece_n",
-        "t_concrete_wall_b_end_piece_w",
+        "t_concrete_wall_b_end_piece_e",
         "t_concrete_wall_b_end_piece_s",
-        "t_concrete_wall_b_end_piece_e"
+        "t_concrete_wall_b_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_concrete_wall_b_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_concrete_wall_b_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_b/t_concrete_wall_cyan.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_b/t_concrete_wall_cyan.json
@@ -3,50 +3,35 @@
   "fg": "t_concrete_wall_cyan_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_cyan_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_cyan_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_cyan_corner_nw",
-        "t_concrete_wall_cyan_corner_sw",
+        "t_concrete_wall_cyan_corner_ne",
         "t_concrete_wall_cyan_corner_se",
-        "t_concrete_wall_cyan_corner_ne"
+        "t_concrete_wall_cyan_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_cyan_t_connection_n",
-        "t_concrete_wall_cyan_t_connection_w",
+        "t_concrete_wall_cyan_t_connection_e",
         "t_concrete_wall_cyan_t_connection_s",
-        "t_concrete_wall_cyan_t_connection_e"
+        "t_concrete_wall_cyan_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_cyan_edge_ns",
-        "t_concrete_wall_cyan_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_cyan_edge_ns", "t_concrete_wall_cyan_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_cyan_end_piece_n",
-        "t_concrete_wall_cyan_end_piece_w",
+        "t_concrete_wall_cyan_end_piece_e",
         "t_concrete_wall_cyan_end_piece_s",
-        "t_concrete_wall_cyan_end_piece_e"
+        "t_concrete_wall_cyan_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_concrete_wall_cyan_unconnected",
-        "t_concrete_wall_cyan_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_concrete_wall_cyan_unconnected", "t_concrete_wall_cyan_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_black/t_concrete_wall_black.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_black/t_concrete_wall_black.json
@@ -3,47 +3,35 @@
   "fg": "t_concrete_wall_black_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_black_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_black_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_black_corner_nw",
-        "t_concrete_wall_black_corner_sw",
+        "t_concrete_wall_black_corner_ne",
         "t_concrete_wall_black_corner_se",
-        "t_concrete_wall_black_corner_ne"
+        "t_concrete_wall_black_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_black_t_connection_n",
-        "t_concrete_wall_black_t_connection_w",
+        "t_concrete_wall_black_t_connection_e",
         "t_concrete_wall_black_t_connection_s",
-        "t_concrete_wall_black_t_connection_e"
+        "t_concrete_wall_black_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_black_edge_ns",
-        "t_concrete_wall_black_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_black_edge_ns", "t_concrete_wall_black_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_black_end_piece_n",
-        "t_concrete_wall_black_end_piece_w",
+        "t_concrete_wall_black_end_piece_e",
         "t_concrete_wall_black_end_piece_s",
-        "t_concrete_wall_black_end_piece_e"
+        "t_concrete_wall_black_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_concrete_wall_black_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_concrete_wall_black_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_brown/t_concrete_wall_brown.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_brown/t_concrete_wall_brown.json
@@ -3,47 +3,35 @@
   "fg": "t_concrete_wall_brown_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_brown_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_brown_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_brown_corner_nw",
-        "t_concrete_wall_brown_corner_sw",
+        "t_concrete_wall_brown_corner_ne",
         "t_concrete_wall_brown_corner_se",
-        "t_concrete_wall_brown_corner_ne"
+        "t_concrete_wall_brown_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_brown_t_connection_n",
-        "t_concrete_wall_brown_t_connection_w",
+        "t_concrete_wall_brown_t_connection_e",
         "t_concrete_wall_brown_t_connection_s",
-        "t_concrete_wall_brown_t_connection_e"
+        "t_concrete_wall_brown_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_brown_edge_ns",
-        "t_concrete_wall_brown_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_brown_edge_ns", "t_concrete_wall_brown_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_brown_end_piece_n",
-        "t_concrete_wall_brown_end_piece_w",
+        "t_concrete_wall_brown_end_piece_e",
         "t_concrete_wall_brown_end_piece_s",
-        "t_concrete_wall_brown_end_piece_e"
+        "t_concrete_wall_brown_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_concrete_wall_brown_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_concrete_wall_brown_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_flesh/t_concrete_wall_flesh.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_flesh/t_concrete_wall_flesh.json
@@ -3,50 +3,35 @@
   "fg": "t_concrete_wall_flesh_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_flesh_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_flesh_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_flesh_corner_nw",
-        "t_concrete_wall_flesh_corner_sw",
+        "t_concrete_wall_flesh_corner_ne",
         "t_concrete_wall_flesh_corner_se",
-        "t_concrete_wall_flesh_corner_ne"
+        "t_concrete_wall_flesh_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_flesh_t_connection_n",
-        "t_concrete_wall_flesh_t_connection_w",
+        "t_concrete_wall_flesh_t_connection_e",
         "t_concrete_wall_flesh_t_connection_s",
-        "t_concrete_wall_flesh_t_connection_e"
+        "t_concrete_wall_flesh_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_flesh_edge_ns",
-        "t_concrete_wall_flesh_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_flesh_edge_ns", "t_concrete_wall_flesh_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_flesh_end_piece_n",
-        "t_concrete_wall_flesh_end_piece_w",
+        "t_concrete_wall_flesh_end_piece_e",
         "t_concrete_wall_flesh_end_piece_s",
-        "t_concrete_wall_flesh_end_piece_e"
+        "t_concrete_wall_flesh_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_concrete_wall_flesh_unconnected",
-        "t_concrete_wall_flesh_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_concrete_wall_flesh_unconnected", "t_concrete_wall_flesh_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_g/t_concrete_wall_g.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_g/t_concrete_wall_g.json
@@ -3,47 +3,35 @@
   "fg": "t_concrete_wall_g_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_g_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_g_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_g_corner_nw",
-        "t_concrete_wall_g_corner_sw",
+        "t_concrete_wall_g_corner_ne",
         "t_concrete_wall_g_corner_se",
-        "t_concrete_wall_g_corner_ne"
+        "t_concrete_wall_g_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_g_t_connection_n",
-        "t_concrete_wall_g_t_connection_w",
+        "t_concrete_wall_g_t_connection_e",
         "t_concrete_wall_g_t_connection_s",
-        "t_concrete_wall_g_t_connection_e"
+        "t_concrete_wall_g_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_g_edge_ns",
-        "t_concrete_wall_g_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_g_edge_ns", "t_concrete_wall_g_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_g_end_piece_n",
-        "t_concrete_wall_g_end_piece_w",
+        "t_concrete_wall_g_end_piece_e",
         "t_concrete_wall_g_end_piece_s",
-        "t_concrete_wall_g_end_piece_e"
+        "t_concrete_wall_g_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_concrete_wall_g_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_concrete_wall_g_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_gray/t_concrete_wall_gray.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_gray/t_concrete_wall_gray.json
@@ -3,47 +3,35 @@
   "fg": "t_concrete_wall_gray_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_gray_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_gray_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_gray_corner_nw",
-        "t_concrete_wall_gray_corner_sw",
+        "t_concrete_wall_gray_corner_ne",
         "t_concrete_wall_gray_corner_se",
-        "t_concrete_wall_gray_corner_ne"
+        "t_concrete_wall_gray_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_gray_t_connection_n",
-        "t_concrete_wall_gray_t_connection_w",
+        "t_concrete_wall_gray_t_connection_e",
         "t_concrete_wall_gray_t_connection_s",
-        "t_concrete_wall_gray_t_connection_e"
+        "t_concrete_wall_gray_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_gray_edge_ns",
-        "t_concrete_wall_gray_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_gray_edge_ns", "t_concrete_wall_gray_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_gray_end_piece_n",
-        "t_concrete_wall_gray_end_piece_w",
+        "t_concrete_wall_gray_end_piece_e",
         "t_concrete_wall_gray_end_piece_s",
-        "t_concrete_wall_gray_end_piece_e"
+        "t_concrete_wall_gray_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_concrete_wall_gray_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_concrete_wall_gray_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_orange/t_concrete_wall_orange.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_orange/t_concrete_wall_orange.json
@@ -3,47 +3,35 @@
   "fg": "t_concrete_wall_orange_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_orange_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_orange_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_orange_corner_nw",
-        "t_concrete_wall_orange_corner_sw",
+        "t_concrete_wall_orange_corner_ne",
         "t_concrete_wall_orange_corner_se",
-        "t_concrete_wall_orange_corner_ne"
+        "t_concrete_wall_orange_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_orange_t_connection_n",
-        "t_concrete_wall_orange_t_connection_w",
+        "t_concrete_wall_orange_t_connection_e",
         "t_concrete_wall_orange_t_connection_s",
-        "t_concrete_wall_orange_t_connection_e"
+        "t_concrete_wall_orange_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_orange_edge_ns",
-        "t_concrete_wall_orange_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_orange_edge_ns", "t_concrete_wall_orange_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_orange_end_piece_n",
-        "t_concrete_wall_orange_end_piece_w",
+        "t_concrete_wall_orange_end_piece_e",
         "t_concrete_wall_orange_end_piece_s",
-        "t_concrete_wall_orange_end_piece_e"
+        "t_concrete_wall_orange_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_concrete_wall_orange_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_concrete_wall_orange_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_p/t_concrete_wall_p.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_p/t_concrete_wall_p.json
@@ -3,47 +3,35 @@
   "fg": "t_concrete_wall_p_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_p_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_p_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_p_corner_nw",
-        "t_concrete_wall_p_corner_sw",
+        "t_concrete_wall_p_corner_ne",
         "t_concrete_wall_p_corner_se",
-        "t_concrete_wall_p_corner_ne"
+        "t_concrete_wall_p_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_p_t_connection_n",
-        "t_concrete_wall_p_t_connection_w",
+        "t_concrete_wall_p_t_connection_e",
         "t_concrete_wall_p_t_connection_s",
-        "t_concrete_wall_p_t_connection_e"
+        "t_concrete_wall_p_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_p_edge_ns",
-        "t_concrete_wall_p_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_p_edge_ns", "t_concrete_wall_p_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_p_end_piece_n",
-        "t_concrete_wall_p_end_piece_w",
+        "t_concrete_wall_p_end_piece_e",
         "t_concrete_wall_p_end_piece_s",
-        "t_concrete_wall_p_end_piece_e"
+        "t_concrete_wall_p_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_concrete_wall_p_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_concrete_wall_p_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_r/t_concrete_wall_r.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_r/t_concrete_wall_r.json
@@ -3,47 +3,35 @@
   "fg": "t_concrete_wall_r_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_r_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_r_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_r_corner_nw",
-        "t_concrete_wall_r_corner_sw",
+        "t_concrete_wall_r_corner_ne",
         "t_concrete_wall_r_corner_se",
-        "t_concrete_wall_r_corner_ne"
+        "t_concrete_wall_r_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_r_t_connection_n",
-        "t_concrete_wall_r_t_connection_w",
+        "t_concrete_wall_r_t_connection_e",
         "t_concrete_wall_r_t_connection_s",
-        "t_concrete_wall_r_t_connection_e"
+        "t_concrete_wall_r_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_r_edge_ns",
-        "t_concrete_wall_r_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_r_edge_ns", "t_concrete_wall_r_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_r_end_piece_n",
-        "t_concrete_wall_r_end_piece_w",
+        "t_concrete_wall_r_end_piece_e",
         "t_concrete_wall_r_end_piece_s",
-        "t_concrete_wall_r_end_piece_e"
+        "t_concrete_wall_r_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_concrete_wall_r_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_concrete_wall_r_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_w/t_concrete_wall_w.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_w/t_concrete_wall_w.json
@@ -3,47 +3,35 @@
   "fg": "t_concrete_wall_w_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_w_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_w_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_w_corner_nw",
-        "t_concrete_wall_w_corner_sw",
+        "t_concrete_wall_w_corner_ne",
         "t_concrete_wall_w_corner_se",
-        "t_concrete_wall_w_corner_ne"
+        "t_concrete_wall_w_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_w_t_connection_n",
-        "t_concrete_wall_w_t_connection_w",
+        "t_concrete_wall_w_t_connection_e",
         "t_concrete_wall_w_t_connection_s",
-        "t_concrete_wall_w_t_connection_e"
+        "t_concrete_wall_w_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_w_edge_ns",
-        "t_concrete_wall_w_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_w_edge_ns", "t_concrete_wall_w_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_w_end_piece_n",
-        "t_concrete_wall_w_end_piece_w",
+        "t_concrete_wall_w_end_piece_e",
         "t_concrete_wall_w_end_piece_s",
-        "t_concrete_wall_w_end_piece_e"
+        "t_concrete_wall_w_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_concrete_wall_w_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_concrete_wall_w_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_y/t_concrete_wall_y.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_concrete_wall_y/t_concrete_wall_y.json
@@ -3,47 +3,35 @@
   "fg": "t_concrete_wall_y_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_concrete_wall_y_center"
-    },
+    { "id": "center", "fg": "t_concrete_wall_y_center" },
     {
       "id": "corner",
       "fg": [
         "t_concrete_wall_y_corner_nw",
-        "t_concrete_wall_y_corner_sw",
+        "t_concrete_wall_y_corner_ne",
         "t_concrete_wall_y_corner_se",
-        "t_concrete_wall_y_corner_ne"
+        "t_concrete_wall_y_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_concrete_wall_y_t_connection_n",
-        "t_concrete_wall_y_t_connection_w",
+        "t_concrete_wall_y_t_connection_e",
         "t_concrete_wall_y_t_connection_s",
-        "t_concrete_wall_y_t_connection_e"
+        "t_concrete_wall_y_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_concrete_wall_y_edge_ns",
-        "t_concrete_wall_y_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_concrete_wall_y_edge_ns", "t_concrete_wall_y_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_concrete_wall_y_end_piece_n",
-        "t_concrete_wall_y_end_piece_w",
+        "t_concrete_wall_y_end_piece_e",
         "t_concrete_wall_y_end_piece_s",
-        "t_concrete_wall_y_end_piece_e"
+        "t_concrete_wall_y_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_concrete_wall_y_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_concrete_wall_y_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_conveyor/t_conveyor.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_conveyor/t_conveyor.json
@@ -4,56 +4,27 @@
   "fg": "t_conveyor_unconnected",
   "bg": "t_thconc_floor_center",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "t_thconc_floor_center",
-      "fg": "t_conveyor_center"
-    },
+    { "id": "center", "bg": "t_thconc_floor_center", "fg": "t_conveyor_center" },
     {
       "id": "corner",
       "bg": "t_thconc_floor_center",
-      "fg": [
-        "t_conveyor_corner_nw",
-        "t_conveyor_corner_sw",
-        "t_conveyor_corner_se",
-        "t_conveyor_corner_ne"
-      ]
+      "fg": [ "t_conveyor_corner_nw", "t_conveyor_corner_ne", "t_conveyor_corner_se", "t_conveyor_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "t_thconc_floor_center",
-      "fg": [
-        "t_conveyor_t_connection_n",
-        "t_conveyor_t_connection_w",
-        "t_conveyor_t_connection_s",
-        "t_conveyor_t_connection_e"
-      ]
+      "fg": [ "t_conveyor_t_connection_n", "t_conveyor_t_connection_e", "t_conveyor_t_connection_s", "t_conveyor_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "t_thconc_floor_center",
-      "fg": [
-        "t_conveyor_edge_ns",
-        "t_conveyor_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "t_thconc_floor_center", "fg": [ "t_conveyor_edge_ns", "t_conveyor_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "t_thconc_floor_center",
-      "fg": [
-        "t_conveyor_end_piece_n",
-        "t_conveyor_end_piece_w",
-        "t_conveyor_end_piece_s",
-        "t_conveyor_end_piece_e"
-      ]
+      "fg": [ "t_conveyor_end_piece_n", "t_conveyor_end_piece_e", "t_conveyor_end_piece_s", "t_conveyor_end_piece_w" ]
     },
     {
       "bg": "t_thconc_floor_center",
       "id": "unconnected",
-      "fg": [
-        "t_conveyor_unconnected",
-        "t_conveyor_unconnected"
-      ]
+      "fg": [ "t_conveyor_unconnected", "t_conveyor_unconnected" ]
     }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_deck_coating_no_roof/t_deck_coating_no_roof.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_deck_coating_no_roof/t_deck_coating_no_roof.json
@@ -9,18 +9,18 @@
         "id": "corner",
         "fg": [
           "t_deck_coating_no_roof_corner_nw",
-          "t_deck_coating_no_roof_corner_sw",
+          "t_deck_coating_no_roof_corner_ne",
           "t_deck_coating_no_roof_corner_se",
-          "t_deck_coating_no_roof_corner_ne"
+          "t_deck_coating_no_roof_corner_sw"
         ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_deck_coating_no_roof_t_connection_n",
-          "t_deck_coating_no_roof_t_connection_w",
+          "t_deck_coating_no_roof_t_connection_e",
           "t_deck_coating_no_roof_t_connection_s",
-          "t_deck_coating_no_roof_t_connection_e"
+          "t_deck_coating_no_roof_t_connection_w"
         ]
       },
       { "id": "edge", "fg": [ "t_deck_coating_no_roof_edge_ns", "t_deck_coating_no_roof_edge_ew" ] },
@@ -28,9 +28,9 @@
         "id": "end_piece",
         "fg": [
           "t_deck_coating_no_roof_end_piece_n",
-          "t_deck_coating_no_roof_end_piece_w",
+          "t_deck_coating_no_roof_end_piece_e",
           "t_deck_coating_no_roof_end_piece_s",
-          "t_deck_coating_no_roof_end_piece_e"
+          "t_deck_coating_no_roof_end_piece_w"
         ]
       },
       { "id": "unconnected", "fg": [ "t_deck_coating_no_roof_edge_ns", "t_deck_coating_no_roof_edge_ns" ] }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_deck_coating_no_roof/t_deck_coating_no_roof_r.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_deck_coating_no_roof/t_deck_coating_no_roof_r.json
@@ -11,9 +11,9 @@
         "fg": "t_deck_coating_no_roof_r",
         "bg": [
           "t_deck_coating_no_roof_corner_nw",
-          "t_deck_coating_no_roof_corner_sw",
+          "t_deck_coating_no_roof_corner_ne",
           "t_deck_coating_no_roof_corner_se",
-          "t_deck_coating_no_roof_corner_ne"
+          "t_deck_coating_no_roof_corner_sw"
         ]
       },
       {
@@ -21,9 +21,9 @@
         "fg": "t_deck_coating_no_roof_r",
         "bg": [
           "t_deck_coating_no_roof_t_connection_n",
-          "t_deck_coating_no_roof_t_connection_w",
+          "t_deck_coating_no_roof_t_connection_e",
           "t_deck_coating_no_roof_t_connection_s",
-          "t_deck_coating_no_roof_t_connection_e"
+          "t_deck_coating_no_roof_t_connection_w"
         ]
       },
       {
@@ -36,9 +36,9 @@
         "fg": "t_deck_coating_no_roof_r",
         "bg": [
           "t_deck_coating_no_roof_end_piece_n",
-          "t_deck_coating_no_roof_end_piece_w",
+          "t_deck_coating_no_roof_end_piece_e",
           "t_deck_coating_no_roof_end_piece_s",
-          "t_deck_coating_no_roof_end_piece_e"
+          "t_deck_coating_no_roof_end_piece_w"
         ]
       },
       {

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_deck_coating_no_roof/t_deck_coating_no_roof_w.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_deck_coating_no_roof/t_deck_coating_no_roof_w.json
@@ -11,9 +11,9 @@
         "fg": "t_deck_coating_no_roof_w",
         "bg": [
           "t_deck_coating_no_roof_corner_nw",
-          "t_deck_coating_no_roof_corner_sw",
+          "t_deck_coating_no_roof_corner_ne",
           "t_deck_coating_no_roof_corner_se",
-          "t_deck_coating_no_roof_corner_ne"
+          "t_deck_coating_no_roof_corner_sw"
         ]
       },
       {
@@ -21,9 +21,9 @@
         "fg": "t_deck_coating_no_roof_w",
         "bg": [
           "t_deck_coating_no_roof_t_connection_n",
-          "t_deck_coating_no_roof_t_connection_w",
+          "t_deck_coating_no_roof_t_connection_e",
           "t_deck_coating_no_roof_t_connection_s",
-          "t_deck_coating_no_roof_t_connection_e"
+          "t_deck_coating_no_roof_t_connection_w"
         ]
       },
       {
@@ -36,9 +36,9 @@
         "fg": "t_deck_coating_no_roof_w",
         "bg": [
           "t_deck_coating_no_roof_end_piece_n",
-          "t_deck_coating_no_roof_end_piece_w",
+          "t_deck_coating_no_roof_end_piece_e",
           "t_deck_coating_no_roof_end_piece_s",
-          "t_deck_coating_no_roof_end_piece_e"
+          "t_deck_coating_no_roof_end_piece_w"
         ]
       },
       {

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_deck_coating_no_roof/t_deck_coating_no_roof_y.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_deck_coating_no_roof/t_deck_coating_no_roof_y.json
@@ -11,9 +11,9 @@
         "fg": "t_deck_coating_no_roof_y",
         "bg": [
           "t_deck_coating_no_roof_corner_nw",
-          "t_deck_coating_no_roof_corner_sw",
+          "t_deck_coating_no_roof_corner_ne",
           "t_deck_coating_no_roof_corner_se",
-          "t_deck_coating_no_roof_corner_ne"
+          "t_deck_coating_no_roof_corner_sw"
         ]
       },
       {
@@ -21,9 +21,9 @@
         "fg": "t_deck_coating_no_roof_y",
         "bg": [
           "t_deck_coating_no_roof_t_connection_n",
-          "t_deck_coating_no_roof_t_connection_w",
+          "t_deck_coating_no_roof_t_connection_e",
           "t_deck_coating_no_roof_t_connection_s",
-          "t_deck_coating_no_roof_t_connection_e"
+          "t_deck_coating_no_roof_t_connection_w"
         ]
       },
       {
@@ -36,9 +36,9 @@
         "fg": "t_deck_coating_no_roof_y",
         "bg": [
           "t_deck_coating_no_roof_end_piece_n",
-          "t_deck_coating_no_roof_end_piece_w",
+          "t_deck_coating_no_roof_end_piece_e",
           "t_deck_coating_no_roof_end_piece_s",
-          "t_deck_coating_no_roof_end_piece_e"
+          "t_deck_coating_no_roof_end_piece_w"
         ]
       },
       {

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_dirt/autumn/t_dirt_season_autumn.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_dirt/autumn/t_dirt_season_autumn.json
@@ -8,9 +8,9 @@
       "id": "center",
       "fg": [
         "t_dirt_season_autumn_center",
-        "t_dirt_season_autumn_center2",
+        "t_dirt_season_autumn_center4",
         "t_dirt_season_autumn_center3",
-        "t_dirt_season_autumn_center4"
+        "t_dirt_season_autumn_center2"
       ],
       "bg": ""
     },
@@ -18,9 +18,9 @@
       "id": "corner",
       "fg": [
         "t_dirt_season_autumn_corner_nw",
-        "t_dirt_season_autumn_corner_sw",
+        "t_dirt_season_autumn_corner_ne",
         "t_dirt_season_autumn_corner_se",
-        "t_dirt_season_autumn_corner_ne"
+        "t_dirt_season_autumn_corner_sw"
       ],
       "bg": ""
     },
@@ -28,36 +28,26 @@
       "id": "t_connection",
       "fg": [
         "t_dirt_season_autumn_t_connection_n",
-        "t_dirt_season_autumn_t_connection_w",
+        "t_dirt_season_autumn_t_connection_e",
         "t_dirt_season_autumn_t_connection_s",
-        "t_dirt_season_autumn_t_connection_e"
+        "t_dirt_season_autumn_t_connection_w"
       ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_dirt_season_autumn_edge_ns",
-        "t_dirt_season_autumn_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "t_dirt_season_autumn_edge_ns", "t_dirt_season_autumn_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
       "fg": [
         "t_dirt_season_autumn_end_piece_n",
-        "t_dirt_season_autumn_end_piece_w",
+        "t_dirt_season_autumn_end_piece_e",
         "t_dirt_season_autumn_end_piece_s",
-        "t_dirt_season_autumn_end_piece_e"
+        "t_dirt_season_autumn_end_piece_w"
       ],
       "bg": ""
     },
     {
       "id": "unconnected",
-      "fg": [
-        "t_dirt_season_autumn_unconnected",
-        "t_dirt_season_autumn_unconnected"
-      ],
+      "fg": [ "t_dirt_season_autumn_unconnected", "t_dirt_season_autumn_unconnected" ],
       "bg": ""
     }
   ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_dirt/summer/t_dirt_season_summer.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_dirt/summer/t_dirt_season_summer.json
@@ -8,9 +8,9 @@
       "id": "center",
       "fg": [
         "t_dirt_season_summer_center",
-        "t_dirt_season_summer_center2",
+        "t_dirt_season_summer_center4",
         "t_dirt_season_summer_center3",
-        "t_dirt_season_summer_center4"
+        "t_dirt_season_summer_center2"
       ],
       "bg": ""
     },
@@ -18,9 +18,9 @@
       "id": "corner",
       "fg": [
         "t_dirt_season_summer_corner_nw",
-        "t_dirt_season_summer_corner_sw",
+        "t_dirt_season_summer_corner_ne",
         "t_dirt_season_summer_corner_se",
-        "t_dirt_season_summer_corner_ne"
+        "t_dirt_season_summer_corner_sw"
       ],
       "bg": ""
     },
@@ -28,36 +28,26 @@
       "id": "t_connection",
       "fg": [
         "t_dirt_season_summer_t_connection_n",
-        "t_dirt_season_summer_t_connection_w",
+        "t_dirt_season_summer_t_connection_e",
         "t_dirt_season_summer_t_connection_s",
-        "t_dirt_season_summer_t_connection_e"
+        "t_dirt_season_summer_t_connection_w"
       ],
       "bg": ""
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_dirt_season_summer_edge_ns",
-        "t_dirt_season_summer_edge_ew"
-      ],
-      "bg": ""
-    },
+    { "id": "edge", "fg": [ "t_dirt_season_summer_edge_ns", "t_dirt_season_summer_edge_ew" ], "bg": "" },
     {
       "id": "end_piece",
       "fg": [
         "t_dirt_season_summer_end_piece_n",
-        "t_dirt_season_summer_end_piece_w",
+        "t_dirt_season_summer_end_piece_e",
         "t_dirt_season_summer_end_piece_s",
-        "t_dirt_season_summer_end_piece_e"
+        "t_dirt_season_summer_end_piece_w"
       ],
       "bg": ""
     },
     {
       "id": "unconnected",
-      "fg": [
-        "t_dirt_season_summer_unconnected",
-        "t_dirt_season_summer_unconnected"
-      ],
+      "fg": [ "t_dirt_season_summer_unconnected", "t_dirt_season_summer_unconnected" ],
       "bg": ""
     }
   ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_dirt/t_dirt.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_dirt/t_dirt.json
@@ -17,50 +17,21 @@
       },
       {
         "id": "corner",
-        "fg": [
-          "t_dirt_corner_nw",
-          "t_dirt_corner_sw",
-          "t_dirt_corner_se",
-          "t_dirt_corner_ne"
-        ],
+        "fg": [ "t_dirt_corner_nw", "t_dirt_corner_ne", "t_dirt_corner_se", "t_dirt_corner_sw" ],
         "bg": ""
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_dirt_t_connection_n",
-          "t_dirt_t_connection_w",
-          "t_dirt_t_connection_s",
-          "t_dirt_t_connection_e"
-        ],
+        "fg": [ "t_dirt_t_connection_n", "t_dirt_t_connection_e", "t_dirt_t_connection_s", "t_dirt_t_connection_w" ],
         "bg": ""
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_dirt_edge_ns",
-          "t_dirt_edge_ew"
-        ],
-        "bg": ""
-      },
+      { "id": "edge", "fg": [ "t_dirt_edge_ns", "t_dirt_edge_ew" ], "bg": "" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_dirt_end_piece_n",
-          "t_dirt_end_piece_w",
-          "t_dirt_end_piece_s",
-          "t_dirt_end_piece_e"
-        ],
+        "fg": [ "t_dirt_end_piece_n", "t_dirt_end_piece_e", "t_dirt_end_piece_s", "t_dirt_end_piece_w" ],
         "bg": ""
       },
-      {
-        "id": "unconnected",
-        "fg": [
-          "t_dirt_unconnected",
-          "t_dirt_unconnected"
-        ],
-        "bg": ""
-      }
+      { "id": "unconnected", "fg": [ "t_dirt_unconnected", "t_dirt_unconnected" ], "bg": "" }
     ]
   },
   {

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_dirtfloor/t_dirtfloor.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_dirtfloor/t_dirtfloor.json
@@ -4,53 +4,28 @@
   "fg": "t_dirtfloor_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_dirtfloor_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_dirtfloor_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_dirtfloor_corner_nw",
-        "t_dirtfloor_corner_sw",
-        "t_dirtfloor_corner_se",
-        "t_dirtfloor_corner_ne"
-      ]
+      "fg": [ "t_dirtfloor_corner_nw", "t_dirtfloor_corner_ne", "t_dirtfloor_corner_se", "t_dirtfloor_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_dirtfloor_t_connection_n",
-        "t_dirtfloor_t_connection_w",
+        "t_dirtfloor_t_connection_e",
         "t_dirtfloor_t_connection_s",
-        "t_dirtfloor_t_connection_e"
+        "t_dirtfloor_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_dirtfloor_edge_ns",
-        "t_dirtfloor_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_dirtfloor_edge_ns", "t_dirtfloor_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_dirtfloor_end_piece_n",
-        "t_dirtfloor_end_piece_w",
-        "t_dirtfloor_end_piece_s",
-        "t_dirtfloor_end_piece_e"
-      ]
+      "fg": [ "t_dirtfloor_end_piece_n", "t_dirtfloor_end_piece_e", "t_dirtfloor_end_piece_s", "t_dirtfloor_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_dirtfloor_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_dirtfloor_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_embrasure_adobe_brick/t_embrasure_adobe_brick.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_embrasure_adobe_brick/t_embrasure_adobe_brick.json
@@ -4,71 +4,57 @@
   "bg": "t_adobe_brick_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_embrasure_adobe_brick_center",
-      "bg": "t_adobe_brick_wall_center"
-    },
+    { "id": "center", "fg": "t_embrasure_adobe_brick_center", "bg": "t_adobe_brick_wall_center" },
     {
       "id": "corner",
       "fg": [
         "t_embrasure_adobe_brick_corner_nw",
-        "t_embrasure_adobe_brick_corner_sw",
+        "t_embrasure_adobe_brick_corner_ne",
         "t_embrasure_adobe_brick_corner_se",
-        "t_embrasure_adobe_brick_corner_ne"
+        "t_embrasure_adobe_brick_corner_sw"
       ],
       "bg": [
         "t_adobe_brick_wall_corner_nw",
-        "t_adobe_brick_wall_corner_sw",
+        "t_adobe_brick_wall_corner_ne",
         "t_adobe_brick_wall_corner_se",
-        "t_adobe_brick_wall_corner_ne"
+        "t_adobe_brick_wall_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_embrasure_adobe_brick_t_connection_n",
-        "t_embrasure_adobe_brick_t_connection_w",
+        "t_embrasure_adobe_brick_t_connection_e",
         "t_embrasure_adobe_brick_t_connection_s",
-        "t_embrasure_adobe_brick_t_connection_e"
+        "t_embrasure_adobe_brick_t_connection_w"
       ],
       "bg": [
         "t_adobe_brick_wall_t_connection_n",
-        "t_adobe_brick_wall_t_connection_w",
+        "t_adobe_brick_wall_t_connection_e",
         "t_adobe_brick_wall_t_connection_s",
-        "t_adobe_brick_wall_t_connection_e"
+        "t_adobe_brick_wall_t_connection_w"
       ]
     },
     {
       "id": "edge",
-      "fg": [
-        "t_embrasure_adobe_brick_edge_ns",
-        "t_embrasure_adobe_brick_edge_ew"
-      ],
-      "bg": [
-        "t_adobe_brick_wall_edge_ns",
-        "t_adobe_brick_wall_edge_ew"
-      ]
+      "fg": [ "t_embrasure_adobe_brick_edge_ns", "t_embrasure_adobe_brick_edge_ew" ],
+      "bg": [ "t_adobe_brick_wall_edge_ns", "t_adobe_brick_wall_edge_ew" ]
     },
     {
       "id": "end_piece",
       "fg": [
         "t_embrasure_adobe_brick_end_piece_n",
-        "t_embrasure_adobe_brick_end_piece_w",
+        "t_embrasure_adobe_brick_end_piece_e",
         "t_embrasure_adobe_brick_end_piece_s",
-        "t_embrasure_adobe_brick_end_piece_e"
+        "t_embrasure_adobe_brick_end_piece_w"
       ],
       "bg": [
         "t_adobe_brick_wall_end_piece_n",
-        "t_adobe_brick_wall_end_piece_w",
+        "t_adobe_brick_wall_end_piece_e",
         "t_adobe_brick_wall_end_piece_s",
-        "t_adobe_brick_wall_end_piece_e"
+        "t_adobe_brick_wall_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_embrasure_adobe_brick_unconnected",
-      "bg": "t_adobe_brick_wall_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_embrasure_adobe_brick_unconnected", "bg": "t_adobe_brick_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_embrasure_brick/t_embrasure_brick.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_embrasure_brick/t_embrasure_brick.json
@@ -4,71 +4,47 @@
   "bg": "t_brick_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_embrasure_brick_center",
-      "bg": "t_brick_wall_center"
-    },
+    { "id": "center", "fg": "t_embrasure_brick_center", "bg": "t_brick_wall_center" },
     {
       "id": "corner",
       "fg": [
         "t_embrasure_brick_corner_nw",
-        "t_embrasure_brick_corner_sw",
+        "t_embrasure_brick_corner_ne",
         "t_embrasure_brick_corner_se",
-        "t_embrasure_brick_corner_ne"
+        "t_embrasure_brick_corner_sw"
       ],
-      "bg": [
-        "t_brick_wall_corner_nw",
-        "t_brick_wall_corner_sw",
-        "t_brick_wall_corner_se",
-        "t_brick_wall_corner_ne"
-      ]
+      "bg": [ "t_brick_wall_corner_nw", "t_brick_wall_corner_ne", "t_brick_wall_corner_se", "t_brick_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_embrasure_brick_t_connection_n",
-        "t_embrasure_brick_t_connection_w",
+        "t_embrasure_brick_t_connection_e",
         "t_embrasure_brick_t_connection_s",
-        "t_embrasure_brick_t_connection_e"
+        "t_embrasure_brick_t_connection_w"
       ],
       "bg": [
         "t_brick_wall_t_connection_n",
-        "t_brick_wall_t_connection_w",
+        "t_brick_wall_t_connection_e",
         "t_brick_wall_t_connection_s",
-        "t_brick_wall_t_connection_e"
+        "t_brick_wall_t_connection_w"
       ]
     },
     {
       "id": "edge",
-      "fg": [
-        "t_embrasure_brick_edge_ns",
-        "t_embrasure_brick_edge_ew"
-      ],
-      "bg": [
-        "t_brick_wall_edge_ns",
-        "t_brick_wall_edge_ew"
-      ]
+      "fg": [ "t_embrasure_brick_edge_ns", "t_embrasure_brick_edge_ew" ],
+      "bg": [ "t_brick_wall_edge_ns", "t_brick_wall_edge_ew" ]
     },
     {
       "id": "end_piece",
       "fg": [
         "t_embrasure_brick_end_piece_n",
-        "t_embrasure_brick_end_piece_w",
+        "t_embrasure_brick_end_piece_e",
         "t_embrasure_brick_end_piece_s",
-        "t_embrasure_brick_end_piece_e"
+        "t_embrasure_brick_end_piece_w"
       ],
-      "bg": [
-        "t_brick_wall_end_piece_n",
-        "t_brick_wall_end_piece_w",
-        "t_brick_wall_end_piece_s",
-        "t_brick_wall_end_piece_e"
-      ]
+      "bg": [ "t_brick_wall_end_piece_n", "t_brick_wall_end_piece_e", "t_brick_wall_end_piece_s", "t_brick_wall_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_embrasure_brick_unconnected",
-      "bg": "t_brick_wall_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_embrasure_brick_unconnected", "bg": "t_brick_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_embrasure_log/t_embrasure_log.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_embrasure_log/t_embrasure_log.json
@@ -5,72 +5,38 @@
     "bg": "t_grass",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_embrasure_log_center",
-        "bg": "t_wall_log_center"
-      },
+      { "id": "center", "fg": "t_embrasure_log_center", "bg": "t_wall_log_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_embrasure_log_corner_nw",
-          "t_embrasure_log_corner_sw",
-          "t_embrasure_log_corner_se",
-          "t_embrasure_log_corner_ne"
-        ],
-        "bg": [
-          "t_wall_log_corner_nw",
-          "t_wall_log_corner_sw",
-          "t_wall_log_corner_se",
-          "t_wall_log_corner_ne"
-        ]
+        "fg": [ "t_embrasure_log_corner_nw", "t_embrasure_log_corner_ne", "t_embrasure_log_corner_se", "t_embrasure_log_corner_sw" ],
+        "bg": [ "t_wall_log_corner_nw", "t_wall_log_corner_ne", "t_wall_log_corner_se", "t_wall_log_corner_sw" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_embrasure_log_t_connection_n",
-          "t_embrasure_log_t_connection_w",
+          "t_embrasure_log_t_connection_e",
           "t_embrasure_log_t_connection_s",
-          "t_embrasure_log_t_connection_e"
+          "t_embrasure_log_t_connection_w"
         ],
-        "bg": [
-          "t_wall_log_t_connection_n",
-          "t_wall_log_t_connection_w",
-          "t_wall_log_t_connection_s",
-          "t_wall_log_t_connection_e"
-        ]
+        "bg": [ "t_wall_log_t_connection_n", "t_wall_log_t_connection_e", "t_wall_log_t_connection_s", "t_wall_log_t_connection_w" ]
       },
       {
         "id": "edge",
-        "fg": [
-          "t_embrasure_log_edge_ns",
-          "t_embrasure_log_edge_ew"
-        ],
-        "bg": [
-          "t_wall_log_edge_ns",
-          "t_wall_log_edge_ew"
-        ]
+        "fg": [ "t_embrasure_log_edge_ns", "t_embrasure_log_edge_ew" ],
+        "bg": [ "t_wall_log_edge_ns", "t_wall_log_edge_ew" ]
       },
       {
         "id": "end_piece",
         "fg": [
           "t_embrasure_log_end_piece_n",
-          "t_embrasure_log_end_piece_w",
+          "t_embrasure_log_end_piece_e",
           "t_embrasure_log_end_piece_s",
-          "t_embrasure_log_end_piece_e"
+          "t_embrasure_log_end_piece_w"
         ],
-        "bg": [
-          "t_wall_log_end_piece_n",
-          "t_wall_log_end_piece_w",
-          "t_wall_log_end_piece_s",
-          "t_wall_log_end_piece_e"
-        ]
+        "bg": [ "t_wall_log_end_piece_n", "t_wall_log_end_piece_e", "t_wall_log_end_piece_s", "t_wall_log_end_piece_w" ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_embrasure_log_unconnected",
-        "bg": "t_grass"
-      }
+      { "id": "unconnected", "fg": "t_embrasure_log_unconnected", "bg": "t_grass" }
     ]
   },
   {
@@ -79,72 +45,38 @@
     "bg": "t_grass_summer",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_embrasure_log_center",
-        "bg": "t_wall_log_center"
-      },
+      { "id": "center", "fg": "t_embrasure_log_center", "bg": "t_wall_log_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_embrasure_log_corner_nw",
-          "t_embrasure_log_corner_sw",
-          "t_embrasure_log_corner_se",
-          "t_embrasure_log_corner_ne"
-        ],
-        "bg": [
-          "t_wall_log_corner_nw",
-          "t_wall_log_corner_sw",
-          "t_wall_log_corner_se",
-          "t_wall_log_corner_ne"
-        ]
+        "fg": [ "t_embrasure_log_corner_nw", "t_embrasure_log_corner_ne", "t_embrasure_log_corner_se", "t_embrasure_log_corner_sw" ],
+        "bg": [ "t_wall_log_corner_nw", "t_wall_log_corner_ne", "t_wall_log_corner_se", "t_wall_log_corner_sw" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_embrasure_log_t_connection_n",
-          "t_embrasure_log_t_connection_w",
+          "t_embrasure_log_t_connection_e",
           "t_embrasure_log_t_connection_s",
-          "t_embrasure_log_t_connection_e"
+          "t_embrasure_log_t_connection_w"
         ],
-        "bg": [
-          "t_wall_log_t_connection_n",
-          "t_wall_log_t_connection_w",
-          "t_wall_log_t_connection_s",
-          "t_wall_log_t_connection_e"
-        ]
+        "bg": [ "t_wall_log_t_connection_n", "t_wall_log_t_connection_e", "t_wall_log_t_connection_s", "t_wall_log_t_connection_w" ]
       },
       {
         "id": "edge",
-        "fg": [
-          "t_embrasure_log_edge_ns",
-          "t_embrasure_log_edge_ew"
-        ],
-        "bg": [
-          "t_wall_log_edge_ns",
-          "t_wall_log_edge_ew"
-        ]
+        "fg": [ "t_embrasure_log_edge_ns", "t_embrasure_log_edge_ew" ],
+        "bg": [ "t_wall_log_edge_ns", "t_wall_log_edge_ew" ]
       },
       {
         "id": "end_piece",
         "fg": [
           "t_embrasure_log_end_piece_n",
-          "t_embrasure_log_end_piece_w",
+          "t_embrasure_log_end_piece_e",
           "t_embrasure_log_end_piece_s",
-          "t_embrasure_log_end_piece_e"
+          "t_embrasure_log_end_piece_w"
         ],
-        "bg": [
-          "t_wall_log_end_piece_n",
-          "t_wall_log_end_piece_w",
-          "t_wall_log_end_piece_s",
-          "t_wall_log_end_piece_e"
-        ]
+        "bg": [ "t_wall_log_end_piece_n", "t_wall_log_end_piece_e", "t_wall_log_end_piece_s", "t_wall_log_end_piece_w" ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_embrasure_log_unconnected",
-        "bg": "t_grass_summer"
-      }
+      { "id": "unconnected", "fg": "t_embrasure_log_unconnected", "bg": "t_grass_summer" }
     ]
   },
   {
@@ -153,72 +85,38 @@
     "bg": "t_grass_autumn",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_embrasure_log_center",
-        "bg": "t_wall_log_center"
-      },
+      { "id": "center", "fg": "t_embrasure_log_center", "bg": "t_wall_log_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_embrasure_log_corner_nw",
-          "t_embrasure_log_corner_sw",
-          "t_embrasure_log_corner_se",
-          "t_embrasure_log_corner_ne"
-        ],
-        "bg": [
-          "t_wall_log_corner_nw",
-          "t_wall_log_corner_sw",
-          "t_wall_log_corner_se",
-          "t_wall_log_corner_ne"
-        ]
+        "fg": [ "t_embrasure_log_corner_nw", "t_embrasure_log_corner_ne", "t_embrasure_log_corner_se", "t_embrasure_log_corner_sw" ],
+        "bg": [ "t_wall_log_corner_nw", "t_wall_log_corner_ne", "t_wall_log_corner_se", "t_wall_log_corner_sw" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_embrasure_log_t_connection_n",
-          "t_embrasure_log_t_connection_w",
+          "t_embrasure_log_t_connection_e",
           "t_embrasure_log_t_connection_s",
-          "t_embrasure_log_t_connection_e"
+          "t_embrasure_log_t_connection_w"
         ],
-        "bg": [
-          "t_wall_log_t_connection_n",
-          "t_wall_log_t_connection_w",
-          "t_wall_log_t_connection_s",
-          "t_wall_log_t_connection_e"
-        ]
+        "bg": [ "t_wall_log_t_connection_n", "t_wall_log_t_connection_e", "t_wall_log_t_connection_s", "t_wall_log_t_connection_w" ]
       },
       {
         "id": "edge",
-        "fg": [
-          "t_embrasure_log_edge_ns",
-          "t_embrasure_log_edge_ew"
-        ],
-        "bg": [
-          "t_wall_log_edge_ns",
-          "t_wall_log_edge_ew"
-        ]
+        "fg": [ "t_embrasure_log_edge_ns", "t_embrasure_log_edge_ew" ],
+        "bg": [ "t_wall_log_edge_ns", "t_wall_log_edge_ew" ]
       },
       {
         "id": "end_piece",
         "fg": [
           "t_embrasure_log_end_piece_n",
-          "t_embrasure_log_end_piece_w",
+          "t_embrasure_log_end_piece_e",
           "t_embrasure_log_end_piece_s",
-          "t_embrasure_log_end_piece_e"
+          "t_embrasure_log_end_piece_w"
         ],
-        "bg": [
-          "t_wall_log_end_piece_n",
-          "t_wall_log_end_piece_w",
-          "t_wall_log_end_piece_s",
-          "t_wall_log_end_piece_e"
-        ]
+        "bg": [ "t_wall_log_end_piece_n", "t_wall_log_end_piece_e", "t_wall_log_end_piece_s", "t_wall_log_end_piece_w" ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_embrasure_log_unconnected",
-        "bg": "t_grass_autumn"
-      }
+      { "id": "unconnected", "fg": "t_embrasure_log_unconnected", "bg": "t_grass_autumn" }
     ]
   },
   {
@@ -227,72 +125,38 @@
     "bg": "snow_shallow_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_embrasure_log_center",
-        "bg": "t_wall_log_center"
-      },
+      { "id": "center", "fg": "t_embrasure_log_center", "bg": "t_wall_log_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_embrasure_log_corner_nw",
-          "t_embrasure_log_corner_sw",
-          "t_embrasure_log_corner_se",
-          "t_embrasure_log_corner_ne"
-        ],
-        "bg": [
-          "t_wall_log_corner_nw",
-          "t_wall_log_corner_sw",
-          "t_wall_log_corner_se",
-          "t_wall_log_corner_ne"
-        ]
+        "fg": [ "t_embrasure_log_corner_nw", "t_embrasure_log_corner_ne", "t_embrasure_log_corner_se", "t_embrasure_log_corner_sw" ],
+        "bg": [ "t_wall_log_corner_nw", "t_wall_log_corner_ne", "t_wall_log_corner_se", "t_wall_log_corner_sw" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_embrasure_log_t_connection_n",
-          "t_embrasure_log_t_connection_w",
+          "t_embrasure_log_t_connection_e",
           "t_embrasure_log_t_connection_s",
-          "t_embrasure_log_t_connection_e"
+          "t_embrasure_log_t_connection_w"
         ],
-        "bg": [
-          "t_wall_log_t_connection_n",
-          "t_wall_log_t_connection_w",
-          "t_wall_log_t_connection_s",
-          "t_wall_log_t_connection_e"
-        ]
+        "bg": [ "t_wall_log_t_connection_n", "t_wall_log_t_connection_e", "t_wall_log_t_connection_s", "t_wall_log_t_connection_w" ]
       },
       {
         "id": "edge",
-        "fg": [
-          "t_embrasure_log_edge_ns",
-          "t_embrasure_log_edge_ew"
-        ],
-        "bg": [
-          "t_wall_log_edge_ns",
-          "t_wall_log_edge_ew"
-        ]
+        "fg": [ "t_embrasure_log_edge_ns", "t_embrasure_log_edge_ew" ],
+        "bg": [ "t_wall_log_edge_ns", "t_wall_log_edge_ew" ]
       },
       {
         "id": "end_piece",
         "fg": [
           "t_embrasure_log_end_piece_n",
-          "t_embrasure_log_end_piece_w",
+          "t_embrasure_log_end_piece_e",
           "t_embrasure_log_end_piece_s",
-          "t_embrasure_log_end_piece_e"
+          "t_embrasure_log_end_piece_w"
         ],
-        "bg": [
-          "t_wall_log_end_piece_n",
-          "t_wall_log_end_piece_w",
-          "t_wall_log_end_piece_s",
-          "t_wall_log_end_piece_e"
-        ]
+        "bg": [ "t_wall_log_end_piece_n", "t_wall_log_end_piece_e", "t_wall_log_end_piece_s", "t_wall_log_end_piece_w" ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_embrasure_log_unconnected",
-        "bg": "snow_shallow_center"
-      }
+      { "id": "unconnected", "fg": "t_embrasure_log_unconnected", "bg": "snow_shallow_center" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_embrasure_rock/t_embrasure_rock.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_embrasure_rock/t_embrasure_rock.json
@@ -4,71 +4,47 @@
   "bg": "t_rock_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_embrasure_rock_center",
-      "bg": "t_rock_wall_center"
-    },
+    { "id": "center", "fg": "t_embrasure_rock_center", "bg": "t_rock_wall_center" },
     {
       "id": "corner",
       "fg": [
         "t_embrasure_rock_corner_nw",
-        "t_embrasure_rock_corner_sw",
+        "t_embrasure_rock_corner_ne",
         "t_embrasure_rock_corner_se",
-        "t_embrasure_rock_corner_ne"
+        "t_embrasure_rock_corner_sw"
       ],
-      "bg": [
-        "t_rock_wall_corner_nw",
-        "t_rock_wall_corner_sw",
-        "t_rock_wall_corner_se",
-        "t_rock_wall_corner_ne"
-      ]
+      "bg": [ "t_rock_wall_corner_nw", "t_rock_wall_corner_ne", "t_rock_wall_corner_se", "t_rock_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_embrasure_rock_t_connection_n",
-        "t_embrasure_rock_t_connection_w",
+        "t_embrasure_rock_t_connection_e",
         "t_embrasure_rock_t_connection_s",
-        "t_embrasure_rock_t_connection_e"
+        "t_embrasure_rock_t_connection_w"
       ],
       "bg": [
         "t_rock_wall_t_connection_n",
-        "t_rock_wall_t_connection_w",
+        "t_rock_wall_t_connection_e",
         "t_rock_wall_t_connection_s",
-        "t_rock_wall_t_connection_e"
+        "t_rock_wall_t_connection_w"
       ]
     },
     {
       "id": "edge",
-      "fg": [
-        "t_embrasure_rock_edge_ns",
-        "t_embrasure_rock_edge_ew"
-      ],
-      "bg": [
-        "t_rock_wall_edge_ns",
-        "t_rock_wall_edge_ew"
-      ]
+      "fg": [ "t_embrasure_rock_edge_ns", "t_embrasure_rock_edge_ew" ],
+      "bg": [ "t_rock_wall_edge_ns", "t_rock_wall_edge_ew" ]
     },
     {
       "id": "end_piece",
       "fg": [
         "t_embrasure_rock_end_piece_n",
-        "t_embrasure_rock_end_piece_w",
+        "t_embrasure_rock_end_piece_e",
         "t_embrasure_rock_end_piece_s",
-        "t_embrasure_rock_end_piece_e"
+        "t_embrasure_rock_end_piece_w"
       ],
-      "bg": [
-        "t_rock_wall_end_piece_n",
-        "t_rock_wall_end_piece_w",
-        "t_rock_wall_end_piece_s",
-        "t_rock_wall_end_piece_e"
-      ]
+      "bg": [ "t_rock_wall_end_piece_n", "t_rock_wall_end_piece_e", "t_rock_wall_end_piece_s", "t_rock_wall_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_embrasure_rock_unconnected",
-      "bg": "t_rock_wall_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_embrasure_rock_unconnected", "bg": "t_rock_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_embrasure_sconc/t_embrasure_concrete.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_embrasure_sconc/t_embrasure_concrete.json
@@ -5,72 +5,48 @@
     "bg": "t_sconc_wall_unconnected",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_embrasure_sconc_center",
-        "bg": "t_sconc_wall_center"
-      },
+      { "id": "center", "fg": "t_embrasure_sconc_center", "bg": "t_sconc_wall_center" },
       {
         "id": "corner",
         "fg": [
           "t_embrasure_sconc_corner_nw",
-          "t_embrasure_sconc_corner_sw",
+          "t_embrasure_sconc_corner_ne",
           "t_embrasure_sconc_corner_se",
-          "t_embrasure_sconc_corner_ne"
+          "t_embrasure_sconc_corner_sw"
         ],
-        "bg": [
-          "t_sconc_wall_corner_nw",
-          "t_sconc_wall_corner_sw",
-          "t_sconc_wall_corner_se",
-          "t_sconc_wall_corner_ne"
-        ]
+        "bg": [ "t_sconc_wall_corner_nw", "t_sconc_wall_corner_ne", "t_sconc_wall_corner_se", "t_sconc_wall_corner_sw" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_embrasure_sconc_t_connection_n",
-          "t_embrasure_sconc_t_connection_w",
+          "t_embrasure_sconc_t_connection_e",
           "t_embrasure_sconc_t_connection_s",
-          "t_embrasure_sconc_t_connection_e"
+          "t_embrasure_sconc_t_connection_w"
         ],
         "bg": [
           "t_sconc_wall_t_connection_n",
-          "t_sconc_wall_t_connection_w",
+          "t_sconc_wall_t_connection_e",
           "t_sconc_wall_t_connection_s",
-          "t_sconc_wall_t_connection_e"
+          "t_sconc_wall_t_connection_w"
         ]
       },
       {
         "id": "edge",
-        "fg": [
-          "t_embrasure_sconc_edge_ns",
-          "t_embrasure_sconc_edge_ew"
-        ],
-        "bg": [
-          "t_sconc_wall_edge_ns",
-          "t_sconc_wall_edge_ew"
-        ]
+        "fg": [ "t_embrasure_sconc_edge_ns", "t_embrasure_sconc_edge_ew" ],
+        "bg": [ "t_sconc_wall_edge_ns", "t_sconc_wall_edge_ew" ]
       },
       {
         "id": "end_piece",
         "fg": [
           "t_embrasure_sconc_end_piece_n",
-          "t_embrasure_sconc_end_piece_w",
+          "t_embrasure_sconc_end_piece_e",
           "t_embrasure_sconc_end_piece_s",
-          "t_embrasure_sconc_end_piece_e"
+          "t_embrasure_sconc_end_piece_w"
         ],
-        "bg": [
-          "t_sconc_wall_end_piece_n",
-          "t_sconc_wall_end_piece_w",
-          "t_sconc_wall_end_piece_s",
-          "t_sconc_wall_end_piece_e"
-        ]
+        "bg": [ "t_sconc_wall_end_piece_n", "t_sconc_wall_end_piece_e", "t_sconc_wall_end_piece_s", "t_sconc_wall_end_piece_w" ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_embrasure_sconc_unconnected",
-        "bg": "t_sconc_wall_unconnected"
-      }
+      { "id": "unconnected", "fg": "t_embrasure_sconc_unconnected", "bg": "t_sconc_wall_unconnected" }
     ]
   },
   {
@@ -79,72 +55,53 @@
     "bg": "t_strconc_wall_unconnected",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_embrasure_sconc_center",
-        "bg": "t_strconc_wall_center"
-      },
+      { "id": "center", "fg": "t_embrasure_sconc_center", "bg": "t_strconc_wall_center" },
       {
         "id": "corner",
         "fg": [
           "t_embrasure_sconc_corner_nw",
-          "t_embrasure_sconc_corner_sw",
+          "t_embrasure_sconc_corner_ne",
           "t_embrasure_sconc_corner_se",
-          "t_embrasure_sconc_corner_ne"
+          "t_embrasure_sconc_corner_sw"
         ],
-        "bg": [
-          "t_strconc_wall_corner_nw",
-          "t_strconc_wall_corner_sw",
-          "t_strconc_wall_corner_se",
-          "t_strconc_wall_corner_ne"
-        ]
+        "bg": [ "t_strconc_wall_corner_nw", "t_strconc_wall_corner_ne", "t_strconc_wall_corner_se", "t_strconc_wall_corner_sw" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_embrasure_sconc_t_connection_n",
-          "t_embrasure_sconc_t_connection_w",
+          "t_embrasure_sconc_t_connection_e",
           "t_embrasure_sconc_t_connection_s",
-          "t_embrasure_sconc_t_connection_e"
+          "t_embrasure_sconc_t_connection_w"
         ],
         "bg": [
           "t_strconc_wall_t_connection_n",
-          "t_strconc_wall_t_connection_w",
+          "t_strconc_wall_t_connection_e",
           "t_strconc_wall_t_connection_s",
-          "t_strconc_wall_t_connection_e"
+          "t_strconc_wall_t_connection_w"
         ]
       },
       {
         "id": "edge",
-        "fg": [
-          "t_embrasure_sconc_edge_ns",
-          "t_embrasure_sconc_edge_ew"
-        ],
-        "bg": [
-          "t_strconc_wall_edge_ns",
-          "t_strconc_wall_edge_ew"
-        ]
+        "fg": [ "t_embrasure_sconc_edge_ns", "t_embrasure_sconc_edge_ew" ],
+        "bg": [ "t_strconc_wall_edge_ns", "t_strconc_wall_edge_ew" ]
       },
       {
         "id": "end_piece",
         "fg": [
           "t_embrasure_sconc_end_piece_n",
-          "t_embrasure_sconc_end_piece_w",
+          "t_embrasure_sconc_end_piece_e",
           "t_embrasure_sconc_end_piece_s",
-          "t_embrasure_sconc_end_piece_e"
+          "t_embrasure_sconc_end_piece_w"
         ],
         "bg": [
           "t_strconc_wall_end_piece_n",
-          "t_strconc_wall_end_piece_w",
+          "t_strconc_wall_end_piece_e",
           "t_strconc_wall_end_piece_s",
-          "t_strconc_wall_end_piece_e"
+          "t_strconc_wall_end_piece_w"
         ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_embrasure_sconc_unconnected",
-        "bg": "t_strconc_wall_unconnected"
-      }
+      { "id": "unconnected", "fg": "t_embrasure_sconc_unconnected", "bg": "t_strconc_wall_unconnected" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_embrasure_wood/t_embrasure_wood.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_embrasure_wood/t_embrasure_wood.json
@@ -4,71 +4,47 @@
   "bg": "t_wall_wood_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_embrasure_wood_t_connection_n",
-      "bg": "t_wall_wood_t_connection_n"
-    },
+    { "id": "center", "fg": "t_embrasure_wood_t_connection_n", "bg": "t_wall_wood_t_connection_n" },
     {
       "id": "corner",
       "fg": [
         "t_embrasure_wood_corner_nw",
-        "t_embrasure_wood_corner_sw",
+        "t_embrasure_wood_corner_ne",
         "t_embrasure_wood_corner_se",
-        "t_embrasure_wood_corner_ne"
+        "t_embrasure_wood_corner_sw"
       ],
-      "bg": [
-        "t_wall_wood_corner_nw",
-        "t_wall_wood_corner_sw",
-        "t_wall_wood_corner_se",
-        "t_wall_wood_corner_ne"
-      ]
+      "bg": [ "t_wall_wood_corner_nw", "t_wall_wood_corner_ne", "t_wall_wood_corner_se", "t_wall_wood_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_embrasure_wood_t_connection_n",
-        "t_embrasure_wood_t_connection_w",
+        "t_embrasure_wood_t_connection_e",
         "t_embrasure_wood_t_connection_s",
-        "t_embrasure_wood_t_connection_e"
+        "t_embrasure_wood_t_connection_w"
       ],
       "bg": [
         "t_wall_wood_t_connection_n",
-        "t_wall_wood_t_connection_w",
+        "t_wall_wood_t_connection_e",
         "t_wall_wood_t_connection_s",
-        "t_wall_wood_t_connection_e"
+        "t_wall_wood_t_connection_w"
       ]
     },
     {
       "id": "edge",
-      "fg": [
-        "t_embrasure_wood_edge_ns",
-        "t_embrasure_wood_edge_ew"
-      ],
-      "bg": [
-        "t_wall_wood_edge_ns",
-        "t_wall_wood_edge_ew"
-      ]
+      "fg": [ "t_embrasure_wood_edge_ns", "t_embrasure_wood_edge_ew" ],
+      "bg": [ "t_wall_wood_edge_ns", "t_wall_wood_edge_ew" ]
     },
     {
       "id": "end_piece",
       "fg": [
         "t_embrasure_wood_end_piece_n",
-        "t_embrasure_wood_end_piece_w",
+        "t_embrasure_wood_end_piece_e",
         "t_embrasure_wood_end_piece_s",
-        "t_embrasure_wood_end_piece_e"
+        "t_embrasure_wood_end_piece_w"
       ],
-      "bg": [
-        "t_wall_wood_end_piece_n",
-        "t_wall_wood_end_piece_w",
-        "t_wall_wood_end_piece_s",
-        "t_wall_wood_end_piece_e"
-      ]
+      "bg": [ "t_wall_wood_end_piece_n", "t_wall_wood_end_piece_e", "t_wall_wood_end_piece_s", "t_wall_wood_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_embrasure_wood_unconnected",
-      "bg": "t_wall_wood_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_embrasure_wood_unconnected", "bg": "t_wall_wood_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fence/t_fence.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fence/t_fence.json
@@ -9,18 +9,18 @@
       {
         "id": "corner",
         "bg": "t_grass",
-        "fg": [ "t_fence_corner_nw", "t_fence_corner_sw", "t_fence_corner_se", "t_fence_corner_ne" ]
+        "fg": [ "t_fence_corner_nw", "t_fence_corner_ne", "t_fence_corner_se", "t_fence_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass",
-        "fg": [ "t_fence_t_connection_n", "t_fence_t_connection_w", "t_fence_t_connection_s", "t_fence_t_connection_e" ]
+        "fg": [ "t_fence_t_connection_n", "t_fence_t_connection_e", "t_fence_t_connection_s", "t_fence_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_grass", "fg": [ "t_fence_edge_ns", "t_fence_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass",
-        "fg": [ "t_fence_end_piece_n", "t_fence_end_piece_w", "t_fence_end_piece_s", "t_fence_end_piece_e" ]
+        "fg": [ "t_fence_end_piece_n", "t_fence_end_piece_e", "t_fence_end_piece_s", "t_fence_end_piece_w" ]
       },
       { "bg": "t_grass", "id": "unconnected", "fg": "t_fence_unconnected" }
     ]
@@ -35,18 +35,18 @@
       {
         "id": "corner",
         "bg": "t_grass_summer",
-        "fg": [ "t_fence_corner_nw", "t_fence_corner_sw", "t_fence_corner_se", "t_fence_corner_ne" ]
+        "fg": [ "t_fence_corner_nw", "t_fence_corner_ne", "t_fence_corner_se", "t_fence_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_summer",
-        "fg": [ "t_fence_t_connection_n", "t_fence_t_connection_w", "t_fence_t_connection_s", "t_fence_t_connection_e" ]
+        "fg": [ "t_fence_t_connection_n", "t_fence_t_connection_e", "t_fence_t_connection_s", "t_fence_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_grass_summer", "fg": [ "t_fence_edge_ns", "t_fence_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_summer",
-        "fg": [ "t_fence_end_piece_n", "t_fence_end_piece_w", "t_fence_end_piece_s", "t_fence_end_piece_e" ]
+        "fg": [ "t_fence_end_piece_n", "t_fence_end_piece_e", "t_fence_end_piece_s", "t_fence_end_piece_w" ]
       },
       { "bg": "t_grass_summer", "id": "unconnected", "fg": "t_fence_unconnected" }
     ]
@@ -61,18 +61,18 @@
       {
         "id": "corner",
         "bg": "t_grass_autumn",
-        "fg": [ "t_fence_corner_nw", "t_fence_corner_sw", "t_fence_corner_se", "t_fence_corner_ne" ]
+        "fg": [ "t_fence_corner_nw", "t_fence_corner_ne", "t_fence_corner_se", "t_fence_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_autumn",
-        "fg": [ "t_fence_t_connection_n", "t_fence_t_connection_w", "t_fence_t_connection_s", "t_fence_t_connection_e" ]
+        "fg": [ "t_fence_t_connection_n", "t_fence_t_connection_e", "t_fence_t_connection_s", "t_fence_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_grass_autumn", "fg": [ "t_fence_edge_ns", "t_fence_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_autumn",
-        "fg": [ "t_fence_end_piece_n", "t_fence_end_piece_w", "t_fence_end_piece_s", "t_fence_end_piece_e" ]
+        "fg": [ "t_fence_end_piece_n", "t_fence_end_piece_e", "t_fence_end_piece_s", "t_fence_end_piece_w" ]
       },
       { "bg": "t_grass_autumn", "id": "unconnected", "fg": "t_fence_unconnected" }
     ]
@@ -87,18 +87,18 @@
       {
         "id": "corner",
         "bg": "snow_shallow_center",
-        "fg": [ "t_fence_corner_nw", "t_fence_corner_sw", "t_fence_corner_se", "t_fence_corner_ne" ]
+        "fg": [ "t_fence_corner_nw", "t_fence_corner_ne", "t_fence_corner_se", "t_fence_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "snow_shallow_center",
-        "fg": [ "t_fence_t_connection_n", "t_fence_t_connection_w", "t_fence_t_connection_s", "t_fence_t_connection_e" ]
+        "fg": [ "t_fence_t_connection_n", "t_fence_t_connection_e", "t_fence_t_connection_s", "t_fence_t_connection_w" ]
       },
       { "id": "edge", "bg": "snow_shallow_center", "fg": [ "t_fence_edge_ns", "t_fence_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "snow_shallow_center",
-        "fg": [ "t_fence_end_piece_n", "t_fence_end_piece_w", "t_fence_end_piece_s", "t_fence_end_piece_e" ]
+        "fg": [ "t_fence_end_piece_n", "t_fence_end_piece_e", "t_fence_end_piece_s", "t_fence_end_piece_w" ]
       },
       { "bg": "snow_shallow_center", "id": "unconnected", "fg": "t_fence_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fence_barbed/t_fence_barbed.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fence_barbed/t_fence_barbed.json
@@ -9,18 +9,28 @@
       {
         "id": "corner",
         "bg": "t_grass",
-        "fg": [ "t_fence_barbed_corner_nw", "t_fence_barbed_corner_sw", "t_fence_barbed_corner_se", "t_fence_barbed_corner_ne" ]
+        "fg": [ "t_fence_barbed_corner_nw", "t_fence_barbed_corner_ne", "t_fence_barbed_corner_se", "t_fence_barbed_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass",
-        "fg": [ "t_fence_barbed_t_connection_n", "t_fence_barbed_t_connection_w", "t_fence_barbed_t_connection_s", "t_fence_barbed_t_connection_e" ]
+        "fg": [
+          "t_fence_barbed_t_connection_n",
+          "t_fence_barbed_t_connection_e",
+          "t_fence_barbed_t_connection_s",
+          "t_fence_barbed_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "t_grass", "fg": [ "t_fence_barbed_edge_ns", "t_fence_barbed_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass",
-        "fg": [ "t_fence_barbed_end_piece_n", "t_fence_barbed_end_piece_w", "t_fence_barbed_end_piece_s", "t_fence_barbed_end_piece_e" ]
+        "fg": [
+          "t_fence_barbed_end_piece_n",
+          "t_fence_barbed_end_piece_e",
+          "t_fence_barbed_end_piece_s",
+          "t_fence_barbed_end_piece_w"
+        ]
       },
       { "bg": "t_grass", "id": "unconnected", "fg": "t_fence_barbed_unconnected" }
     ]
@@ -35,18 +45,28 @@
       {
         "id": "corner",
         "bg": "t_grass_summer",
-        "fg": [ "t_fence_barbed_corner_nw", "t_fence_barbed_corner_sw", "t_fence_barbed_corner_se", "t_fence_barbed_corner_ne" ]
+        "fg": [ "t_fence_barbed_corner_nw", "t_fence_barbed_corner_ne", "t_fence_barbed_corner_se", "t_fence_barbed_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_summer",
-        "fg": [ "t_fence_barbed_t_connection_n", "t_fence_barbed_t_connection_w", "t_fence_barbed_t_connection_s", "t_fence_barbed_t_connection_e" ]
+        "fg": [
+          "t_fence_barbed_t_connection_n",
+          "t_fence_barbed_t_connection_e",
+          "t_fence_barbed_t_connection_s",
+          "t_fence_barbed_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "t_grass_summer", "fg": [ "t_fence_barbed_edge_ns", "t_fence_barbed_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_summer",
-        "fg": [ "t_fence_barbed_end_piece_n", "t_fence_barbed_end_piece_w", "t_fence_barbed_end_piece_s", "t_fence_barbed_end_piece_e" ]
+        "fg": [
+          "t_fence_barbed_end_piece_n",
+          "t_fence_barbed_end_piece_e",
+          "t_fence_barbed_end_piece_s",
+          "t_fence_barbed_end_piece_w"
+        ]
       },
       { "bg": "t_grass_summer", "id": "unconnected", "fg": "t_fence_barbed_unconnected" }
     ]
@@ -61,18 +81,28 @@
       {
         "id": "corner",
         "bg": "t_grass_autumn",
-        "fg": [ "t_fence_barbed_corner_nw", "t_fence_barbed_corner_sw", "t_fence_barbed_corner_se", "t_fence_barbed_corner_ne" ]
+        "fg": [ "t_fence_barbed_corner_nw", "t_fence_barbed_corner_ne", "t_fence_barbed_corner_se", "t_fence_barbed_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_autumn",
-        "fg": [ "t_fence_barbed_t_connection_n", "t_fence_barbed_t_connection_w", "t_fence_barbed_t_connection_s", "t_fence_barbed_t_connection_e" ]
+        "fg": [
+          "t_fence_barbed_t_connection_n",
+          "t_fence_barbed_t_connection_e",
+          "t_fence_barbed_t_connection_s",
+          "t_fence_barbed_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "t_grass_autumn", "fg": [ "t_fence_barbed_edge_ns", "t_fence_barbed_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_autumn",
-        "fg": [ "t_fence_barbed_end_piece_n", "t_fence_barbed_end_piece_w", "t_fence_barbed_end_piece_s", "t_fence_barbed_end_piece_e" ]
+        "fg": [
+          "t_fence_barbed_end_piece_n",
+          "t_fence_barbed_end_piece_e",
+          "t_fence_barbed_end_piece_s",
+          "t_fence_barbed_end_piece_w"
+        ]
       },
       { "bg": "t_grass_autumn", "id": "unconnected", "fg": "t_fence_barbed_unconnected" }
     ]
@@ -87,18 +117,28 @@
       {
         "id": "corner",
         "bg": "snow_shallow_center",
-        "fg": [ "t_fence_barbed_corner_nw", "t_fence_barbed_corner_sw", "t_fence_barbed_corner_se", "t_fence_barbed_corner_ne" ]
+        "fg": [ "t_fence_barbed_corner_nw", "t_fence_barbed_corner_ne", "t_fence_barbed_corner_se", "t_fence_barbed_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "snow_shallow_center",
-        "fg": [ "t_fence_barbed_t_connection_n", "t_fence_barbed_t_connection_w", "t_fence_barbed_t_connection_s", "t_fence_barbed_t_connection_e" ]
+        "fg": [
+          "t_fence_barbed_t_connection_n",
+          "t_fence_barbed_t_connection_e",
+          "t_fence_barbed_t_connection_s",
+          "t_fence_barbed_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "snow_shallow_center", "fg": [ "t_fence_barbed_edge_ns", "t_fence_barbed_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "snow_shallow_center",
-        "fg": [ "t_fence_barbed_end_piece_n", "t_fence_barbed_end_piece_w", "t_fence_barbed_end_piece_s", "t_fence_barbed_end_piece_e" ]
+        "fg": [
+          "t_fence_barbed_end_piece_n",
+          "t_fence_barbed_end_piece_e",
+          "t_fence_barbed_end_piece_s",
+          "t_fence_barbed_end_piece_w"
+        ]
       },
       { "bg": "snow_shallow_center", "id": "unconnected", "fg": "t_fence_barbed_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fence_rope/t_fence_rope.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fence_rope/t_fence_rope.json
@@ -8,23 +8,23 @@
       { "id": "center", "fg": "t_fence_rope_center", "bg": "t_grass" },
       {
         "id": "corner",
-        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_sw", "t_fence_rope_corner_se", "t_fence_rope_corner_ne" ],
+        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_ne", "t_fence_rope_corner_se", "t_fence_rope_corner_sw" ],
         "bg": "t_grass"
       },
       {
         "id": "t_connection",
         "fg": [
           "t_fence_rope_t_connection_n",
-          "t_fence_rope_t_connection_w",
+          "t_fence_rope_t_connection_e",
           "t_fence_rope_t_connection_s",
-          "t_fence_rope_t_connection_e"
+          "t_fence_rope_t_connection_w"
         ],
         "bg": "t_grass"
       },
       { "id": "edge", "fg": [ "t_fence_rope_edge_ns", "t_fence_rope_edge_ew" ], "bg": "t_grass" },
       {
         "id": "end_piece",
-        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_w", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_e" ],
+        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_e", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_w" ],
         "bg": "t_grass"
       },
       { "id": "unconnected", "fg": [ "t_fence_rope_unconnected", "t_fence_rope_unconnected" ], "bg": "t_grass" }
@@ -39,23 +39,23 @@
       { "id": "center", "fg": "t_fence_rope_center", "bg": "t_dirt_season_summer_center" },
       {
         "id": "corner",
-        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_sw", "t_fence_rope_corner_se", "t_fence_rope_corner_ne" ],
+        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_ne", "t_fence_rope_corner_se", "t_fence_rope_corner_sw" ],
         "bg": "t_grass_summer"
       },
       {
         "id": "t_connection",
         "fg": [
           "t_fence_rope_t_connection_n",
-          "t_fence_rope_t_connection_w",
+          "t_fence_rope_t_connection_e",
           "t_fence_rope_t_connection_s",
-          "t_fence_rope_t_connection_e"
+          "t_fence_rope_t_connection_w"
         ],
         "bg": "t_grass_summer"
       },
       { "id": "edge", "fg": [ "t_fence_rope_edge_ns", "t_fence_rope_edge_ew" ], "bg": "t_grass_summer" },
       {
         "id": "end_piece",
-        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_w", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_e" ],
+        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_e", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_w" ],
         "bg": "t_grass_summer"
       },
       {
@@ -74,23 +74,23 @@
       { "id": "center", "fg": "t_fence_rope_center", "bg": "t_dirt_season_autumn_center" },
       {
         "id": "corner",
-        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_sw", "t_fence_rope_corner_se", "t_fence_rope_corner_ne" ],
+        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_ne", "t_fence_rope_corner_se", "t_fence_rope_corner_sw" ],
         "bg": "t_grass_autumn"
       },
       {
         "id": "t_connection",
         "fg": [
           "t_fence_rope_t_connection_n",
-          "t_fence_rope_t_connection_w",
+          "t_fence_rope_t_connection_e",
           "t_fence_rope_t_connection_s",
-          "t_fence_rope_t_connection_e"
+          "t_fence_rope_t_connection_w"
         ],
         "bg": "t_grass_autumn"
       },
       { "id": "edge", "fg": [ "t_fence_rope_edge_ns", "t_fence_rope_edge_ew" ], "bg": "t_grass_autumn" },
       {
         "id": "end_piece",
-        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_w", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_e" ],
+        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_e", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_w" ],
         "bg": "t_grass_autumn"
       },
       {
@@ -109,23 +109,23 @@
       { "id": "center", "fg": "t_fence_rope_center", "bg": "snow_shallow_center" },
       {
         "id": "corner",
-        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_sw", "t_fence_rope_corner_se", "t_fence_rope_corner_ne" ],
+        "fg": [ "t_fence_rope_corner_nw", "t_fence_rope_corner_ne", "t_fence_rope_corner_se", "t_fence_rope_corner_sw" ],
         "bg": "snow_shallow_center"
       },
       {
         "id": "t_connection",
         "fg": [
           "t_fence_rope_t_connection_n",
-          "t_fence_rope_t_connection_w",
+          "t_fence_rope_t_connection_e",
           "t_fence_rope_t_connection_s",
-          "t_fence_rope_t_connection_e"
+          "t_fence_rope_t_connection_w"
         ],
         "bg": "snow_shallow_center"
       },
       { "id": "edge", "fg": [ "t_fence_rope_edge_ns", "t_fence_rope_edge_ew" ], "bg": "snow_shallow_center" },
       {
         "id": "end_piece",
-        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_w", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_e" ],
+        "fg": [ "t_fence_rope_end_piece_n", "t_fence_rope_end_piece_e", "t_fence_rope_end_piece_s", "t_fence_rope_end_piece_w" ],
         "bg": "snow_shallow_center"
       },
       {

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fence_wire/t_fence_wire.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fence_wire/t_fence_wire.json
@@ -9,18 +9,23 @@
       {
         "id": "corner",
         "bg": "t_grass",
-        "fg": [ "t_fence_wire_corner_nw", "t_fence_wire_corner_sw", "t_fence_wire_corner_se", "t_fence_wire_corner_ne" ]
+        "fg": [ "t_fence_wire_corner_nw", "t_fence_wire_corner_ne", "t_fence_wire_corner_se", "t_fence_wire_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass",
-        "fg": [ "t_fence_wire_t_connection_n", "t_fence_wire_t_connection_w", "t_fence_wire_t_connection_s", "t_fence_wire_t_connection_e" ]
+        "fg": [
+          "t_fence_wire_t_connection_n",
+          "t_fence_wire_t_connection_e",
+          "t_fence_wire_t_connection_s",
+          "t_fence_wire_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "t_grass", "fg": [ "t_fence_wire_edge_ns", "t_fence_wire_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass",
-        "fg": [ "t_fence_wire_end_piece_n", "t_fence_wire_end_piece_w", "t_fence_wire_end_piece_s", "t_fence_wire_end_piece_e" ]
+        "fg": [ "t_fence_wire_end_piece_n", "t_fence_wire_end_piece_e", "t_fence_wire_end_piece_s", "t_fence_wire_end_piece_w" ]
       },
       { "bg": "t_grass", "id": "unconnected", "fg": "t_fence_wire_unconnected" }
     ]
@@ -35,18 +40,23 @@
       {
         "id": "corner",
         "bg": "t_grass_summer",
-        "fg": [ "t_fence_wire_corner_nw", "t_fence_wire_corner_sw", "t_fence_wire_corner_se", "t_fence_wire_corner_ne" ]
+        "fg": [ "t_fence_wire_corner_nw", "t_fence_wire_corner_ne", "t_fence_wire_corner_se", "t_fence_wire_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_summer",
-        "fg": [ "t_fence_wire_t_connection_n", "t_fence_wire_t_connection_w", "t_fence_wire_t_connection_s", "t_fence_wire_t_connection_e" ]
+        "fg": [
+          "t_fence_wire_t_connection_n",
+          "t_fence_wire_t_connection_e",
+          "t_fence_wire_t_connection_s",
+          "t_fence_wire_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "t_grass_summer", "fg": [ "t_fence_wire_edge_ns", "t_fence_wire_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_summer",
-        "fg": [ "t_fence_wire_end_piece_n", "t_fence_wire_end_piece_w", "t_fence_wire_end_piece_s", "t_fence_wire_end_piece_e" ]
+        "fg": [ "t_fence_wire_end_piece_n", "t_fence_wire_end_piece_e", "t_fence_wire_end_piece_s", "t_fence_wire_end_piece_w" ]
       },
       { "bg": "t_grass_summer", "id": "unconnected", "fg": "t_fence_wire_unconnected" }
     ]
@@ -61,18 +71,23 @@
       {
         "id": "corner",
         "bg": "t_grass_autumn",
-        "fg": [ "t_fence_wire_corner_nw", "t_fence_wire_corner_sw", "t_fence_wire_corner_se", "t_fence_wire_corner_ne" ]
+        "fg": [ "t_fence_wire_corner_nw", "t_fence_wire_corner_ne", "t_fence_wire_corner_se", "t_fence_wire_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_autumn",
-        "fg": [ "t_fence_wire_t_connection_n", "t_fence_wire_t_connection_w", "t_fence_wire_t_connection_s", "t_fence_wire_t_connection_e" ]
+        "fg": [
+          "t_fence_wire_t_connection_n",
+          "t_fence_wire_t_connection_e",
+          "t_fence_wire_t_connection_s",
+          "t_fence_wire_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "t_grass_autumn", "fg": [ "t_fence_wire_edge_ns", "t_fence_wire_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_autumn",
-        "fg": [ "t_fence_wire_end_piece_n", "t_fence_wire_end_piece_w", "t_fence_wire_end_piece_s", "t_fence_wire_end_piece_e" ]
+        "fg": [ "t_fence_wire_end_piece_n", "t_fence_wire_end_piece_e", "t_fence_wire_end_piece_s", "t_fence_wire_end_piece_w" ]
       },
       { "bg": "t_grass_autumn", "id": "unconnected", "fg": "t_fence_wire_unconnected" }
     ]
@@ -87,18 +102,23 @@
       {
         "id": "corner",
         "bg": "snow_shallow_center",
-        "fg": [ "t_fence_wire_corner_nw", "t_fence_wire_corner_sw", "t_fence_wire_corner_se", "t_fence_wire_corner_ne" ]
+        "fg": [ "t_fence_wire_corner_nw", "t_fence_wire_corner_ne", "t_fence_wire_corner_se", "t_fence_wire_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "snow_shallow_center",
-        "fg": [ "t_fence_wire_t_connection_n", "t_fence_wire_t_connection_w", "t_fence_wire_t_connection_s", "t_fence_wire_t_connection_e" ]
+        "fg": [
+          "t_fence_wire_t_connection_n",
+          "t_fence_wire_t_connection_e",
+          "t_fence_wire_t_connection_s",
+          "t_fence_wire_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "snow_shallow_center", "fg": [ "t_fence_wire_edge_ns", "t_fence_wire_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "snow_shallow_center",
-        "fg": [ "t_fence_wire_end_piece_n", "t_fence_wire_end_piece_w", "t_fence_wire_end_piece_s", "t_fence_wire_end_piece_e" ]
+        "fg": [ "t_fence_wire_end_piece_n", "t_fence_wire_end_piece_e", "t_fence_wire_end_piece_s", "t_fence_wire_end_piece_w" ]
       },
       { "bg": "snow_shallow_center", "id": "unconnected", "fg": "t_fence_wire_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_floor/t_floor.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_floor/t_floor.json
@@ -8,53 +8,27 @@
       "id": "center",
       "bg": "",
       "fg": [
-          { "weight": 1, "sprite": "t_floor_center" },
-          { "weight": 1, "sprite": "t_floor_center2" },
-          { "weight": 1, "sprite": "t_floor_center3" }
+        { "weight": 1, "sprite": "t_floor_center" },
+        { "weight": 1, "sprite": "t_floor_center2" },
+        { "weight": 1, "sprite": "t_floor_center3" }
       ]
     },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_floor_corner_nw",
-        "t_floor_corner_sw",
-        "t_floor_corner_se",
-        "t_floor_corner_ne"
-      ]
+      "fg": [ "t_floor_corner_nw", "t_floor_corner_ne", "t_floor_corner_se", "t_floor_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "t_floor_t_connection_n",
-        "t_floor_t_connection_w",
-        "t_floor_t_connection_s",
-        "t_floor_t_connection_e"
-      ]
+      "fg": [ "t_floor_t_connection_n", "t_floor_t_connection_e", "t_floor_t_connection_s", "t_floor_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_floor_edge_ns",
-        "t_floor_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_floor_edge_ns", "t_floor_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_floor_end_piece_n",
-        "t_floor_end_piece_w",
-        "t_floor_end_piece_s",
-        "t_floor_end_piece_e"
-      ]
+      "fg": [ "t_floor_end_piece_n", "t_floor_end_piece_e", "t_floor_end_piece_s", "t_floor_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_floor_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_floor_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_floor_resin/t_floor_resin.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_floor_resin/t_floor_resin.json
@@ -4,53 +4,28 @@
   "fg": "t_floor_resin_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_floor_resin_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_floor_resin_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_floor_resin_corner_nw",
-        "t_floor_resin_corner_sw",
-        "t_floor_resin_corner_se",
-        "t_floor_resin_corner_ne"
-      ]
+      "fg": [ "t_floor_resin_corner_nw", "t_floor_resin_corner_ne", "t_floor_resin_corner_se", "t_floor_resin_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_floor_resin_t_connection_n",
-        "t_floor_resin_t_connection_w",
+        "t_floor_resin_t_connection_e",
         "t_floor_resin_t_connection_s",
-        "t_floor_resin_t_connection_e"
+        "t_floor_resin_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_floor_resin_edge_ns",
-        "t_floor_resin_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_floor_resin_edge_ns", "t_floor_resin_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_floor_resin_end_piece_n",
-        "t_floor_resin_end_piece_w",
-        "t_floor_resin_end_piece_s",
-        "t_floor_resin_end_piece_e"
-      ]
+      "fg": [ "t_floor_resin_end_piece_n", "t_floor_resin_end_piece_e", "t_floor_resin_end_piece_s", "t_floor_resin_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_floor_resin_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_floor_resin_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_floor_wax/t_floor_wax.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_floor_wax/t_floor_wax.json
@@ -4,53 +4,28 @@
   "fg": "t_floor_wax_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_floor_wax_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_floor_wax_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_floor_wax_corner_nw",
-        "t_floor_wax_corner_sw",
-        "t_floor_wax_corner_se",
-        "t_floor_wax_corner_ne"
-      ]
+      "fg": [ "t_floor_wax_corner_nw", "t_floor_wax_corner_ne", "t_floor_wax_corner_se", "t_floor_wax_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_floor_wax_t_connection_n",
-        "t_floor_wax_t_connection_w",
+        "t_floor_wax_t_connection_e",
         "t_floor_wax_t_connection_s",
-        "t_floor_wax_t_connection_e"
+        "t_floor_wax_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_floor_wax_edge_ns",
-        "t_floor_wax_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_floor_wax_edge_ns", "t_floor_wax_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_floor_wax_end_piece_n",
-        "t_floor_wax_end_piece_w",
-        "t_floor_wax_end_piece_s",
-        "t_floor_wax_end_piece_e"
-      ]
+      "fg": [ "t_floor_wax_end_piece_n", "t_floor_wax_end_piece_e", "t_floor_wax_end_piece_s", "t_floor_wax_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_floor_wax_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_floor_wax_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_floor_waxed/t_floor_waxed.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_floor_waxed/t_floor_waxed.json
@@ -4,53 +4,28 @@
   "fg": "t_floor_waxed_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_floor_waxed_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_floor_waxed_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_floor_waxed_corner_nw",
-        "t_floor_waxed_corner_sw",
-        "t_floor_waxed_corner_se",
-        "t_floor_waxed_corner_ne"
-      ]
+      "fg": [ "t_floor_waxed_corner_nw", "t_floor_waxed_corner_ne", "t_floor_waxed_corner_se", "t_floor_waxed_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_floor_waxed_t_connection_n",
-        "t_floor_waxed_t_connection_w",
+        "t_floor_waxed_t_connection_e",
         "t_floor_waxed_t_connection_s",
-        "t_floor_waxed_t_connection_e"
+        "t_floor_waxed_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_floor_waxed_edge_ns",
-        "t_floor_waxed_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_floor_waxed_edge_ns", "t_floor_waxed_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_floor_waxed_end_piece_n",
-        "t_floor_waxed_end_piece_w",
-        "t_floor_waxed_end_piece_s",
-        "t_floor_waxed_end_piece_e"
-      ]
+      "fg": [ "t_floor_waxed_end_piece_n", "t_floor_waxed_end_piece_e", "t_floor_waxed_end_piece_s", "t_floor_waxed_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_floor_waxed_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_floor_waxed_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_floor_waxed_y/t_floor_waxed_y.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_floor_waxed_y/t_floor_waxed_y.json
@@ -4,53 +4,33 @@
   "fg": "t_floor_waxed_y_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_floor_waxed_y_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_floor_waxed_y_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_floor_waxed_y_corner_nw",
-        "t_floor_waxed_y_corner_sw",
-        "t_floor_waxed_y_corner_se",
-        "t_floor_waxed_y_corner_ne"
-      ]
+      "fg": [ "t_floor_waxed_y_corner_nw", "t_floor_waxed_y_corner_ne", "t_floor_waxed_y_corner_se", "t_floor_waxed_y_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_floor_waxed_y_t_connection_n",
-        "t_floor_waxed_y_t_connection_w",
+        "t_floor_waxed_y_t_connection_e",
         "t_floor_waxed_y_t_connection_s",
-        "t_floor_waxed_y_t_connection_e"
+        "t_floor_waxed_y_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_floor_waxed_y_edge_ns",
-        "t_floor_waxed_y_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_floor_waxed_y_edge_ns", "t_floor_waxed_y_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "t_floor_waxed_y_end_piece_n",
-        "t_floor_waxed_y_end_piece_w",
+        "t_floor_waxed_y_end_piece_e",
         "t_floor_waxed_y_end_piece_s",
-        "t_floor_waxed_y_end_piece_e"
+        "t_floor_waxed_y_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_floor_waxed_y_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_floor_waxed_y_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fungus/t_fungus.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fungus/t_fungus.json
@@ -5,106 +5,154 @@
     "fg": "t_fungus1_unconnected",
     "bg": "t_dirt_center",
     "additional_tiles": [
-      { "id": "center", "bg": "t_dirt_center", "fg": [
-          {"weight": 32, "sprite": "t_fungus1_center"},
-          {"weight": 32, "sprite": "t_fungus2_center"},
-          {"weight": 32, "sprite": "t_fungus3_center"},
-          {"weight": 32, "sprite": "t_fungus4_center"},
-          {"weight": 32, "sprite": "t_fungus5_center"},
-          {"weight": 32, "sprite": "t_fungus6_center"},
-          {"weight": 1, "sprite": "t_fungus_sticks01"},
-          {"weight": 1, "sprite": "t_fungus_sticks02"},
-          {"weight": 1, "sprite": "t_fungus_sticks03"},
-          {"weight": 1, "sprite": "t_fungus_sticks04"},
-          {"weight": 1, "sprite": "t_fungus_sticks05"},
-          {"weight": 1, "sprite": "t_fungus_sticks06"},
-          {"weight": 1, "sprite": "t_fungus_sticks07"},
-          {"weight": 1, "sprite": "t_fungus_sticks08"},
-          {"weight": 1, "sprite": "t_fungus_sticks09"},
-          {"weight": 1, "sprite": "t_fungus_sticks10"},
-          {"weight": 1, "sprite": "t_fungus_sticks11"},
-          {"weight": 1, "sprite": "t_fungus_sticks12"},
-          {"weight": 1, "sprite": "t_fungus_sticks13"},
-          {"weight": 1, "sprite": "t_fungus_sticks14"},
-          {"weight": 1, "sprite": "t_fungus_sticks15"},
-          {"weight": 1, "sprite": "t_fungus_1ball16"},
-          {"weight": 1, "sprite": "t_fungus_1ball01"},
-          {"weight": 1, "sprite": "t_fungus_1ball02"},
-          {"weight": 1, "sprite": "t_fungus_1ball03"},
-          {"weight": 1, "sprite": "t_fungus_1ball04"},
-          {"weight": 1, "sprite": "t_fungus_1ball05"},
-          {"weight": 1, "sprite": "t_fungus_1ball06"},
-          {"weight": 1, "sprite": "t_fungus_1ball07"},
-          {"weight": 1, "sprite": "t_fungus_1ball08"},
-          {"weight": 1, "sprite": "t_fungus_1ball09"},
-          {"weight": 1, "sprite": "t_fungus_1ball10"},
-          {"weight": 1, "sprite": "t_fungus_1ball11"},
-          {"weight": 1, "sprite": "t_fungus_1ball12"},
-          {"weight": 1, "sprite": "t_fungus_1ball13"},
-          {"weight": 1, "sprite": "t_fungus_1ball14"},
-          {"weight": 1, "sprite": "t_fungus_1ball15"},
-          {"weight": 1, "sprite": "t_fungus_1ball16"},
-          {"weight": 1, "sprite": "t_fungus_1ball16"},
-          {"weight": 1, "sprite": "t_fungus_2balls01"},
-          {"weight": 1, "sprite": "t_fungus_2balls02"},
-          {"weight": 1, "sprite": "t_fungus_2balls03"},
-          {"weight": 1, "sprite": "t_fungus_2balls04"},
-          {"weight": 1, "sprite": "t_fungus_2balls05"},
-          {"weight": 1, "sprite": "t_fungus_2balls06"},
-          {"weight": 1, "sprite": "t_fungus_2balls07"},
-          {"weight": 1, "sprite": "t_fungus_2balls08"},
-          {"weight": 1, "sprite": "t_fungus_2balls09"},
-          {"weight": 1, "sprite": "t_fungus_2balls10"},
-          {"weight": 1, "sprite": "t_fungus_2balls11"},
-          {"weight": 1, "sprite": "t_fungus_2balls12"},
-          {"weight": 1, "sprite": "t_fungus_2balls13"},
-          {"weight": 1, "sprite": "t_fungus_2balls14"},
-          {"weight": 1, "sprite": "t_fungus_2balls15"},
-          {"weight": 1, "sprite": "t_fungus_2balls16"}
+      {
+        "id": "center",
+        "bg": "t_dirt_center",
+        "fg": [
+          { "weight": 32, "sprite": "t_fungus1_center" },
+          { "weight": 32, "sprite": "t_fungus2_center" },
+          { "weight": 32, "sprite": "t_fungus3_center" },
+          { "weight": 32, "sprite": "t_fungus4_center" },
+          { "weight": 32, "sprite": "t_fungus5_center" },
+          { "weight": 32, "sprite": "t_fungus6_center" },
+          { "weight": 1, "sprite": "t_fungus_sticks01" },
+          { "weight": 1, "sprite": "t_fungus_sticks02" },
+          { "weight": 1, "sprite": "t_fungus_sticks03" },
+          { "weight": 1, "sprite": "t_fungus_sticks04" },
+          { "weight": 1, "sprite": "t_fungus_sticks05" },
+          { "weight": 1, "sprite": "t_fungus_sticks06" },
+          { "weight": 1, "sprite": "t_fungus_sticks07" },
+          { "weight": 1, "sprite": "t_fungus_sticks08" },
+          { "weight": 1, "sprite": "t_fungus_sticks09" },
+          { "weight": 1, "sprite": "t_fungus_sticks10" },
+          { "weight": 1, "sprite": "t_fungus_sticks11" },
+          { "weight": 1, "sprite": "t_fungus_sticks12" },
+          { "weight": 1, "sprite": "t_fungus_sticks13" },
+          { "weight": 1, "sprite": "t_fungus_sticks14" },
+          { "weight": 1, "sprite": "t_fungus_sticks15" },
+          { "weight": 1, "sprite": "t_fungus_1ball16" },
+          { "weight": 1, "sprite": "t_fungus_1ball01" },
+          { "weight": 1, "sprite": "t_fungus_1ball02" },
+          { "weight": 1, "sprite": "t_fungus_1ball03" },
+          { "weight": 1, "sprite": "t_fungus_1ball04" },
+          { "weight": 1, "sprite": "t_fungus_1ball05" },
+          { "weight": 1, "sprite": "t_fungus_1ball06" },
+          { "weight": 1, "sprite": "t_fungus_1ball07" },
+          { "weight": 1, "sprite": "t_fungus_1ball08" },
+          { "weight": 1, "sprite": "t_fungus_1ball09" },
+          { "weight": 1, "sprite": "t_fungus_1ball10" },
+          { "weight": 1, "sprite": "t_fungus_1ball11" },
+          { "weight": 1, "sprite": "t_fungus_1ball12" },
+          { "weight": 1, "sprite": "t_fungus_1ball13" },
+          { "weight": 1, "sprite": "t_fungus_1ball14" },
+          { "weight": 1, "sprite": "t_fungus_1ball15" },
+          { "weight": 1, "sprite": "t_fungus_1ball16" },
+          { "weight": 1, "sprite": "t_fungus_1ball16" },
+          { "weight": 1, "sprite": "t_fungus_2balls01" },
+          { "weight": 1, "sprite": "t_fungus_2balls02" },
+          { "weight": 1, "sprite": "t_fungus_2balls03" },
+          { "weight": 1, "sprite": "t_fungus_2balls04" },
+          { "weight": 1, "sprite": "t_fungus_2balls05" },
+          { "weight": 1, "sprite": "t_fungus_2balls06" },
+          { "weight": 1, "sprite": "t_fungus_2balls07" },
+          { "weight": 1, "sprite": "t_fungus_2balls08" },
+          { "weight": 1, "sprite": "t_fungus_2balls09" },
+          { "weight": 1, "sprite": "t_fungus_2balls10" },
+          { "weight": 1, "sprite": "t_fungus_2balls11" },
+          { "weight": 1, "sprite": "t_fungus_2balls12" },
+          { "weight": 1, "sprite": "t_fungus_2balls13" },
+          { "weight": 1, "sprite": "t_fungus_2balls14" },
+          { "weight": 1, "sprite": "t_fungus_2balls15" },
+          { "weight": 1, "sprite": "t_fungus_2balls16" }
         ]
       },
       {
         "id": "corner",
         "bg": "t_dirt_center",
         "fg": [
-          { "weight": 1, "sprite": [ "t_fungus1_corner_nw", "t_fungus1_corner_sw", "t_fungus1_corner_se", "t_fungus1_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus2_corner_nw", "t_fungus2_corner_sw", "t_fungus2_corner_se", "t_fungus2_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus3_corner_nw", "t_fungus3_corner_sw", "t_fungus3_corner_se", "t_fungus3_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus5_corner_nw", "t_fungus5_corner_sw", "t_fungus5_corner_se", "t_fungus5_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus6_corner_nw", "t_fungus6_corner_sw", "t_fungus6_corner_se", "t_fungus6_corner_ne" ] }
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus1_corner_nw", "t_fungus1_corner_ne", "t_fungus1_corner_se", "t_fungus1_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus2_corner_nw", "t_fungus2_corner_ne", "t_fungus2_corner_se", "t_fungus2_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus3_corner_nw", "t_fungus3_corner_ne", "t_fungus3_corner_se", "t_fungus3_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus5_corner_nw", "t_fungus5_corner_ne", "t_fungus5_corner_se", "t_fungus5_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus6_corner_nw", "t_fungus6_corner_ne", "t_fungus6_corner_se", "t_fungus6_corner_sw" ]
+          }
         ]
       },
       {
         "id": "t_connection",
         "bg": "t_dirt_center",
-        "fg": [ 
-          { "weight": 1, "sprite": [ "t_fungus1_t_connection_n", "t_fungus1_t_connection_w", "t_fungus1_t_connection_s", "t_fungus1_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus2_t_connection_n", "t_fungus2_t_connection_w", "t_fungus2_t_connection_s", "t_fungus2_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus3_t_connection_n", "t_fungus3_t_connection_w", "t_fungus3_t_connection_s", "t_fungus3_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus5_t_connection_n", "t_fungus5_t_connection_w", "t_fungus5_t_connection_s", "t_fungus5_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus6_t_connection_n", "t_fungus6_t_connection_w", "t_fungus6_t_connection_s", "t_fungus6_t_connection_e" ] }
+        "fg": [
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus1_t_connection_n", "t_fungus1_t_connection_e", "t_fungus1_t_connection_s", "t_fungus1_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus2_t_connection_n", "t_fungus2_t_connection_e", "t_fungus2_t_connection_s", "t_fungus2_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus3_t_connection_n", "t_fungus3_t_connection_e", "t_fungus3_t_connection_s", "t_fungus3_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus5_t_connection_n", "t_fungus5_t_connection_e", "t_fungus5_t_connection_s", "t_fungus5_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus6_t_connection_n", "t_fungus6_t_connection_e", "t_fungus6_t_connection_s", "t_fungus6_t_connection_w" ]
+          }
         ]
       },
-      { 
-        "id": "edge", 
-        "bg": "t_dirt_center", 
-        "fg": [ 
+      {
+        "id": "edge",
+        "bg": "t_dirt_center",
+        "fg": [
           { "weight": 1, "sprite": [ "t_fungus1_edge_ns", "t_fungus1_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus2_edge_ns", "t_fungus2_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus3_edge_ns", "t_fungus3_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus5_edge_ns", "t_fungus5_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus6_edge_ns", "t_fungus6_edge_ew" ] }
-        ] 
+        ]
       },
       {
         "id": "end_piece",
         "bg": "t_dirt_center",
-        "fg": [ 
-          { "weight": 1, "sprite": [ "t_fungus1_end_piece_n", "t_fungus1_end_piece_w", "t_fungus1_end_piece_s", "t_fungus1_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus2_end_piece_n", "t_fungus2_end_piece_w", "t_fungus2_end_piece_s", "t_fungus2_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus3_end_piece_n", "t_fungus3_end_piece_w", "t_fungus3_end_piece_s", "t_fungus3_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus5_end_piece_n", "t_fungus5_end_piece_w", "t_fungus5_end_piece_s", "t_fungus5_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus6_end_piece_n", "t_fungus6_end_piece_w", "t_fungus6_end_piece_s", "t_fungus6_end_piece_e" ] }
+        "fg": [
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus1_end_piece_n", "t_fungus1_end_piece_e", "t_fungus1_end_piece_s", "t_fungus1_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus2_end_piece_n", "t_fungus2_end_piece_e", "t_fungus2_end_piece_s", "t_fungus2_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus3_end_piece_n", "t_fungus3_end_piece_e", "t_fungus3_end_piece_s", "t_fungus3_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus5_end_piece_n", "t_fungus5_end_piece_e", "t_fungus5_end_piece_s", "t_fungus5_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus6_end_piece_n", "t_fungus6_end_piece_e", "t_fungus6_end_piece_s", "t_fungus6_end_piece_w" ]
+          }
         ]
       },
       { "bg": "t_dirt_center", "id": "unconnected", "fg": "t_fungus1_unconnected" }
@@ -116,96 +164,144 @@
     "fg": "t_fungus1_unconnected",
     "bg": "t_dirt_center",
     "additional_tiles": [
-      { "id": "center", "bg": "t_dirt_center", "fg": [
-          {"weight": 32, "sprite": "t_fungus1_center"},
-          {"weight": 32, "sprite": "t_fungus2_center"},
-          {"weight": 32, "sprite": "t_fungus3_center"},
-          {"weight": 32, "sprite": "t_fungus4_center"},
-          {"weight": 32, "sprite": "t_fungus5_center"},
-          {"weight": 32, "sprite": "t_fungus6_center"},
-          {"weight": 1, "sprite": "t_fungus_sticks01"},
-          {"weight": 1, "sprite": "t_fungus_sticks02"},
-          {"weight": 1, "sprite": "t_fungus_sticks03"},
-          {"weight": 1, "sprite": "t_fungus_sticks04"},
-          {"weight": 1, "sprite": "t_fungus_sticks05"},
-          {"weight": 1, "sprite": "t_fungus_sticks06"},
-          {"weight": 1, "sprite": "t_fungus_sticks07"},
-          {"weight": 1, "sprite": "t_fungus_sticks08"},
-          {"weight": 1, "sprite": "t_fungus_sticks09"},
-          {"weight": 1, "sprite": "t_fungus_sticks10"},
-          {"weight": 1, "sprite": "t_fungus_sticks11"},
-          {"weight": 1, "sprite": "t_fungus_sticks12"},
-          {"weight": 1, "sprite": "t_fungus_sticks13"},
-          {"weight": 1, "sprite": "t_fungus_sticks14"},
-          {"weight": 1, "sprite": "t_fungus_sticks15"},
-          {"weight": 1, "sprite": "t_fungus_1ball16"},
-          {"weight": 1, "sprite": "t_fungus_1ball01"},
-          {"weight": 1, "sprite": "t_fungus_1ball02"},
-          {"weight": 1, "sprite": "t_fungus_1ball03"},
-          {"weight": 1, "sprite": "t_fungus_1ball04"},
-          {"weight": 1, "sprite": "t_fungus_1ball05"},
-          {"weight": 1, "sprite": "t_fungus_1ball06"},
-          {"weight": 1, "sprite": "t_fungus_1ball07"},
-          {"weight": 1, "sprite": "t_fungus_1ball08"},
-          {"weight": 1, "sprite": "t_fungus_1ball09"},
-          {"weight": 1, "sprite": "t_fungus_1ball10"},
-          {"weight": 1, "sprite": "t_fungus_1ball11"},
-          {"weight": 1, "sprite": "t_fungus_1ball12"},
-          {"weight": 1, "sprite": "t_fungus_1ball13"},
-          {"weight": 1, "sprite": "t_fungus_1ball14"},
-          {"weight": 1, "sprite": "t_fungus_1ball15"},
-          {"weight": 1, "sprite": "t_fungus_1ball16"},
-          {"weight": 1, "sprite": "t_fungus_1ball16"},
-          {"weight": 1, "sprite": "t_fungus_2balls01"},
-          {"weight": 1, "sprite": "t_fungus_2balls02"},
-          {"weight": 1, "sprite": "t_fungus_2balls03"},
-          {"weight": 1, "sprite": "t_fungus_2balls04"},
-          {"weight": 1, "sprite": "t_fungus_2balls05"},
-          {"weight": 1, "sprite": "t_fungus_2balls06"},
-          {"weight": 1, "sprite": "t_fungus_2balls07"},
-          {"weight": 1, "sprite": "t_fungus_2balls08"},
-          {"weight": 1, "sprite": "t_fungus_2balls09"},
-          {"weight": 1, "sprite": "t_fungus_2balls10"},
-          {"weight": 1, "sprite": "t_fungus_2balls11"},
-          {"weight": 1, "sprite": "t_fungus_2balls12"},
-          {"weight": 1, "sprite": "t_fungus_2balls13"},
-          {"weight": 1, "sprite": "t_fungus_2balls14"},
-          {"weight": 1, "sprite": "t_fungus_2balls15"},
-          {"weight": 1, "sprite": "t_fungus_2balls16"}
+      {
+        "id": "center",
+        "bg": "t_dirt_center",
+        "fg": [
+          { "weight": 32, "sprite": "t_fungus1_center" },
+          { "weight": 32, "sprite": "t_fungus2_center" },
+          { "weight": 32, "sprite": "t_fungus3_center" },
+          { "weight": 32, "sprite": "t_fungus4_center" },
+          { "weight": 32, "sprite": "t_fungus5_center" },
+          { "weight": 32, "sprite": "t_fungus6_center" },
+          { "weight": 1, "sprite": "t_fungus_sticks01" },
+          { "weight": 1, "sprite": "t_fungus_sticks02" },
+          { "weight": 1, "sprite": "t_fungus_sticks03" },
+          { "weight": 1, "sprite": "t_fungus_sticks04" },
+          { "weight": 1, "sprite": "t_fungus_sticks05" },
+          { "weight": 1, "sprite": "t_fungus_sticks06" },
+          { "weight": 1, "sprite": "t_fungus_sticks07" },
+          { "weight": 1, "sprite": "t_fungus_sticks08" },
+          { "weight": 1, "sprite": "t_fungus_sticks09" },
+          { "weight": 1, "sprite": "t_fungus_sticks10" },
+          { "weight": 1, "sprite": "t_fungus_sticks11" },
+          { "weight": 1, "sprite": "t_fungus_sticks12" },
+          { "weight": 1, "sprite": "t_fungus_sticks13" },
+          { "weight": 1, "sprite": "t_fungus_sticks14" },
+          { "weight": 1, "sprite": "t_fungus_sticks15" },
+          { "weight": 1, "sprite": "t_fungus_1ball16" },
+          { "weight": 1, "sprite": "t_fungus_1ball01" },
+          { "weight": 1, "sprite": "t_fungus_1ball02" },
+          { "weight": 1, "sprite": "t_fungus_1ball03" },
+          { "weight": 1, "sprite": "t_fungus_1ball04" },
+          { "weight": 1, "sprite": "t_fungus_1ball05" },
+          { "weight": 1, "sprite": "t_fungus_1ball06" },
+          { "weight": 1, "sprite": "t_fungus_1ball07" },
+          { "weight": 1, "sprite": "t_fungus_1ball08" },
+          { "weight": 1, "sprite": "t_fungus_1ball09" },
+          { "weight": 1, "sprite": "t_fungus_1ball10" },
+          { "weight": 1, "sprite": "t_fungus_1ball11" },
+          { "weight": 1, "sprite": "t_fungus_1ball12" },
+          { "weight": 1, "sprite": "t_fungus_1ball13" },
+          { "weight": 1, "sprite": "t_fungus_1ball14" },
+          { "weight": 1, "sprite": "t_fungus_1ball15" },
+          { "weight": 1, "sprite": "t_fungus_1ball16" },
+          { "weight": 1, "sprite": "t_fungus_1ball16" },
+          { "weight": 1, "sprite": "t_fungus_2balls01" },
+          { "weight": 1, "sprite": "t_fungus_2balls02" },
+          { "weight": 1, "sprite": "t_fungus_2balls03" },
+          { "weight": 1, "sprite": "t_fungus_2balls04" },
+          { "weight": 1, "sprite": "t_fungus_2balls05" },
+          { "weight": 1, "sprite": "t_fungus_2balls06" },
+          { "weight": 1, "sprite": "t_fungus_2balls07" },
+          { "weight": 1, "sprite": "t_fungus_2balls08" },
+          { "weight": 1, "sprite": "t_fungus_2balls09" },
+          { "weight": 1, "sprite": "t_fungus_2balls10" },
+          { "weight": 1, "sprite": "t_fungus_2balls11" },
+          { "weight": 1, "sprite": "t_fungus_2balls12" },
+          { "weight": 1, "sprite": "t_fungus_2balls13" },
+          { "weight": 1, "sprite": "t_fungus_2balls14" },
+          { "weight": 1, "sprite": "t_fungus_2balls15" },
+          { "weight": 1, "sprite": "t_fungus_2balls16" }
         ]
       },
       {
         "id": "corner",
         "bg": "t_dirt_center",
         "fg": [
-          { "weight": 1, "sprite": [ "t_fungus1_corner_nw", "t_fungus1_corner_sw", "t_fungus1_corner_se", "t_fungus1_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus2_corner_nw", "t_fungus2_corner_sw", "t_fungus2_corner_se", "t_fungus2_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus3_corner_nw", "t_fungus3_corner_sw", "t_fungus3_corner_se", "t_fungus3_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus5_corner_nw", "t_fungus5_corner_sw", "t_fungus5_corner_se", "t_fungus5_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus6_corner_nw", "t_fungus6_corner_sw", "t_fungus6_corner_se", "t_fungus6_corner_ne" ] }
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus1_corner_nw", "t_fungus1_corner_ne", "t_fungus1_corner_se", "t_fungus1_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus2_corner_nw", "t_fungus2_corner_ne", "t_fungus2_corner_se", "t_fungus2_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus3_corner_nw", "t_fungus3_corner_ne", "t_fungus3_corner_se", "t_fungus3_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus5_corner_nw", "t_fungus5_corner_ne", "t_fungus5_corner_se", "t_fungus5_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus6_corner_nw", "t_fungus6_corner_ne", "t_fungus6_corner_se", "t_fungus6_corner_sw" ]
+          }
         ]
       },
       {
         "id": "t_connection",
         "bg": "t_dirt_center",
-        "fg": [ 
-          { "weight": 1, "sprite": [ "t_fungus1_t_connection_n", "t_fungus1_t_connection_w", "t_fungus1_t_connection_s", "t_fungus1_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus2_t_connection_n", "t_fungus2_t_connection_w", "t_fungus2_t_connection_s", "t_fungus2_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus3_t_connection_n", "t_fungus3_t_connection_w", "t_fungus3_t_connection_s", "t_fungus3_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus5_t_connection_n", "t_fungus5_t_connection_w", "t_fungus5_t_connection_s", "t_fungus5_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus6_t_connection_n", "t_fungus6_t_connection_w", "t_fungus6_t_connection_s", "t_fungus6_t_connection_e" ] }
+        "fg": [
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus1_t_connection_n", "t_fungus1_t_connection_e", "t_fungus1_t_connection_s", "t_fungus1_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus2_t_connection_n", "t_fungus2_t_connection_e", "t_fungus2_t_connection_s", "t_fungus2_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus3_t_connection_n", "t_fungus3_t_connection_e", "t_fungus3_t_connection_s", "t_fungus3_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus5_t_connection_n", "t_fungus5_t_connection_e", "t_fungus5_t_connection_s", "t_fungus5_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus6_t_connection_n", "t_fungus6_t_connection_e", "t_fungus6_t_connection_s", "t_fungus6_t_connection_w" ]
+          }
         ]
       },
       { "id": "edge", "bg": "t_dirt_center", "fg": [ "t_fungus1_edge_ns", "t_fungus1_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_dirt_center",
-        "fg": [ 
-          { "weight": 1, "sprite": [ "t_fungus1_end_piece_n", "t_fungus1_end_piece_w", "t_fungus1_end_piece_s", "t_fungus1_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus2_end_piece_n", "t_fungus2_end_piece_w", "t_fungus2_end_piece_s", "t_fungus2_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus3_end_piece_n", "t_fungus3_end_piece_w", "t_fungus3_end_piece_s", "t_fungus3_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus5_end_piece_n", "t_fungus5_end_piece_w", "t_fungus5_end_piece_s", "t_fungus5_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus6_end_piece_n", "t_fungus6_end_piece_w", "t_fungus6_end_piece_s", "t_fungus6_end_piece_e" ] }
+        "fg": [
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus1_end_piece_n", "t_fungus1_end_piece_e", "t_fungus1_end_piece_s", "t_fungus1_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus2_end_piece_n", "t_fungus2_end_piece_e", "t_fungus2_end_piece_s", "t_fungus2_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus3_end_piece_n", "t_fungus3_end_piece_e", "t_fungus3_end_piece_s", "t_fungus3_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus5_end_piece_n", "t_fungus5_end_piece_e", "t_fungus5_end_piece_s", "t_fungus5_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus6_end_piece_n", "t_fungus6_end_piece_e", "t_fungus6_end_piece_s", "t_fungus6_end_piece_w" ]
+          }
         ]
       },
       { "bg": "t_dirt_center", "id": "unconnected", "fg": "t_fungus1_unconnected" }
@@ -217,96 +313,144 @@
     "fg": "t_fungus1_unconnected",
     "bg": "t_dirt_center",
     "additional_tiles": [
-      { "id": "center", "bg": "t_dirt_center", "fg": [
-          {"weight": 32, "sprite": "t_fungus1_center"},
-          {"weight": 32, "sprite": "t_fungus2_center"},
-          {"weight": 32, "sprite": "t_fungus3_center"},
-          {"weight": 32, "sprite": "t_fungus4_center"},
-          {"weight": 32, "sprite": "t_fungus5_center"},
-          {"weight": 32, "sprite": "t_fungus6_center"},
-          {"weight": 1, "sprite": "t_fungus_sticks01"},
-          {"weight": 1, "sprite": "t_fungus_sticks02"},
-          {"weight": 1, "sprite": "t_fungus_sticks03"},
-          {"weight": 1, "sprite": "t_fungus_sticks04"},
-          {"weight": 1, "sprite": "t_fungus_sticks05"},
-          {"weight": 1, "sprite": "t_fungus_sticks06"},
-          {"weight": 1, "sprite": "t_fungus_sticks07"},
-          {"weight": 1, "sprite": "t_fungus_sticks08"},
-          {"weight": 1, "sprite": "t_fungus_sticks09"},
-          {"weight": 1, "sprite": "t_fungus_sticks10"},
-          {"weight": 1, "sprite": "t_fungus_sticks11"},
-          {"weight": 1, "sprite": "t_fungus_sticks12"},
-          {"weight": 1, "sprite": "t_fungus_sticks13"},
-          {"weight": 1, "sprite": "t_fungus_sticks14"},
-          {"weight": 1, "sprite": "t_fungus_sticks15"},
-          {"weight": 1, "sprite": "t_fungus_1ball16"},
-          {"weight": 1, "sprite": "t_fungus_1ball01"},
-          {"weight": 1, "sprite": "t_fungus_1ball02"},
-          {"weight": 1, "sprite": "t_fungus_1ball03"},
-          {"weight": 1, "sprite": "t_fungus_1ball04"},
-          {"weight": 1, "sprite": "t_fungus_1ball05"},
-          {"weight": 1, "sprite": "t_fungus_1ball06"},
-          {"weight": 1, "sprite": "t_fungus_1ball07"},
-          {"weight": 1, "sprite": "t_fungus_1ball08"},
-          {"weight": 1, "sprite": "t_fungus_1ball09"},
-          {"weight": 1, "sprite": "t_fungus_1ball10"},
-          {"weight": 1, "sprite": "t_fungus_1ball11"},
-          {"weight": 1, "sprite": "t_fungus_1ball12"},
-          {"weight": 1, "sprite": "t_fungus_1ball13"},
-          {"weight": 1, "sprite": "t_fungus_1ball14"},
-          {"weight": 1, "sprite": "t_fungus_1ball15"},
-          {"weight": 1, "sprite": "t_fungus_1ball16"},
-          {"weight": 1, "sprite": "t_fungus_1ball16"},
-          {"weight": 1, "sprite": "t_fungus_2balls01"},
-          {"weight": 1, "sprite": "t_fungus_2balls02"},
-          {"weight": 1, "sprite": "t_fungus_2balls03"},
-          {"weight": 1, "sprite": "t_fungus_2balls04"},
-          {"weight": 1, "sprite": "t_fungus_2balls05"},
-          {"weight": 1, "sprite": "t_fungus_2balls06"},
-          {"weight": 1, "sprite": "t_fungus_2balls07"},
-          {"weight": 1, "sprite": "t_fungus_2balls08"},
-          {"weight": 1, "sprite": "t_fungus_2balls09"},
-          {"weight": 1, "sprite": "t_fungus_2balls10"},
-          {"weight": 1, "sprite": "t_fungus_2balls11"},
-          {"weight": 1, "sprite": "t_fungus_2balls12"},
-          {"weight": 1, "sprite": "t_fungus_2balls13"},
-          {"weight": 1, "sprite": "t_fungus_2balls14"},
-          {"weight": 1, "sprite": "t_fungus_2balls15"},
-          {"weight": 1, "sprite": "t_fungus_2balls16"}
+      {
+        "id": "center",
+        "bg": "t_dirt_center",
+        "fg": [
+          { "weight": 32, "sprite": "t_fungus1_center" },
+          { "weight": 32, "sprite": "t_fungus2_center" },
+          { "weight": 32, "sprite": "t_fungus3_center" },
+          { "weight": 32, "sprite": "t_fungus4_center" },
+          { "weight": 32, "sprite": "t_fungus5_center" },
+          { "weight": 32, "sprite": "t_fungus6_center" },
+          { "weight": 1, "sprite": "t_fungus_sticks01" },
+          { "weight": 1, "sprite": "t_fungus_sticks02" },
+          { "weight": 1, "sprite": "t_fungus_sticks03" },
+          { "weight": 1, "sprite": "t_fungus_sticks04" },
+          { "weight": 1, "sprite": "t_fungus_sticks05" },
+          { "weight": 1, "sprite": "t_fungus_sticks06" },
+          { "weight": 1, "sprite": "t_fungus_sticks07" },
+          { "weight": 1, "sprite": "t_fungus_sticks08" },
+          { "weight": 1, "sprite": "t_fungus_sticks09" },
+          { "weight": 1, "sprite": "t_fungus_sticks10" },
+          { "weight": 1, "sprite": "t_fungus_sticks11" },
+          { "weight": 1, "sprite": "t_fungus_sticks12" },
+          { "weight": 1, "sprite": "t_fungus_sticks13" },
+          { "weight": 1, "sprite": "t_fungus_sticks14" },
+          { "weight": 1, "sprite": "t_fungus_sticks15" },
+          { "weight": 1, "sprite": "t_fungus_1ball16" },
+          { "weight": 1, "sprite": "t_fungus_1ball01" },
+          { "weight": 1, "sprite": "t_fungus_1ball02" },
+          { "weight": 1, "sprite": "t_fungus_1ball03" },
+          { "weight": 1, "sprite": "t_fungus_1ball04" },
+          { "weight": 1, "sprite": "t_fungus_1ball05" },
+          { "weight": 1, "sprite": "t_fungus_1ball06" },
+          { "weight": 1, "sprite": "t_fungus_1ball07" },
+          { "weight": 1, "sprite": "t_fungus_1ball08" },
+          { "weight": 1, "sprite": "t_fungus_1ball09" },
+          { "weight": 1, "sprite": "t_fungus_1ball10" },
+          { "weight": 1, "sprite": "t_fungus_1ball11" },
+          { "weight": 1, "sprite": "t_fungus_1ball12" },
+          { "weight": 1, "sprite": "t_fungus_1ball13" },
+          { "weight": 1, "sprite": "t_fungus_1ball14" },
+          { "weight": 1, "sprite": "t_fungus_1ball15" },
+          { "weight": 1, "sprite": "t_fungus_1ball16" },
+          { "weight": 1, "sprite": "t_fungus_1ball16" },
+          { "weight": 1, "sprite": "t_fungus_2balls01" },
+          { "weight": 1, "sprite": "t_fungus_2balls02" },
+          { "weight": 1, "sprite": "t_fungus_2balls03" },
+          { "weight": 1, "sprite": "t_fungus_2balls04" },
+          { "weight": 1, "sprite": "t_fungus_2balls05" },
+          { "weight": 1, "sprite": "t_fungus_2balls06" },
+          { "weight": 1, "sprite": "t_fungus_2balls07" },
+          { "weight": 1, "sprite": "t_fungus_2balls08" },
+          { "weight": 1, "sprite": "t_fungus_2balls09" },
+          { "weight": 1, "sprite": "t_fungus_2balls10" },
+          { "weight": 1, "sprite": "t_fungus_2balls11" },
+          { "weight": 1, "sprite": "t_fungus_2balls12" },
+          { "weight": 1, "sprite": "t_fungus_2balls13" },
+          { "weight": 1, "sprite": "t_fungus_2balls14" },
+          { "weight": 1, "sprite": "t_fungus_2balls15" },
+          { "weight": 1, "sprite": "t_fungus_2balls16" }
         ]
       },
       {
         "id": "corner",
         "bg": "t_dirt_center",
         "fg": [
-          { "weight": 1, "sprite": [ "t_fungus1_corner_nw", "t_fungus1_corner_sw", "t_fungus1_corner_se", "t_fungus1_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus2_corner_nw", "t_fungus2_corner_sw", "t_fungus2_corner_se", "t_fungus2_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus3_corner_nw", "t_fungus3_corner_sw", "t_fungus3_corner_se", "t_fungus3_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus5_corner_nw", "t_fungus5_corner_sw", "t_fungus5_corner_se", "t_fungus5_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus6_corner_nw", "t_fungus6_corner_sw", "t_fungus6_corner_se", "t_fungus6_corner_ne" ] }
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus1_corner_nw", "t_fungus1_corner_ne", "t_fungus1_corner_se", "t_fungus1_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus2_corner_nw", "t_fungus2_corner_ne", "t_fungus2_corner_se", "t_fungus2_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus3_corner_nw", "t_fungus3_corner_ne", "t_fungus3_corner_se", "t_fungus3_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus5_corner_nw", "t_fungus5_corner_ne", "t_fungus5_corner_se", "t_fungus5_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus6_corner_nw", "t_fungus6_corner_ne", "t_fungus6_corner_se", "t_fungus6_corner_sw" ]
+          }
         ]
       },
       {
         "id": "t_connection",
         "bg": "t_dirt_center",
-        "fg": [ 
-          { "weight": 1, "sprite": [ "t_fungus1_t_connection_n", "t_fungus1_t_connection_w", "t_fungus1_t_connection_s", "t_fungus1_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus2_t_connection_n", "t_fungus2_t_connection_w", "t_fungus2_t_connection_s", "t_fungus2_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus3_t_connection_n", "t_fungus3_t_connection_w", "t_fungus3_t_connection_s", "t_fungus3_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus5_t_connection_n", "t_fungus5_t_connection_w", "t_fungus5_t_connection_s", "t_fungus5_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus6_t_connection_n", "t_fungus6_t_connection_w", "t_fungus6_t_connection_s", "t_fungus6_t_connection_e" ] }
+        "fg": [
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus1_t_connection_n", "t_fungus1_t_connection_e", "t_fungus1_t_connection_s", "t_fungus1_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus2_t_connection_n", "t_fungus2_t_connection_e", "t_fungus2_t_connection_s", "t_fungus2_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus3_t_connection_n", "t_fungus3_t_connection_e", "t_fungus3_t_connection_s", "t_fungus3_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus5_t_connection_n", "t_fungus5_t_connection_e", "t_fungus5_t_connection_s", "t_fungus5_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus6_t_connection_n", "t_fungus6_t_connection_e", "t_fungus6_t_connection_s", "t_fungus6_t_connection_w" ]
+          }
         ]
       },
       { "id": "edge", "bg": "t_dirt_center", "fg": [ "t_fungus1_edge_ns", "t_fungus1_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_dirt_center",
-        "fg": [ 
-          { "weight": 1, "sprite": [ "t_fungus1_end_piece_n", "t_fungus1_end_piece_w", "t_fungus1_end_piece_s", "t_fungus1_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus2_end_piece_n", "t_fungus2_end_piece_w", "t_fungus2_end_piece_s", "t_fungus2_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus3_end_piece_n", "t_fungus3_end_piece_w", "t_fungus3_end_piece_s", "t_fungus3_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus5_end_piece_n", "t_fungus5_end_piece_w", "t_fungus5_end_piece_s", "t_fungus5_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus6_end_piece_n", "t_fungus6_end_piece_w", "t_fungus6_end_piece_s", "t_fungus6_end_piece_e" ] }
+        "fg": [
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus1_end_piece_n", "t_fungus1_end_piece_e", "t_fungus1_end_piece_s", "t_fungus1_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus2_end_piece_n", "t_fungus2_end_piece_e", "t_fungus2_end_piece_s", "t_fungus2_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus3_end_piece_n", "t_fungus3_end_piece_e", "t_fungus3_end_piece_s", "t_fungus3_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus5_end_piece_n", "t_fungus5_end_piece_e", "t_fungus5_end_piece_s", "t_fungus5_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus6_end_piece_n", "t_fungus6_end_piece_e", "t_fungus6_end_piece_s", "t_fungus6_end_piece_w" ]
+          }
         ]
       },
       { "bg": "t_dirt_center", "id": "unconnected", "fg": "t_fungus1_unconnected" }
@@ -318,96 +462,144 @@
     "fg": "t_fungus1_unconnected",
     "bg": "snow_shallow_center",
     "additional_tiles": [
-      { "id": "center", "bg": "snow_shallow_center", "fg": [
-          {"weight": 32, "sprite": "t_fungus1_center"},
-          {"weight": 32, "sprite": "t_fungus2_center"},
-          {"weight": 32, "sprite": "t_fungus3_center"},
-          {"weight": 32, "sprite": "t_fungus4_center"},
-          {"weight": 32, "sprite": "t_fungus5_center"},
-          {"weight": 32, "sprite": "t_fungus6_center"},
-          {"weight": 1, "sprite": "t_fungus_sticks01"},
-          {"weight": 1, "sprite": "t_fungus_sticks02"},
-          {"weight": 1, "sprite": "t_fungus_sticks03"},
-          {"weight": 1, "sprite": "t_fungus_sticks04"},
-          {"weight": 1, "sprite": "t_fungus_sticks05"},
-          {"weight": 1, "sprite": "t_fungus_sticks06"},
-          {"weight": 1, "sprite": "t_fungus_sticks07"},
-          {"weight": 1, "sprite": "t_fungus_sticks08"},
-          {"weight": 1, "sprite": "t_fungus_sticks09"},
-          {"weight": 1, "sprite": "t_fungus_sticks10"},
-          {"weight": 1, "sprite": "t_fungus_sticks11"},
-          {"weight": 1, "sprite": "t_fungus_sticks12"},
-          {"weight": 1, "sprite": "t_fungus_sticks13"},
-          {"weight": 1, "sprite": "t_fungus_sticks14"},
-          {"weight": 1, "sprite": "t_fungus_sticks15"},
-          {"weight": 1, "sprite": "t_fungus_1ball16"},
-          {"weight": 1, "sprite": "t_fungus_1ball01"},
-          {"weight": 1, "sprite": "t_fungus_1ball02"},
-          {"weight": 1, "sprite": "t_fungus_1ball03"},
-          {"weight": 1, "sprite": "t_fungus_1ball04"},
-          {"weight": 1, "sprite": "t_fungus_1ball05"},
-          {"weight": 1, "sprite": "t_fungus_1ball06"},
-          {"weight": 1, "sprite": "t_fungus_1ball07"},
-          {"weight": 1, "sprite": "t_fungus_1ball08"},
-          {"weight": 1, "sprite": "t_fungus_1ball09"},
-          {"weight": 1, "sprite": "t_fungus_1ball10"},
-          {"weight": 1, "sprite": "t_fungus_1ball11"},
-          {"weight": 1, "sprite": "t_fungus_1ball12"},
-          {"weight": 1, "sprite": "t_fungus_1ball13"},
-          {"weight": 1, "sprite": "t_fungus_1ball14"},
-          {"weight": 1, "sprite": "t_fungus_1ball15"},
-          {"weight": 1, "sprite": "t_fungus_1ball16"},
-          {"weight": 1, "sprite": "t_fungus_1ball16"},
-          {"weight": 1, "sprite": "t_fungus_2balls01"},
-          {"weight": 1, "sprite": "t_fungus_2balls02"},
-          {"weight": 1, "sprite": "t_fungus_2balls03"},
-          {"weight": 1, "sprite": "t_fungus_2balls04"},
-          {"weight": 1, "sprite": "t_fungus_2balls05"},
-          {"weight": 1, "sprite": "t_fungus_2balls06"},
-          {"weight": 1, "sprite": "t_fungus_2balls07"},
-          {"weight": 1, "sprite": "t_fungus_2balls08"},
-          {"weight": 1, "sprite": "t_fungus_2balls09"},
-          {"weight": 1, "sprite": "t_fungus_2balls10"},
-          {"weight": 1, "sprite": "t_fungus_2balls11"},
-          {"weight": 1, "sprite": "t_fungus_2balls12"},
-          {"weight": 1, "sprite": "t_fungus_2balls13"},
-          {"weight": 1, "sprite": "t_fungus_2balls14"},
-          {"weight": 1, "sprite": "t_fungus_2balls15"},
-          {"weight": 1, "sprite": "t_fungus_2balls16"}
+      {
+        "id": "center",
+        "bg": "snow_shallow_center",
+        "fg": [
+          { "weight": 32, "sprite": "t_fungus1_center" },
+          { "weight": 32, "sprite": "t_fungus2_center" },
+          { "weight": 32, "sprite": "t_fungus3_center" },
+          { "weight": 32, "sprite": "t_fungus4_center" },
+          { "weight": 32, "sprite": "t_fungus5_center" },
+          { "weight": 32, "sprite": "t_fungus6_center" },
+          { "weight": 1, "sprite": "t_fungus_sticks01" },
+          { "weight": 1, "sprite": "t_fungus_sticks02" },
+          { "weight": 1, "sprite": "t_fungus_sticks03" },
+          { "weight": 1, "sprite": "t_fungus_sticks04" },
+          { "weight": 1, "sprite": "t_fungus_sticks05" },
+          { "weight": 1, "sprite": "t_fungus_sticks06" },
+          { "weight": 1, "sprite": "t_fungus_sticks07" },
+          { "weight": 1, "sprite": "t_fungus_sticks08" },
+          { "weight": 1, "sprite": "t_fungus_sticks09" },
+          { "weight": 1, "sprite": "t_fungus_sticks10" },
+          { "weight": 1, "sprite": "t_fungus_sticks11" },
+          { "weight": 1, "sprite": "t_fungus_sticks12" },
+          { "weight": 1, "sprite": "t_fungus_sticks13" },
+          { "weight": 1, "sprite": "t_fungus_sticks14" },
+          { "weight": 1, "sprite": "t_fungus_sticks15" },
+          { "weight": 1, "sprite": "t_fungus_1ball16" },
+          { "weight": 1, "sprite": "t_fungus_1ball01" },
+          { "weight": 1, "sprite": "t_fungus_1ball02" },
+          { "weight": 1, "sprite": "t_fungus_1ball03" },
+          { "weight": 1, "sprite": "t_fungus_1ball04" },
+          { "weight": 1, "sprite": "t_fungus_1ball05" },
+          { "weight": 1, "sprite": "t_fungus_1ball06" },
+          { "weight": 1, "sprite": "t_fungus_1ball07" },
+          { "weight": 1, "sprite": "t_fungus_1ball08" },
+          { "weight": 1, "sprite": "t_fungus_1ball09" },
+          { "weight": 1, "sprite": "t_fungus_1ball10" },
+          { "weight": 1, "sprite": "t_fungus_1ball11" },
+          { "weight": 1, "sprite": "t_fungus_1ball12" },
+          { "weight": 1, "sprite": "t_fungus_1ball13" },
+          { "weight": 1, "sprite": "t_fungus_1ball14" },
+          { "weight": 1, "sprite": "t_fungus_1ball15" },
+          { "weight": 1, "sprite": "t_fungus_1ball16" },
+          { "weight": 1, "sprite": "t_fungus_1ball16" },
+          { "weight": 1, "sprite": "t_fungus_2balls01" },
+          { "weight": 1, "sprite": "t_fungus_2balls02" },
+          { "weight": 1, "sprite": "t_fungus_2balls03" },
+          { "weight": 1, "sprite": "t_fungus_2balls04" },
+          { "weight": 1, "sprite": "t_fungus_2balls05" },
+          { "weight": 1, "sprite": "t_fungus_2balls06" },
+          { "weight": 1, "sprite": "t_fungus_2balls07" },
+          { "weight": 1, "sprite": "t_fungus_2balls08" },
+          { "weight": 1, "sprite": "t_fungus_2balls09" },
+          { "weight": 1, "sprite": "t_fungus_2balls10" },
+          { "weight": 1, "sprite": "t_fungus_2balls11" },
+          { "weight": 1, "sprite": "t_fungus_2balls12" },
+          { "weight": 1, "sprite": "t_fungus_2balls13" },
+          { "weight": 1, "sprite": "t_fungus_2balls14" },
+          { "weight": 1, "sprite": "t_fungus_2balls15" },
+          { "weight": 1, "sprite": "t_fungus_2balls16" }
         ]
       },
       {
         "id": "corner",
         "bg": "snow_shallow_center",
         "fg": [
-          { "weight": 1, "sprite": [ "t_fungus1_corner_nw", "t_fungus1_corner_sw", "t_fungus1_corner_se", "t_fungus1_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus2_corner_nw", "t_fungus2_corner_sw", "t_fungus2_corner_se", "t_fungus2_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus3_corner_nw", "t_fungus3_corner_sw", "t_fungus3_corner_se", "t_fungus3_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus5_corner_nw", "t_fungus5_corner_sw", "t_fungus5_corner_se", "t_fungus5_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus6_corner_nw", "t_fungus6_corner_sw", "t_fungus6_corner_se", "t_fungus6_corner_ne" ] }
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus1_corner_nw", "t_fungus1_corner_ne", "t_fungus1_corner_se", "t_fungus1_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus2_corner_nw", "t_fungus2_corner_ne", "t_fungus2_corner_se", "t_fungus2_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus3_corner_nw", "t_fungus3_corner_ne", "t_fungus3_corner_se", "t_fungus3_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus5_corner_nw", "t_fungus5_corner_ne", "t_fungus5_corner_se", "t_fungus5_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus6_corner_nw", "t_fungus6_corner_ne", "t_fungus6_corner_se", "t_fungus6_corner_sw" ]
+          }
         ]
       },
       {
         "id": "t_connection",
         "bg": "snow_shallow_center",
-        "fg": [ 
-          { "weight": 1, "sprite": [ "t_fungus1_t_connection_n", "t_fungus1_t_connection_w", "t_fungus1_t_connection_s", "t_fungus1_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus2_t_connection_n", "t_fungus2_t_connection_w", "t_fungus2_t_connection_s", "t_fungus2_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus3_t_connection_n", "t_fungus3_t_connection_w", "t_fungus3_t_connection_s", "t_fungus3_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus5_t_connection_n", "t_fungus5_t_connection_w", "t_fungus5_t_connection_s", "t_fungus5_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus6_t_connection_n", "t_fungus6_t_connection_w", "t_fungus6_t_connection_s", "t_fungus6_t_connection_e" ] }
+        "fg": [
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus1_t_connection_n", "t_fungus1_t_connection_e", "t_fungus1_t_connection_s", "t_fungus1_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus2_t_connection_n", "t_fungus2_t_connection_e", "t_fungus2_t_connection_s", "t_fungus2_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus3_t_connection_n", "t_fungus3_t_connection_e", "t_fungus3_t_connection_s", "t_fungus3_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus5_t_connection_n", "t_fungus5_t_connection_e", "t_fungus5_t_connection_s", "t_fungus5_t_connection_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus6_t_connection_n", "t_fungus6_t_connection_e", "t_fungus6_t_connection_s", "t_fungus6_t_connection_w" ]
+          }
         ]
       },
       { "id": "edge", "bg": "t_dirt_center", "fg": [ "t_fungus1_edge_ns", "t_fungus1_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "snow_shallow_center",
-        "fg": [ 
-          { "weight": 1, "sprite": [ "t_fungus1_end_piece_n", "t_fungus1_end_piece_w", "t_fungus1_end_piece_s", "t_fungus1_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus2_end_piece_n", "t_fungus2_end_piece_w", "t_fungus2_end_piece_s", "t_fungus2_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus3_end_piece_n", "t_fungus3_end_piece_w", "t_fungus3_end_piece_s", "t_fungus3_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus5_end_piece_n", "t_fungus5_end_piece_w", "t_fungus5_end_piece_s", "t_fungus5_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus6_end_piece_n", "t_fungus6_end_piece_w", "t_fungus6_end_piece_s", "t_fungus6_end_piece_e" ] }
+        "fg": [
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus1_end_piece_n", "t_fungus1_end_piece_e", "t_fungus1_end_piece_s", "t_fungus1_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus2_end_piece_n", "t_fungus2_end_piece_e", "t_fungus2_end_piece_s", "t_fungus2_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus3_end_piece_n", "t_fungus3_end_piece_e", "t_fungus3_end_piece_s", "t_fungus3_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus5_end_piece_n", "t_fungus5_end_piece_e", "t_fungus5_end_piece_s", "t_fungus5_end_piece_w" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus6_end_piece_n", "t_fungus6_end_piece_e", "t_fungus6_end_piece_s", "t_fungus6_end_piece_w" ]
+          }
         ]
       },
       { "bg": "snow_shallow_center", "id": "unconnected", "fg": "t_fungus1_unconnected" }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fungus_mound/t_fungus_mound.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fungus_mound/t_fungus_mound.json
@@ -1,249 +1,557 @@
 [
-  { "id": "t_fungus_mound",
+  {
+    "id": "t_fungus_mound",
     "fg": "t_fungus_mound_unconnected",
     "bg": "t_dirt_center",
     "multitile": true,
-      "additional_tiles": [
-        { "id": "center", "bg": "t_dirt_center", "fg": [
-          {"weight": 1, "sprite": "t_fungus_mound_center"},
-          {"weight": 1, "sprite": "t_fungus_mound1_center"},
-          {"weight": 1, "sprite": "t_fungus_mound2_center"},
-          {"weight": 1, "sprite": "t_fungus_mound3_center"}
+    "additional_tiles": [
+      {
+        "id": "center",
+        "bg": "t_dirt_center",
+        "fg": [
+          { "weight": 1, "sprite": "t_fungus_mound_center" },
+          { "weight": 1, "sprite": "t_fungus_mound1_center" },
+          { "weight": 1, "sprite": "t_fungus_mound2_center" },
+          { "weight": 1, "sprite": "t_fungus_mound3_center" }
         ]
       },
       {
         "id": "corner",
         "bg": "t_dirt_center",
         "fg": [
-          { "weight": 1, "sprite": [ "t_fungus_mound_corner_nw", "t_fungus_mound_corner_sw", "t_fungus_mound_corner_se", "t_fungus_mound_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound1_corner_nw", "t_fungus_mound1_corner_sw", "t_fungus_mound1_corner_se", "t_fungus_mound1_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound2_corner_nw", "t_fungus_mound2_corner_sw", "t_fungus_mound2_corner_se", "t_fungus_mound2_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound3_corner_nw", "t_fungus_mound3_corner_sw", "t_fungus_mound3_corner_se", "t_fungus_mound3_corner_ne" ] }
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound_corner_nw", "t_fungus_mound_corner_ne", "t_fungus_mound_corner_se", "t_fungus_mound_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound1_corner_nw", "t_fungus_mound1_corner_ne", "t_fungus_mound1_corner_se", "t_fungus_mound1_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound2_corner_nw", "t_fungus_mound2_corner_ne", "t_fungus_mound2_corner_se", "t_fungus_mound2_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound3_corner_nw", "t_fungus_mound3_corner_ne", "t_fungus_mound3_corner_se", "t_fungus_mound3_corner_sw" ]
+          }
         ]
       },
       {
         "id": "t_connection",
         "bg": "t_dirt_center",
         "fg": [
-          { "weight": 1, "sprite": [ "t_fungus_mound_t_connection_n", "t_fungus_mound_t_connection_w", "t_fungus_mound_t_connection_s", "t_fungus_mound_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound1_t_connection_n", "t_fungus_mound1_t_connection_w", "t_fungus_mound1_t_connection_s", "t_fungus_mound1_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound2_t_connection_n", "t_fungus_mound2_t_connection_w", "t_fungus_mound2_t_connection_s", "t_fungus_mound2_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound3_t_connection_n", "t_fungus_mound3_t_connection_w", "t_fungus_mound3_t_connection_s", "t_fungus_mound3_t_connection_e" ] }
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound_t_connection_n",
+              "t_fungus_mound_t_connection_e",
+              "t_fungus_mound_t_connection_s",
+              "t_fungus_mound_t_connection_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound1_t_connection_n",
+              "t_fungus_mound1_t_connection_e",
+              "t_fungus_mound1_t_connection_s",
+              "t_fungus_mound1_t_connection_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound2_t_connection_n",
+              "t_fungus_mound2_t_connection_e",
+              "t_fungus_mound2_t_connection_s",
+              "t_fungus_mound2_t_connection_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound3_t_connection_n",
+              "t_fungus_mound3_t_connection_e",
+              "t_fungus_mound3_t_connection_s",
+              "t_fungus_mound3_t_connection_w"
+            ]
+          }
         ]
       },
-      { 
-        "id": "edge", 
-        "bg": "t_dirt_center", 
-        "fg": [ 
+      {
+        "id": "edge",
+        "bg": "t_dirt_center",
+        "fg": [
           { "weight": 1, "sprite": [ "t_fungus_mound_edge_ns", "t_fungus_mound_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus_mound1_edge_ns", "t_fungus_mound1_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus_mound2_edge_ns", "t_fungus_mound2_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus_mound3_edge_ns", "t_fungus_mound3_edge_ew" ] }
-        ] 
+        ]
       },
       {
         "id": "end_piece",
         "bg": "t_dirt_center",
-        "fg": [ 
-          { "weight": 1, "sprite": [ "t_fungus_mound_end_piece_n", "t_fungus_mound_end_piece_w", "t_fungus_mound_end_piece_s", "t_fungus_mound_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound1_end_piece_n", "t_fungus_mound1_end_piece_w", "t_fungus_mound1_end_piece_s", "t_fungus_mound1_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound2_end_piece_n", "t_fungus_mound2_end_piece_w", "t_fungus_mound2_end_piece_s", "t_fungus_mound2_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound3_end_piece_n", "t_fungus_mound3_end_piece_w", "t_fungus_mound3_end_piece_s", "t_fungus_mound3_end_piece_e" ] }
+        "fg": [
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound_end_piece_n",
+              "t_fungus_mound_end_piece_e",
+              "t_fungus_mound_end_piece_s",
+              "t_fungus_mound_end_piece_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound1_end_piece_n",
+              "t_fungus_mound1_end_piece_e",
+              "t_fungus_mound1_end_piece_s",
+              "t_fungus_mound1_end_piece_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound2_end_piece_n",
+              "t_fungus_mound2_end_piece_e",
+              "t_fungus_mound2_end_piece_s",
+              "t_fungus_mound2_end_piece_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound3_end_piece_n",
+              "t_fungus_mound3_end_piece_e",
+              "t_fungus_mound3_end_piece_s",
+              "t_fungus_mound3_end_piece_w"
+            ]
+          }
         ]
       },
       {
         "id": "unconnected",
         "bg": "t_dirt_center",
-        "fg": [
-          "t_fungus_mound_unconnected",
-          "t_fungus_mound_unconnected"
-        ]
+        "fg": [ "t_fungus_mound_unconnected", "t_fungus_mound_unconnected" ]
       }
     ]
   },
-  { "id": "t_fungus_mound_season_summer",
+  {
+    "id": "t_fungus_mound_season_summer",
     "fg": "t_fungus_mound_unconnected",
     "bg": "t_dirt_center",
     "multitile": true,
-      "additional_tiles": [
-        { "id": "center", "bg": "t_dirt_center", "fg": [
-          {"weight": 1, "sprite": "t_fungus_mound_center"},
-          {"weight": 1, "sprite": "t_fungus_mound1_center"},
-          {"weight": 1, "sprite": "t_fungus_mound2_center"},
-          {"weight": 1, "sprite": "t_fungus_mound3_center"}
+    "additional_tiles": [
+      {
+        "id": "center",
+        "bg": "t_dirt_center",
+        "fg": [
+          { "weight": 1, "sprite": "t_fungus_mound_center" },
+          { "weight": 1, "sprite": "t_fungus_mound1_center" },
+          { "weight": 1, "sprite": "t_fungus_mound2_center" },
+          { "weight": 1, "sprite": "t_fungus_mound3_center" }
         ]
       },
       {
         "id": "corner",
         "bg": "t_dirt_center",
         "fg": [
-          { "weight": 1, "sprite": [ "t_fungus_mound_corner_nw", "t_fungus_mound_corner_sw", "t_fungus_mound_corner_se", "t_fungus_mound_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound1_corner_nw", "t_fungus_mound1_corner_sw", "t_fungus_mound1_corner_se", "t_fungus_mound1_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound2_corner_nw", "t_fungus_mound2_corner_sw", "t_fungus_mound2_corner_se", "t_fungus_mound2_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound3_corner_nw", "t_fungus_mound3_corner_sw", "t_fungus_mound3_corner_se", "t_fungus_mound3_corner_ne" ] }
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound_corner_nw", "t_fungus_mound_corner_ne", "t_fungus_mound_corner_se", "t_fungus_mound_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound1_corner_nw", "t_fungus_mound1_corner_ne", "t_fungus_mound1_corner_se", "t_fungus_mound1_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound2_corner_nw", "t_fungus_mound2_corner_ne", "t_fungus_mound2_corner_se", "t_fungus_mound2_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound3_corner_nw", "t_fungus_mound3_corner_ne", "t_fungus_mound3_corner_se", "t_fungus_mound3_corner_sw" ]
+          }
         ]
       },
       {
         "id": "t_connection",
         "bg": "t_dirt_center",
         "fg": [
-          { "weight": 1, "sprite": [ "t_fungus_mound_t_connection_n", "t_fungus_mound_t_connection_w", "t_fungus_mound_t_connection_s", "t_fungus_mound_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound1_t_connection_n", "t_fungus_mound1_t_connection_w", "t_fungus_mound1_t_connection_s", "t_fungus_mound1_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound2_t_connection_n", "t_fungus_mound2_t_connection_w", "t_fungus_mound2_t_connection_s", "t_fungus_mound2_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound3_t_connection_n", "t_fungus_mound3_t_connection_w", "t_fungus_mound3_t_connection_s", "t_fungus_mound3_t_connection_e" ] }
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound_t_connection_n",
+              "t_fungus_mound_t_connection_e",
+              "t_fungus_mound_t_connection_s",
+              "t_fungus_mound_t_connection_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound1_t_connection_n",
+              "t_fungus_mound1_t_connection_e",
+              "t_fungus_mound1_t_connection_s",
+              "t_fungus_mound1_t_connection_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound2_t_connection_n",
+              "t_fungus_mound2_t_connection_e",
+              "t_fungus_mound2_t_connection_s",
+              "t_fungus_mound2_t_connection_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound3_t_connection_n",
+              "t_fungus_mound3_t_connection_e",
+              "t_fungus_mound3_t_connection_s",
+              "t_fungus_mound3_t_connection_w"
+            ]
+          }
         ]
       },
-      { 
-        "id": "edge", 
-        "bg": "t_dirt_center", 
-        "fg": [ 
+      {
+        "id": "edge",
+        "bg": "t_dirt_center",
+        "fg": [
           { "weight": 1, "sprite": [ "t_fungus_mound_edge_ns", "t_fungus_mound_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus_mound1_edge_ns", "t_fungus_mound1_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus_mound2_edge_ns", "t_fungus_mound2_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus_mound3_edge_ns", "t_fungus_mound3_edge_ew" ] }
-        ] 
+        ]
       },
       {
         "id": "end_piece",
         "bg": "t_dirt_center",
-        "fg": [ 
-          { "weight": 1, "sprite": [ "t_fungus_mound_end_piece_n", "t_fungus_mound_end_piece_w", "t_fungus_mound_end_piece_s", "t_fungus_mound_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound1_end_piece_n", "t_fungus_mound1_end_piece_w", "t_fungus_mound1_end_piece_s", "t_fungus_mound1_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound2_end_piece_n", "t_fungus_mound2_end_piece_w", "t_fungus_mound2_end_piece_s", "t_fungus_mound2_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound3_end_piece_n", "t_fungus_mound3_end_piece_w", "t_fungus_mound3_end_piece_s", "t_fungus_mound3_end_piece_e" ] }
+        "fg": [
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound_end_piece_n",
+              "t_fungus_mound_end_piece_e",
+              "t_fungus_mound_end_piece_s",
+              "t_fungus_mound_end_piece_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound1_end_piece_n",
+              "t_fungus_mound1_end_piece_e",
+              "t_fungus_mound1_end_piece_s",
+              "t_fungus_mound1_end_piece_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound2_end_piece_n",
+              "t_fungus_mound2_end_piece_e",
+              "t_fungus_mound2_end_piece_s",
+              "t_fungus_mound2_end_piece_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound3_end_piece_n",
+              "t_fungus_mound3_end_piece_e",
+              "t_fungus_mound3_end_piece_s",
+              "t_fungus_mound3_end_piece_w"
+            ]
+          }
         ]
       },
       {
         "id": "unconnected",
         "bg": "t_dirt_center",
-        "fg": [
-          "t_fungus_mound_unconnected",
-          "t_fungus_mound_unconnected"
-        ]
+        "fg": [ "t_fungus_mound_unconnected", "t_fungus_mound_unconnected" ]
       }
     ]
   },
-  { "id": "t_fungus_mound_season_autumn",
+  {
+    "id": "t_fungus_mound_season_autumn",
     "fg": "t_fungus_mound_unconnected",
     "bg": "t_dirt_center",
     "multitile": true,
-      "additional_tiles": [
-        { "id": "center", "bg": "t_dirt_center", "fg": [
-          {"weight": 1, "sprite": "t_fungus_mound_center"},
-          {"weight": 1, "sprite": "t_fungus_mound1_center"},
-          {"weight": 1, "sprite": "t_fungus_mound2_center"},
-          {"weight": 1, "sprite": "t_fungus_mound3_center"}
+    "additional_tiles": [
+      {
+        "id": "center",
+        "bg": "t_dirt_center",
+        "fg": [
+          { "weight": 1, "sprite": "t_fungus_mound_center" },
+          { "weight": 1, "sprite": "t_fungus_mound1_center" },
+          { "weight": 1, "sprite": "t_fungus_mound2_center" },
+          { "weight": 1, "sprite": "t_fungus_mound3_center" }
         ]
       },
       {
         "id": "corner",
         "bg": "t_dirt_center",
         "fg": [
-          { "weight": 1, "sprite": [ "t_fungus_mound_corner_nw", "t_fungus_mound_corner_sw", "t_fungus_mound_corner_se", "t_fungus_mound_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound1_corner_nw", "t_fungus_mound1_corner_sw", "t_fungus_mound1_corner_se", "t_fungus_mound1_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound2_corner_nw", "t_fungus_mound2_corner_sw", "t_fungus_mound2_corner_se", "t_fungus_mound2_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound3_corner_nw", "t_fungus_mound3_corner_sw", "t_fungus_mound3_corner_se", "t_fungus_mound3_corner_ne" ] }
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound_corner_nw", "t_fungus_mound_corner_ne", "t_fungus_mound_corner_se", "t_fungus_mound_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound1_corner_nw", "t_fungus_mound1_corner_ne", "t_fungus_mound1_corner_se", "t_fungus_mound1_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound2_corner_nw", "t_fungus_mound2_corner_ne", "t_fungus_mound2_corner_se", "t_fungus_mound2_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound3_corner_nw", "t_fungus_mound3_corner_ne", "t_fungus_mound3_corner_se", "t_fungus_mound3_corner_sw" ]
+          }
         ]
       },
       {
         "id": "t_connection",
         "bg": "t_dirt_center",
         "fg": [
-          { "weight": 1, "sprite": [ "t_fungus_mound_t_connection_n", "t_fungus_mound_t_connection_w", "t_fungus_mound_t_connection_s", "t_fungus_mound_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound1_t_connection_n", "t_fungus_mound1_t_connection_w", "t_fungus_mound1_t_connection_s", "t_fungus_mound1_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound2_t_connection_n", "t_fungus_mound2_t_connection_w", "t_fungus_mound2_t_connection_s", "t_fungus_mound2_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound3_t_connection_n", "t_fungus_mound3_t_connection_w", "t_fungus_mound3_t_connection_s", "t_fungus_mound3_t_connection_e" ] }
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound_t_connection_n",
+              "t_fungus_mound_t_connection_e",
+              "t_fungus_mound_t_connection_s",
+              "t_fungus_mound_t_connection_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound1_t_connection_n",
+              "t_fungus_mound1_t_connection_e",
+              "t_fungus_mound1_t_connection_s",
+              "t_fungus_mound1_t_connection_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound2_t_connection_n",
+              "t_fungus_mound2_t_connection_e",
+              "t_fungus_mound2_t_connection_s",
+              "t_fungus_mound2_t_connection_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound3_t_connection_n",
+              "t_fungus_mound3_t_connection_e",
+              "t_fungus_mound3_t_connection_s",
+              "t_fungus_mound3_t_connection_w"
+            ]
+          }
         ]
       },
-      { 
-        "id": "edge", 
-        "bg": "t_dirt_center", 
-        "fg": [ 
+      {
+        "id": "edge",
+        "bg": "t_dirt_center",
+        "fg": [
           { "weight": 1, "sprite": [ "t_fungus_mound_edge_ns", "t_fungus_mound_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus_mound1_edge_ns", "t_fungus_mound1_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus_mound2_edge_ns", "t_fungus_mound2_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus_mound3_edge_ns", "t_fungus_mound3_edge_ew" ] }
-        ] 
+        ]
       },
       {
         "id": "end_piece",
         "bg": "t_dirt_center",
-        "fg": [ 
-          { "weight": 1, "sprite": [ "t_fungus_mound_end_piece_n", "t_fungus_mound_end_piece_w", "t_fungus_mound_end_piece_s", "t_fungus_mound_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound1_end_piece_n", "t_fungus_mound1_end_piece_w", "t_fungus_mound1_end_piece_s", "t_fungus_mound1_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound2_end_piece_n", "t_fungus_mound2_end_piece_w", "t_fungus_mound2_end_piece_s", "t_fungus_mound2_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound3_end_piece_n", "t_fungus_mound3_end_piece_w", "t_fungus_mound3_end_piece_s", "t_fungus_mound3_end_piece_e" ] }
+        "fg": [
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound_end_piece_n",
+              "t_fungus_mound_end_piece_e",
+              "t_fungus_mound_end_piece_s",
+              "t_fungus_mound_end_piece_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound1_end_piece_n",
+              "t_fungus_mound1_end_piece_e",
+              "t_fungus_mound1_end_piece_s",
+              "t_fungus_mound1_end_piece_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound2_end_piece_n",
+              "t_fungus_mound2_end_piece_e",
+              "t_fungus_mound2_end_piece_s",
+              "t_fungus_mound2_end_piece_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound3_end_piece_n",
+              "t_fungus_mound3_end_piece_e",
+              "t_fungus_mound3_end_piece_s",
+              "t_fungus_mound3_end_piece_w"
+            ]
+          }
         ]
       },
       {
         "id": "unconnected",
         "bg": "t_dirt_center",
-        "fg": [
-          "t_fungus_mound_unconnected",
-          "t_fungus_mound_unconnected"
-        ]
+        "fg": [ "t_fungus_mound_unconnected", "t_fungus_mound_unconnected" ]
       }
     ]
   },
-  { "id": "t_fungus_mound_season_winter",
+  {
+    "id": "t_fungus_mound_season_winter",
     "fg": "t_fungus_mound_unconnected",
     "bg": "snow_shallow_center",
     "multitile": true,
-      "additional_tiles": [
-        { "id": "center", "bg": "snow_shallow_center", "fg": [
-          {"weight": 1, "sprite": "t_fungus_mound_center"},
-          {"weight": 1, "sprite": "t_fungus_mound1_center"},
-          {"weight": 1, "sprite": "t_fungus_mound2_center"},
-          {"weight": 1, "sprite": "t_fungus_mound3_center"}
+    "additional_tiles": [
+      {
+        "id": "center",
+        "bg": "snow_shallow_center",
+        "fg": [
+          { "weight": 1, "sprite": "t_fungus_mound_center" },
+          { "weight": 1, "sprite": "t_fungus_mound1_center" },
+          { "weight": 1, "sprite": "t_fungus_mound2_center" },
+          { "weight": 1, "sprite": "t_fungus_mound3_center" }
         ]
       },
       {
         "id": "corner",
         "bg": "snow_shallow_center",
         "fg": [
-          { "weight": 1, "sprite": [ "t_fungus_mound_corner_nw", "t_fungus_mound_corner_sw", "t_fungus_mound_corner_se", "t_fungus_mound_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound1_corner_nw", "t_fungus_mound1_corner_sw", "t_fungus_mound1_corner_se", "t_fungus_mound1_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound2_corner_nw", "t_fungus_mound2_corner_sw", "t_fungus_mound2_corner_se", "t_fungus_mound2_corner_ne" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound3_corner_nw", "t_fungus_mound3_corner_sw", "t_fungus_mound3_corner_se", "t_fungus_mound3_corner_ne" ] }
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound_corner_nw", "t_fungus_mound_corner_ne", "t_fungus_mound_corner_se", "t_fungus_mound_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound1_corner_nw", "t_fungus_mound1_corner_ne", "t_fungus_mound1_corner_se", "t_fungus_mound1_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound2_corner_nw", "t_fungus_mound2_corner_ne", "t_fungus_mound2_corner_se", "t_fungus_mound2_corner_sw" ]
+          },
+          {
+            "weight": 1,
+            "sprite": [ "t_fungus_mound3_corner_nw", "t_fungus_mound3_corner_ne", "t_fungus_mound3_corner_se", "t_fungus_mound3_corner_sw" ]
+          }
         ]
       },
       {
         "id": "t_connection",
         "bg": "snow_shallow_center",
         "fg": [
-          { "weight": 1, "sprite": [ "t_fungus_mound_t_connection_n", "t_fungus_mound_t_connection_w", "t_fungus_mound_t_connection_s", "t_fungus_mound_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound1_t_connection_n", "t_fungus_mound1_t_connection_w", "t_fungus_mound1_t_connection_s", "t_fungus_mound1_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound2_t_connection_n", "t_fungus_mound2_t_connection_w", "t_fungus_mound2_t_connection_s", "t_fungus_mound2_t_connection_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound3_t_connection_n", "t_fungus_mound3_t_connection_w", "t_fungus_mound3_t_connection_s", "t_fungus_mound3_t_connection_e" ] }
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound_t_connection_n",
+              "t_fungus_mound_t_connection_e",
+              "t_fungus_mound_t_connection_s",
+              "t_fungus_mound_t_connection_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound1_t_connection_n",
+              "t_fungus_mound1_t_connection_e",
+              "t_fungus_mound1_t_connection_s",
+              "t_fungus_mound1_t_connection_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound2_t_connection_n",
+              "t_fungus_mound2_t_connection_e",
+              "t_fungus_mound2_t_connection_s",
+              "t_fungus_mound2_t_connection_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound3_t_connection_n",
+              "t_fungus_mound3_t_connection_e",
+              "t_fungus_mound3_t_connection_s",
+              "t_fungus_mound3_t_connection_w"
+            ]
+          }
         ]
       },
-      { 
-        "id": "edge", 
-        "bg": "snow_shallow_center", 
-        "fg": [ 
+      {
+        "id": "edge",
+        "bg": "snow_shallow_center",
+        "fg": [
           { "weight": 1, "sprite": [ "t_fungus_mound_edge_ns", "t_fungus_mound_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus_mound1_edge_ns", "t_fungus_mound1_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus_mound2_edge_ns", "t_fungus_mound2_edge_ew" ] },
           { "weight": 1, "sprite": [ "t_fungus_mound3_edge_ns", "t_fungus_mound3_edge_ew" ] }
-        ] 
+        ]
       },
       {
         "id": "end_piece",
         "bg": "snow_shallow_center",
-        "fg": [ 
-          { "weight": 1, "sprite": [ "t_fungus_mound_end_piece_n", "t_fungus_mound_end_piece_w", "t_fungus_mound_end_piece_s", "t_fungus_mound_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound1_end_piece_n", "t_fungus_mound1_end_piece_w", "t_fungus_mound1_end_piece_s", "t_fungus_mound1_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound2_end_piece_n", "t_fungus_mound2_end_piece_w", "t_fungus_mound2_end_piece_s", "t_fungus_mound2_end_piece_e" ] },
-          { "weight": 1, "sprite": [ "t_fungus_mound3_end_piece_n", "t_fungus_mound3_end_piece_w", "t_fungus_mound3_end_piece_s", "t_fungus_mound3_end_piece_e" ] }
+        "fg": [
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound_end_piece_n",
+              "t_fungus_mound_end_piece_e",
+              "t_fungus_mound_end_piece_s",
+              "t_fungus_mound_end_piece_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound1_end_piece_n",
+              "t_fungus_mound1_end_piece_e",
+              "t_fungus_mound1_end_piece_s",
+              "t_fungus_mound1_end_piece_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound2_end_piece_n",
+              "t_fungus_mound2_end_piece_e",
+              "t_fungus_mound2_end_piece_s",
+              "t_fungus_mound2_end_piece_w"
+            ]
+          },
+          {
+            "weight": 1,
+            "sprite": [
+              "t_fungus_mound3_end_piece_n",
+              "t_fungus_mound3_end_piece_e",
+              "t_fungus_mound3_end_piece_s",
+              "t_fungus_mound3_end_piece_w"
+            ]
+          }
         ]
       },
       {
         "id": "unconnected",
         "bg": "snow_shallow_center",
-        "fg": [
-          "t_fungus_mound_unconnected",
-          "t_fungus_mound_unconnected"
-        ]
+        "fg": [ "t_fungus_mound_unconnected", "t_fungus_mound_unconnected" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fungus_subtypes/t_fungus_subtypes.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fungus_subtypes/t_fungus_subtypes.json
@@ -1,5 +1,9 @@
 {
-  "id": ["t_fungus_floor_in", "t_fungus_floor_sup", "t_fungus_floor_out"],
+  "id": [
+    "t_fungus_floor_in",
+    "t_fungus_floor_sup",
+    "t_fungus_floor_out"
+  ],
   "fg": "tfa0_unconnected",
   "bg": "t_thconc_floor_center",
   "multitile": true,
@@ -10,11 +14,11 @@
       "bg": "t_thconc_floor_center",
       "fg": [
         { "weight": 512, "sprite": "tfa0_center" },
-        { "weight": 8,   "sprite": "tfa1_center" },
-        { "weight": 8,   "sprite": "tfa2_center" },
+        { "weight": 8, "sprite": "tfa1_center" },
+        { "weight": 8, "sprite": "tfa2_center" },
         { "weight": 128, "sprite": "tfa3_center" },
-        { "weight": 8,   "sprite": "tfa4_center" },
-        { "weight": 8,   "sprite": "tfa1_center" }
+        { "weight": 8, "sprite": "tfa4_center" },
+        { "weight": 8, "sprite": "tfa1_center" }
       ]
     },
     {
@@ -22,12 +26,12 @@
       "animated": true,
       "bg": "t_thconc_floor_center",
       "fg": [
-        { "weight": 512, "sprite": [ "tfa0_corner_nw", "tfa0_corner_sw", "tfa0_corner_se", "tfa0_corner_ne" ] },
-        { "weight": 8,   "sprite": [ "tfa1_corner_nw", "tfa1_corner_sw", "tfa1_corner_se", "tfa1_corner_ne" ] },
-        { "weight": 8,   "sprite": [ "tfa2_corner_nw", "tfa2_corner_sw", "tfa2_corner_se", "tfa2_corner_ne" ] },
-        { "weight": 128, "sprite": [ "tfa3_corner_nw", "tfa3_corner_sw", "tfa3_corner_se", "tfa3_corner_ne" ] },
-        { "weight": 8,   "sprite": [ "tfa4_corner_nw", "tfa4_corner_sw", "tfa4_corner_se", "tfa4_corner_ne" ] },
-        { "weight": 8,   "sprite": [ "tfa1_corner_nw", "tfa1_corner_sw", "tfa1_corner_se", "tfa1_corner_ne" ] }
+        { "weight": 512, "sprite": [ "tfa0_corner_nw", "tfa0_corner_ne", "tfa0_corner_se", "tfa0_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfa1_corner_nw", "tfa1_corner_ne", "tfa1_corner_se", "tfa1_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfa2_corner_nw", "tfa2_corner_ne", "tfa2_corner_se", "tfa2_corner_sw" ] },
+        { "weight": 128, "sprite": [ "tfa3_corner_nw", "tfa3_corner_ne", "tfa3_corner_se", "tfa3_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfa4_corner_nw", "tfa4_corner_ne", "tfa4_corner_se", "tfa4_corner_sw" ] },
+        { "weight": 8, "sprite": [ "tfa1_corner_nw", "tfa1_corner_ne", "tfa1_corner_se", "tfa1_corner_sw" ] }
       ]
     },
     {
@@ -35,12 +39,30 @@
       "animated": true,
       "bg": "t_thconc_floor_center",
       "fg": [
-        { "weight": 512, "sprite": [ "tfa0_t_connection_n", "tfa0_t_connection_w", "tfa0_t_connection_s", "tfa0_t_connection_e" ] },
-        { "weight": 8,   "sprite": [ "tfa1_t_connection_n", "tfa1_t_connection_w", "tfa1_t_connection_s", "tfa1_t_connection_e" ] },
-        { "weight": 8,   "sprite": [ "tfa2_t_connection_n", "tfa2_t_connection_w", "tfa2_t_connection_s", "tfa2_t_connection_e" ] },
-        { "weight": 128, "sprite": [ "tfa3_t_connection_n", "tfa3_t_connection_w", "tfa3_t_connection_s", "tfa3_t_connection_e" ] },
-        { "weight": 8,   "sprite": [ "tfa4_t_connection_n", "tfa4_t_connection_w", "tfa4_t_connection_s", "tfa4_t_connection_e" ] },
-        { "weight": 8,   "sprite": [ "tfa1_t_connection_n", "tfa1_t_connection_w", "tfa1_t_connection_s", "tfa1_t_connection_e" ] }
+        {
+          "weight": 512,
+          "sprite": [ "tfa0_t_connection_n", "tfa0_t_connection_e", "tfa0_t_connection_s", "tfa0_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfa1_t_connection_n", "tfa1_t_connection_e", "tfa1_t_connection_s", "tfa1_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfa2_t_connection_n", "tfa2_t_connection_e", "tfa2_t_connection_s", "tfa2_t_connection_w" ]
+        },
+        {
+          "weight": 128,
+          "sprite": [ "tfa3_t_connection_n", "tfa3_t_connection_e", "tfa3_t_connection_s", "tfa3_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfa4_t_connection_n", "tfa4_t_connection_e", "tfa4_t_connection_s", "tfa4_t_connection_w" ]
+        },
+        {
+          "weight": 8,
+          "sprite": [ "tfa1_t_connection_n", "tfa1_t_connection_e", "tfa1_t_connection_s", "tfa1_t_connection_w" ]
+        }
       ]
     },
     {
@@ -49,11 +71,11 @@
       "bg": "t_thconc_floor_center",
       "fg": [
         { "weight": 512, "sprite": [ "tfa0_edge_ns", "tfa0_edge_ew" ] },
-        { "weight": 8,   "sprite": [ "tfa1_edge_ns", "tfa1_edge_ew" ] },
-        { "weight": 8,   "sprite": [ "tfa2_edge_ns", "tfa2_edge_ew" ] },
+        { "weight": 8, "sprite": [ "tfa1_edge_ns", "tfa1_edge_ew" ] },
+        { "weight": 8, "sprite": [ "tfa2_edge_ns", "tfa2_edge_ew" ] },
         { "weight": 128, "sprite": [ "tfa3_edge_ns", "tfa3_edge_ew" ] },
-        { "weight": 8,   "sprite": [ "tfa4_edge_ns", "tfa4_edge_ew" ] },
-        { "weight": 8,   "sprite": [ "tfa1_edge_ns", "tfa1_edge_ew" ] }
+        { "weight": 8, "sprite": [ "tfa4_edge_ns", "tfa4_edge_ew" ] },
+        { "weight": 8, "sprite": [ "tfa1_edge_ns", "tfa1_edge_ew" ] }
       ]
     },
     {
@@ -61,12 +83,15 @@
       "animated": true,
       "bg": "t_thconc_floor_center",
       "fg": [
-        { "weight": 512, "sprite": [ "tfa0_end_piece_n", "tfa0_end_piece_w", "tfa0_end_piece_s", "tfa0_end_piece_e" ] },
-        { "weight": 8,   "sprite": [ "tfa1_end_piece_n", "tfa1_end_piece_w", "tfa1_end_piece_s", "tfa1_end_piece_e" ] },
-        { "weight": 8,   "sprite": [ "tfa2_end_piece_n", "tfa2_end_piece_w", "tfa2_end_piece_s", "tfa2_end_piece_e" ] },
-        { "weight": 128, "sprite": [ "tfa3_end_piece_n", "tfa3_end_piece_w", "tfa3_end_piece_s", "tfa3_end_piece_e" ] },
-        { "weight": 8,   "sprite": [ "tfa4_end_piece_n", "tfa4_end_piece_w", "tfa4_end_piece_s", "tfa4_end_piece_e" ] },
-        { "weight": 8,   "sprite": [ "tfa1_end_piece_n", "tfa1_end_piece_w", "tfa1_end_piece_s", "tfa1_end_piece_e" ] }
+        { "weight": 512, "sprite": [ "tfa0_end_piece_n", "tfa0_end_piece_e", "tfa0_end_piece_s", "tfa0_end_piece_w" ] },
+        { "weight": 8, "sprite": [ "tfa1_end_piece_n", "tfa1_end_piece_e", "tfa1_end_piece_s", "tfa1_end_piece_w" ] },
+        { "weight": 8, "sprite": [ "tfa2_end_piece_n", "tfa2_end_piece_e", "tfa2_end_piece_s", "tfa2_end_piece_w" ] },
+        {
+          "weight": 128,
+          "sprite": [ "tfa3_end_piece_n", "tfa3_end_piece_e", "tfa3_end_piece_s", "tfa3_end_piece_w" ]
+        },
+        { "weight": 8, "sprite": [ "tfa4_end_piece_n", "tfa4_end_piece_e", "tfa4_end_piece_s", "tfa4_end_piece_w" ] },
+        { "weight": 8, "sprite": [ "tfa1_end_piece_n", "tfa1_end_piece_e", "tfa1_end_piece_s", "tfa1_end_piece_w" ] }
       ]
     },
     {
@@ -75,11 +100,11 @@
       "bg": "t_thconc_floor_center",
       "fg": [
         { "weight": 512, "sprite": [ "tfa0_unconnected", "tfa0_unconnected" ] },
-        { "weight": 8,   "sprite": [ "tfa1_unconnected", "tfa1_unconnected" ] },
-        { "weight": 8,   "sprite": [ "tfa2_unconnected", "tfa2_unconnected" ] },
+        { "weight": 8, "sprite": [ "tfa1_unconnected", "tfa1_unconnected" ] },
+        { "weight": 8, "sprite": [ "tfa2_unconnected", "tfa2_unconnected" ] },
         { "weight": 128, "sprite": [ "tfa3_unconnected", "tfa3_unconnected" ] },
-        { "weight": 8,   "sprite": [ "tfa4_unconnected", "tfa4_unconnected" ] },
-        { "weight": 8,   "sprite": [ "tfa1_unconnected", "tfa1_unconnected" ] }
+        { "weight": 8, "sprite": [ "tfa4_unconnected", "tfa4_unconnected" ] },
+        { "weight": 8, "sprite": [ "tfa1_unconnected", "tfa1_unconnected" ] }
       ]
     }
   ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fungus_wall/t_fungus_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_fungus_wall/t_fungus_wall.json
@@ -3,50 +3,25 @@
   "fg": "t_fungus_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_fungus_wall_center"
-    },
+    { "id": "center", "fg": "t_fungus_wall_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_fungus_wall_corner_nw",
-        "t_fungus_wall_corner_sw",
-        "t_fungus_wall_corner_se",
-        "t_fungus_wall_corner_ne"
-      ]
+      "fg": [ "t_fungus_wall_corner_nw", "t_fungus_wall_corner_ne", "t_fungus_wall_corner_se", "t_fungus_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_fungus_wall_t_connection_n",
-        "t_fungus_wall_t_connection_w",
+        "t_fungus_wall_t_connection_e",
         "t_fungus_wall_t_connection_s",
-        "t_fungus_wall_t_connection_e"
+        "t_fungus_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_fungus_wall_edge_ns",
-        "t_fungus_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_fungus_wall_edge_ns", "t_fungus_wall_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_fungus_wall_end_piece_n",
-        "t_fungus_wall_end_piece_w",
-        "t_fungus_wall_end_piece_s",
-        "t_fungus_wall_end_piece_e"
-      ]
+      "fg": [ "t_fungus_wall_end_piece_n", "t_fungus_wall_end_piece_e", "t_fungus_wall_end_piece_s", "t_fungus_wall_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_fungus_wall_unconnected",
-        "t_fungus_wall_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_fungus_wall_unconnected", "t_fungus_wall_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_glass_roof/t_glass_roof.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_glass_roof/t_glass_roof.json
@@ -3,47 +3,25 @@
   "fg": "t_glass_roof_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_glass_roof_center"
-    },
+    { "id": "center", "fg": "t_glass_roof_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_glass_roof_corner_nw",
-        "t_glass_roof_corner_sw",
-        "t_glass_roof_corner_se",
-        "t_glass_roof_corner_ne"
-      ]
+      "fg": [ "t_glass_roof_corner_nw", "t_glass_roof_corner_ne", "t_glass_roof_corner_se", "t_glass_roof_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_glass_roof_t_connection_n",
-        "t_glass_roof_t_connection_w",
+        "t_glass_roof_t_connection_e",
         "t_glass_roof_t_connection_s",
-        "t_glass_roof_t_connection_e"
+        "t_glass_roof_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_glass_roof_edge_ns",
-        "t_glass_roof_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_glass_roof_edge_ns", "t_glass_roof_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_glass_roof_end_piece_n",
-        "t_glass_roof_end_piece_w",
-        "t_glass_roof_end_piece_s",
-        "t_glass_roof_end_piece_e"
-      ]
+      "fg": [ "t_glass_roof_end_piece_n", "t_glass_roof_end_piece_e", "t_glass_roof_end_piece_s", "t_glass_roof_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_glass_roof_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_glass_roof_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_grass/t_grass.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_grass/t_grass.json
@@ -8,7 +8,8 @@
       { "weight": 1, "sprite": "t_grass_center4" }
     ],
     "bg": ""
-  }, {
+  },
+  {
     "id": "t_grass_season_summer",
     "fg": [
       { "weight": 1, "sprite": "t_grass_summer_center" },
@@ -17,7 +18,8 @@
       { "weight": 1, "sprite": "t_grass_summer_center4" }
     ],
     "bg": ""
-  }, {
+  },
+  {
     "id": "t_grass_season_autumn",
     "fg": [
       { "weight": 1, "sprite": "t_grass_autumn_center" },
@@ -26,7 +28,8 @@
       { "weight": 1, "sprite": "t_grass_autumn_center4" }
     ],
     "bg": ""
-  }, {
+  },
+  {
     "id": "t_grass_season_winter",
     "fg": "snow_shallow_unconnected",
     "bg": "snow_shallow_center",
@@ -45,28 +48,23 @@
       {
         "id": "corner",
         "bg": "snow_shallow_center",
-        "fg": [ "snow_shallow_corner_nw", "snow_shallow_corner_sw", "snow_shallow_corner_se", "snow_shallow_corner_ne" ]
+        "fg": [ "snow_shallow_corner_nw", "snow_shallow_corner_ne", "snow_shallow_corner_se", "snow_shallow_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "snow_shallow_center",
         "fg": [
           "snow_shallow_t_connection_n",
-          "snow_shallow_t_connection_w",
+          "snow_shallow_t_connection_e",
           "snow_shallow_t_connection_s",
-          "snow_shallow_t_connection_e"
+          "snow_shallow_t_connection_w"
         ]
       },
       { "id": "edge", "bg": "snow_shallow_center", "fg": [ "snow_shallow_edge_ns", "snow_shallow_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "snow_shallow_center",
-        "fg": [
-          "snow_shallow_end_piece_n",
-          "snow_shallow_end_piece_w",
-          "snow_shallow_end_piece_s",
-          "snow_shallow_end_piece_e"
-        ]
+        "fg": [ "snow_shallow_end_piece_n", "snow_shallow_end_piece_e", "snow_shallow_end_piece_s", "snow_shallow_end_piece_w" ]
       },
       { "bg": "snow_shallow_center", "id": "unconnected", "fg": "snow_shallow_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_grass_dead/t_grass_dead.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_grass_dead/t_grass_dead.json
@@ -9,23 +9,23 @@
       {
         "id": "corner",
         "bg": "t_grass",
-        "fg": [ "t_grass_dead_corner_nw", "t_grass_dead_corner_sw", "t_grass_dead_corner_se", "t_grass_dead_corner_ne" ]
+        "fg": [ "t_grass_dead_corner_nw", "t_grass_dead_corner_ne", "t_grass_dead_corner_se", "t_grass_dead_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass",
         "fg": [
           "t_grass_dead_t_connection_n",
-          "t_grass_dead_t_connection_w",
+          "t_grass_dead_t_connection_e",
           "t_grass_dead_t_connection_s",
-          "t_grass_dead_t_connection_e"
+          "t_grass_dead_t_connection_w"
         ]
       },
       { "id": "edge", "bg": "t_grass", "fg": [ "t_grass_dead_edge_ns", "t_grass_dead_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass",
-        "fg": [ "t_grass_dead_end_piece_n", "t_grass_dead_end_piece_w", "t_grass_dead_end_piece_s", "t_grass_dead_end_piece_e" ]
+        "fg": [ "t_grass_dead_end_piece_n", "t_grass_dead_end_piece_e", "t_grass_dead_end_piece_s", "t_grass_dead_end_piece_w" ]
       },
       { "bg": "t_grass", "id": "unconnected", "fg": "t_grass_dead_unconnected" }
     ]
@@ -40,23 +40,37 @@
       {
         "id": "corner",
         "bg": "t_grass_summer",
-        "fg": [ "t_grass_dead_season_summer_corner_nw", "t_grass_dead_season_summer_corner_sw", "t_grass_dead_season_summer_corner_se", "t_grass_dead_season_summer_corner_ne" ]
+        "fg": [
+          "t_grass_dead_season_summer_corner_nw",
+          "t_grass_dead_season_summer_corner_ne",
+          "t_grass_dead_season_summer_corner_se",
+          "t_grass_dead_season_summer_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_summer",
         "fg": [
           "t_grass_dead_season_summer_t_connection_n",
-          "t_grass_dead_season_summer_t_connection_w",
+          "t_grass_dead_season_summer_t_connection_e",
           "t_grass_dead_season_summer_t_connection_s",
-          "t_grass_dead_season_summer_t_connection_e"
+          "t_grass_dead_season_summer_t_connection_w"
         ]
       },
-      { "id": "edge", "bg": "t_grass_summer", "fg": [ "t_grass_dead_season_summer_edge_ns", "t_grass_dead_season_summer_edge_ew" ] },
+      {
+        "id": "edge",
+        "bg": "t_grass_summer",
+        "fg": [ "t_grass_dead_season_summer_edge_ns", "t_grass_dead_season_summer_edge_ew" ]
+      },
       {
         "id": "end_piece",
         "bg": "t_grass_summer",
-        "fg": [ "t_grass_dead_season_summer_end_piece_n", "t_grass_dead_season_summer_end_piece_w", "t_grass_dead_season_summer_end_piece_s", "t_grass_dead_season_summer_end_piece_e" ]
+        "fg": [
+          "t_grass_dead_season_summer_end_piece_n",
+          "t_grass_dead_season_summer_end_piece_e",
+          "t_grass_dead_season_summer_end_piece_s",
+          "t_grass_dead_season_summer_end_piece_w"
+        ]
       },
       { "bg": "t_grass_summer", "id": "unconnected", "fg": "t_grass_dead_season_summer_unconnected" }
     ]
@@ -71,23 +85,37 @@
       {
         "id": "corner",
         "bg": "t_grass_autumn",
-        "fg": [ "t_grass_dead_season_autumn_corner_nw", "t_grass_dead_season_autumn_corner_sw", "t_grass_dead_season_autumn_corner_se", "t_grass_dead_season_autumn_corner_ne" ]
+        "fg": [
+          "t_grass_dead_season_autumn_corner_nw",
+          "t_grass_dead_season_autumn_corner_ne",
+          "t_grass_dead_season_autumn_corner_se",
+          "t_grass_dead_season_autumn_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_autumn",
         "fg": [
           "t_grass_dead_season_autumn_t_connection_n",
-          "t_grass_dead_season_autumn_t_connection_w",
+          "t_grass_dead_season_autumn_t_connection_e",
           "t_grass_dead_season_autumn_t_connection_s",
-          "t_grass_dead_season_autumn_t_connection_e"
+          "t_grass_dead_season_autumn_t_connection_w"
         ]
       },
-      { "id": "edge", "bg": "t_grass_autumn", "fg": [ "t_grass_dead_season_autumn_edge_ns", "t_grass_dead_season_autumn_edge_ew" ] },
+      {
+        "id": "edge",
+        "bg": "t_grass_autumn",
+        "fg": [ "t_grass_dead_season_autumn_edge_ns", "t_grass_dead_season_autumn_edge_ew" ]
+      },
       {
         "id": "end_piece",
         "bg": "t_grass_autumn",
-        "fg": [ "t_grass_dead_season_autumn_end_piece_n", "t_grass_dead_season_autumn_end_piece_w", "t_grass_dead_season_autumn_end_piece_s", "t_grass_dead_season_autumn_end_piece_e" ]
+        "fg": [
+          "t_grass_dead_season_autumn_end_piece_n",
+          "t_grass_dead_season_autumn_end_piece_e",
+          "t_grass_dead_season_autumn_end_piece_s",
+          "t_grass_dead_season_autumn_end_piece_w"
+        ]
       },
       { "bg": "t_grass_autumn", "id": "unconnected", "fg": "t_grass_dead_season_autumn_unconnected" }
     ]
@@ -111,28 +139,23 @@
       {
         "id": "corner",
         "bg": "snow_shallow_center",
-        "fg": [ "snow_shallow_corner_nw", "snow_shallow_corner_sw", "snow_shallow_corner_se", "snow_shallow_corner_ne" ]
+        "fg": [ "snow_shallow_corner_nw", "snow_shallow_corner_ne", "snow_shallow_corner_se", "snow_shallow_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "snow_shallow_center",
         "fg": [
           "snow_shallow_t_connection_n",
-          "snow_shallow_t_connection_w",
+          "snow_shallow_t_connection_e",
           "snow_shallow_t_connection_s",
-          "snow_shallow_t_connection_e"
+          "snow_shallow_t_connection_w"
         ]
       },
       { "id": "edge", "bg": "snow_shallow_center", "fg": [ "snow_shallow_edge_ns", "snow_shallow_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "snow_shallow_center",
-        "fg": [
-          "snow_shallow_end_piece_n",
-          "snow_shallow_end_piece_w",
-          "snow_shallow_end_piece_s",
-          "snow_shallow_end_piece_e"
-        ]
+        "fg": [ "snow_shallow_end_piece_n", "snow_shallow_end_piece_e", "snow_shallow_end_piece_s", "snow_shallow_end_piece_w" ]
       },
       { "bg": "snow_shallow_center", "id": "unconnected", "fg": "snow_shallow_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_grate/t_grate.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_grate/t_grate.json
@@ -4,56 +4,23 @@
   "fg": "t_grate_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_grate_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_grate_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_grate_corner_nw",
-        "t_grate_corner_sw",
-        "t_grate_corner_se",
-        "t_grate_corner_ne"
-      ]
+      "fg": [ "t_grate_corner_nw", "t_grate_corner_ne", "t_grate_corner_se", "t_grate_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "t_grate_t_connection_n",
-        "t_grate_t_connection_w",
-        "t_grate_t_connection_s",
-        "t_grate_t_connection_e"
-      ]
+      "fg": [ "t_grate_t_connection_n", "t_grate_t_connection_e", "t_grate_t_connection_s", "t_grate_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_grate_edge_ns",
-        "t_grate_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_grate_edge_ns", "t_grate_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_grate_end_piece_n",
-        "t_grate_end_piece_w",
-        "t_grate_end_piece_s",
-        "t_grate_end_piece_e"
-      ]
+      "fg": [ "t_grate_end_piece_n", "t_grate_end_piece_e", "t_grate_end_piece_s", "t_grate_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [
-        "t_grate_unconnected",
-        "t_grate_unconnected"
-      ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "t_grate_unconnected", "t_grate_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_guardrail/t_guardrail.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_guardrail/t_guardrail.json
@@ -9,7 +9,7 @@
       {
         "id": "end_piece",
         "bg": "t_sidewalk_center",
-        "fg": [ "t_guardrail_end_piece_n", "t_guardrail_end_piece_w", "t_guardrail_end_piece_s", "t_guardrail_end_piece_e" ]
+        "fg": [ "t_guardrail_end_piece_n", "t_guardrail_end_piece_e", "t_guardrail_end_piece_s", "t_guardrail_end_piece_w" ]
       },
       { "bg": "t_sidewalk_center", "id": "unconnected", "fg": "t_guardrail_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_gutter/t_gutter.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_gutter/t_gutter.json
@@ -12,16 +12,16 @@
     { "id": "center", "fg": "t_gutter_unconnected" },
     {
       "id": "corner",
-      "fg": [ "t_gutter_corner_nw", "t_gutter_corner_sw", "t_gutter_corner_se", "t_gutter_corner_ne" ]
+      "fg": [ "t_gutter_corner_nw", "t_gutter_corner_ne", "t_gutter_corner_se", "t_gutter_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [ "t_gutter_t_connection_n", "t_gutter_t_connection_w", "t_gutter_t_connection_s", "t_gutter_t_connection_e" ]
+      "fg": [ "t_gutter_t_connection_n", "t_gutter_t_connection_e", "t_gutter_t_connection_s", "t_gutter_t_connection_w" ]
     },
     { "id": "edge", "fg": [ "t_gutter_edge_ns", "t_gutter_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [ "t_gutter_end_piece_n", "t_gutter_end_piece_w", "t_gutter_end_piece_s", "t_gutter_end_piece_e" ]
+      "fg": [ "t_gutter_end_piece_n", "t_gutter_end_piece_e", "t_gutter_end_piece_s", "t_gutter_end_piece_w" ]
     },
     { "id": "unconnected", "fg": [ "t_gutter_unconnected" ] }
   ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_lava/t_lava.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_lava/t_lava.json
@@ -4,56 +4,23 @@
   "bg": "t_rock_floor_center",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_lava_center",
-      "bg": "t_rock_floor_center"
-    },
+    { "id": "center", "fg": "t_lava_center", "bg": "t_rock_floor_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_lava_corner_nw",
-        "t_lava_corner_sw",
-        "t_lava_corner_se",
-        "t_lava_corner_ne"
-      ],
+      "fg": [ "t_lava_corner_nw", "t_lava_corner_ne", "t_lava_corner_se", "t_lava_corner_sw" ],
       "bg": "t_rock_floor_center"
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_lava_t_connection_n",
-        "t_lava_t_connection_w",
-        "t_lava_t_connection_s",
-        "t_lava_t_connection_e"
-      ],
+      "fg": [ "t_lava_t_connection_n", "t_lava_t_connection_e", "t_lava_t_connection_s", "t_lava_t_connection_w" ],
       "bg": "t_rock_floor_center"
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_lava_edge_ns",
-        "t_lava_edge_ew"
-      ],
-      "bg": "t_rock_floor_center"
-    },
+    { "id": "edge", "fg": [ "t_lava_edge_ns", "t_lava_edge_ew" ], "bg": "t_rock_floor_center" },
     {
       "id": "end_piece",
-      "fg": [
-        "t_lava_end_piece_n",
-        "t_lava_end_piece_w",
-        "t_lava_end_piece_s",
-        "t_lava_end_piece_e"
-      ],
+      "fg": [ "t_lava_end_piece_n", "t_lava_end_piece_e", "t_lava_end_piece_s", "t_lava_end_piece_w" ],
       "bg": "t_rock_floor_center"
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_lava_unconnected",
-        "t_lava_unconnected"
-      ],
-      "bg": "t_rock_floor_center"
-    }
+    { "id": "unconnected", "fg": [ "t_lava_unconnected", "t_lava_unconnected" ], "bg": "t_rock_floor_center" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_linoleum_gray/t_linoleum_gray.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_linoleum_gray/t_linoleum_gray.json
@@ -1,56 +1,39 @@
 {
-  "id": [ "t_linoleum_gray", "t_linoleum_gray_no_roof"  ],
+  "id": [
+    "t_linoleum_gray",
+    "t_linoleum_gray_no_roof"
+  ],
   "multitile": true,
   "fg": "t_linoleum_gray_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_linoleum_gray_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_linoleum_gray_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_linoleum_gray_corner_nw",
-        "t_linoleum_gray_corner_sw",
-        "t_linoleum_gray_corner_se",
-        "t_linoleum_gray_corner_ne"
-      ]
+      "fg": [ "t_linoleum_gray_corner_nw", "t_linoleum_gray_corner_ne", "t_linoleum_gray_corner_se", "t_linoleum_gray_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_linoleum_gray_t_connection_n",
-        "t_linoleum_gray_t_connection_w",
+        "t_linoleum_gray_t_connection_e",
         "t_linoleum_gray_t_connection_s",
-        "t_linoleum_gray_t_connection_e"
+        "t_linoleum_gray_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_linoleum_gray_edge_ns",
-        "t_linoleum_gray_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_linoleum_gray_edge_ns", "t_linoleum_gray_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "t_linoleum_gray_end_piece_n",
-        "t_linoleum_gray_end_piece_w",
+        "t_linoleum_gray_end_piece_e",
         "t_linoleum_gray_end_piece_s",
-        "t_linoleum_gray_end_piece_e"
+        "t_linoleum_gray_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_linoleum_gray_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_linoleum_gray_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_linoleum_white/t_linoleum_white.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_linoleum_white/t_linoleum_white.json
@@ -1,22 +1,21 @@
 {
-  "id": [ "t_linoleum_white", "t_linoleum_white_no_roof" ],
+  "id": [
+    "t_linoleum_white",
+    "t_linoleum_white_no_roof"
+  ],
   "multitile": true,
   "fg": "t_linoleum_white_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_linoleum_white_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_linoleum_white_center" },
     {
       "id": "corner",
       "bg": "",
       "fg": [
         "t_linoleum_white_corner_nw",
-        "t_linoleum_white_corner_sw",
+        "t_linoleum_white_corner_ne",
         "t_linoleum_white_corner_se",
-        "t_linoleum_white_corner_ne"
+        "t_linoleum_white_corner_sw"
       ]
     },
     {
@@ -24,33 +23,22 @@
       "bg": "",
       "fg": [
         "t_linoleum_white_t_connection_n",
-        "t_linoleum_white_t_connection_w",
+        "t_linoleum_white_t_connection_e",
         "t_linoleum_white_t_connection_s",
-        "t_linoleum_white_t_connection_e"
+        "t_linoleum_white_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_linoleum_white_edge_ns",
-        "t_linoleum_white_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_linoleum_white_edge_ns", "t_linoleum_white_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "t_linoleum_white_end_piece_n",
-        "t_linoleum_white_end_piece_w",
+        "t_linoleum_white_end_piece_e",
         "t_linoleum_white_end_piece_s",
-        "t_linoleum_white_end_piece_e"
+        "t_linoleum_white_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_linoleum_white_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_linoleum_white_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_metal_floor/t_metal_floor.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_metal_floor/t_metal_floor.json
@@ -4,53 +4,28 @@
   "fg": "t_metal_floor_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_metal_floor_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_metal_floor_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_metal_floor_corner_nw",
-        "t_metal_floor_corner_sw",
-        "t_metal_floor_corner_se",
-        "t_metal_floor_corner_ne"
-      ]
+      "fg": [ "t_metal_floor_corner_nw", "t_metal_floor_corner_ne", "t_metal_floor_corner_se", "t_metal_floor_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_metal_floor_t_connection_n",
-        "t_metal_floor_t_connection_w",
+        "t_metal_floor_t_connection_e",
         "t_metal_floor_t_connection_s",
-        "t_metal_floor_t_connection_e"
+        "t_metal_floor_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_metal_floor_edge_ns",
-        "t_metal_floor_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_metal_floor_edge_ns", "t_metal_floor_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_metal_floor_end_piece_n",
-        "t_metal_floor_end_piece_w",
-        "t_metal_floor_end_piece_s",
-        "t_metal_floor_end_piece_e"
-      ]
+      "fg": [ "t_metal_floor_end_piece_n", "t_metal_floor_end_piece_e", "t_metal_floor_end_piece_s", "t_metal_floor_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_metal_floor_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_metal_floor_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_moss/t_moss.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_moss/t_moss.json
@@ -8,26 +8,23 @@
       {
         "id": "center",
         "bg": "t_grass_center",
-        "fg": [
-          { "weight": 1, "sprite": "t_moss_center" },
-          { "weight": 1, "sprite": "t_moss_center2" }
-        ]
+        "fg": [ { "weight": 1, "sprite": "t_moss_center" }, { "weight": 1, "sprite": "t_moss_center2" } ]
       },
       {
         "id": "corner",
         "bg": "t_grass_center",
-        "fg": [ "t_moss_corner_nw", "t_moss_corner_sw", "t_moss_corner_se", "t_moss_corner_ne" ]
+        "fg": [ "t_moss_corner_nw", "t_moss_corner_ne", "t_moss_corner_se", "t_moss_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_center",
-        "fg": [ "t_moss_t_connection_n", "t_moss_t_connection_w", "t_moss_t_connection_s", "t_moss_t_connection_e" ]
+        "fg": [ "t_moss_t_connection_n", "t_moss_t_connection_e", "t_moss_t_connection_s", "t_moss_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_grass_center", "fg": [ "t_moss_edge_ns", "t_moss_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_center",
-        "fg": [ "t_moss_end_piece_n", "t_moss_end_piece_w", "t_moss_end_piece_s", "t_moss_end_piece_e" ]
+        "fg": [ "t_moss_end_piece_n", "t_moss_end_piece_e", "t_moss_end_piece_s", "t_moss_end_piece_w" ]
       },
       { "bg": "t_grass_center", "id": "unconnected", "fg": "t_moss_unconnected" }
     ]
@@ -41,36 +38,28 @@
       {
         "id": "center",
         "bg": "t_grass_summer_center",
-        "fg": [
-          { "weight": 1, "sprite": "t_moss_summer_center" },
-          { "weight": 1, "sprite": "t_moss_summer_center2" }
-        ]
+        "fg": [ { "weight": 1, "sprite": "t_moss_summer_center" }, { "weight": 1, "sprite": "t_moss_summer_center2" } ]
       },
       {
         "id": "corner",
         "bg": "t_grass_summer_center",
-        "fg": [ "t_moss_summer_corner_nw", "t_moss_summer_corner_sw", "t_moss_summer_corner_se", "t_moss_summer_corner_ne" ]
+        "fg": [ "t_moss_summer_corner_nw", "t_moss_summer_corner_ne", "t_moss_summer_corner_se", "t_moss_summer_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_summer_center",
         "fg": [
           "t_moss_summer_t_connection_n",
-          "t_moss_summer_t_connection_w",
+          "t_moss_summer_t_connection_e",
           "t_moss_summer_t_connection_s",
-          "t_moss_summer_t_connection_e"
+          "t_moss_summer_t_connection_w"
         ]
       },
       { "id": "edge", "bg": "t_grass_summer_center", "fg": [ "t_moss_summer_edge_ns", "t_moss_summer_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_summer_center",
-        "fg": [
-          "t_moss_summer_end_piece_n",
-          "t_moss_summer_end_piece_w",
-          "t_moss_summer_end_piece_s",
-          "t_moss_summer_end_piece_e"
-        ]
+        "fg": [ "t_moss_summer_end_piece_n", "t_moss_summer_end_piece_e", "t_moss_summer_end_piece_s", "t_moss_summer_end_piece_w" ]
       },
       { "bg": "t_grass_summer_center", "id": "unconnected", "fg": "t_moss_summer_unconnected" }
     ]
@@ -84,36 +73,28 @@
       {
         "id": "center",
         "bg": "t_grass_autumn_center",
-        "fg": [
-          { "weight": 1, "sprite": "t_moss_autumn_center" },
-          { "weight": 1, "sprite": "t_moss_autumn_center2" }
-        ]
+        "fg": [ { "weight": 1, "sprite": "t_moss_autumn_center" }, { "weight": 1, "sprite": "t_moss_autumn_center2" } ]
       },
       {
         "id": "corner",
         "bg": "t_grass_autumn_center",
-        "fg": [ "t_moss_autumn_corner_nw", "t_moss_autumn_corner_sw", "t_moss_autumn_corner_se", "t_moss_autumn_corner_ne" ]
+        "fg": [ "t_moss_autumn_corner_nw", "t_moss_autumn_corner_ne", "t_moss_autumn_corner_se", "t_moss_autumn_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_autumn_center",
         "fg": [
           "t_moss_autumn_t_connection_n",
-          "t_moss_autumn_t_connection_w",
+          "t_moss_autumn_t_connection_e",
           "t_moss_autumn_t_connection_s",
-          "t_moss_autumn_t_connection_e"
+          "t_moss_autumn_t_connection_w"
         ]
       },
       { "id": "edge", "bg": "t_grass_autumn_center", "fg": [ "t_moss_autumn_edge_ns", "t_moss_autumn_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_autumn_center",
-        "fg": [
-          "t_moss_autumn_end_piece_n",
-          "t_moss_autumn_end_piece_w",
-          "t_moss_autumn_end_piece_s",
-          "t_moss_autumn_end_piece_e"
-        ]
+        "fg": [ "t_moss_autumn_end_piece_n", "t_moss_autumn_end_piece_e", "t_moss_autumn_end_piece_s", "t_moss_autumn_end_piece_w" ]
       },
       { "bg": "t_grass_autumn_center", "id": "unconnected", "fg": "t_moss_autumn_unconnected" }
     ]
@@ -127,36 +108,28 @@
       {
         "id": "center",
         "bg": "snow_shallow_center",
-        "fg": [
-          { "weight": 1, "sprite": "snow_shallow_center" },
-          { "weight": 1, "sprite": "snow_shallow_center2" }
-        ]
+        "fg": [ { "weight": 1, "sprite": "snow_shallow_center" }, { "weight": 1, "sprite": "snow_shallow_center2" } ]
       },
       {
         "id": "corner",
         "bg": "snow_shallow_center",
-        "fg": [ "snow_shallow_corner_nw", "snow_shallow_corner_sw", "snow_shallow_corner_se", "snow_shallow_corner_ne" ]
+        "fg": [ "snow_shallow_corner_nw", "snow_shallow_corner_ne", "snow_shallow_corner_se", "snow_shallow_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "snow_shallow_center",
         "fg": [
           "snow_shallow_t_connection_n",
-          "snow_shallow_t_connection_w",
+          "snow_shallow_t_connection_e",
           "snow_shallow_t_connection_s",
-          "snow_shallow_t_connection_e"
+          "snow_shallow_t_connection_w"
         ]
       },
       { "id": "edge", "bg": "snow_shallow_center", "fg": [ "snow_shallow_edge_ns", "snow_shallow_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "snow_shallow_center",
-        "fg": [
-          "snow_shallow_end_piece_n",
-          "snow_shallow_end_piece_w",
-          "snow_shallow_end_piece_s",
-          "snow_shallow_end_piece_e"
-        ]
+        "fg": [ "snow_shallow_end_piece_n", "snow_shallow_end_piece_e", "snow_shallow_end_piece_s", "snow_shallow_end_piece_w" ]
       },
       { "bg": "snow_shallow_center", "id": "unconnected", "fg": "snow_shallow_unconnected" }
     ]
@@ -170,26 +143,23 @@
       {
         "id": "center",
         "bg": "t_rock_floor_center",
-        "fg": [
-          { "weight": 1, "sprite": "t_moss_center" },
-          { "weight": 1, "sprite": "t_moss_center2" }
-        ]
+        "fg": [ { "weight": 1, "sprite": "t_moss_center" }, { "weight": 1, "sprite": "t_moss_center2" } ]
       },
       {
         "id": "corner",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_moss_corner_nw", "t_moss_corner_sw", "t_moss_corner_se", "t_moss_corner_ne" ]
+        "fg": [ "t_moss_corner_nw", "t_moss_corner_ne", "t_moss_corner_se", "t_moss_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_moss_t_connection_n", "t_moss_t_connection_w", "t_moss_t_connection_s", "t_moss_t_connection_e" ]
+        "fg": [ "t_moss_t_connection_n", "t_moss_t_connection_e", "t_moss_t_connection_s", "t_moss_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_rock_floor_center", "fg": [ "t_moss_edge_ns", "t_moss_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_moss_end_piece_n", "t_moss_end_piece_w", "t_moss_end_piece_s", "t_moss_end_piece_e" ]
+        "fg": [ "t_moss_end_piece_n", "t_moss_end_piece_e", "t_moss_end_piece_s", "t_moss_end_piece_w" ]
       },
       { "bg": "t_rock_floor_center", "id": "unconnected", "fg": "t_moss_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_nm_brain/t_nm_brain.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_nm_brain/t_nm_brain.json
@@ -15,43 +15,19 @@
       },
       {
         "id": "corner",
-        "fg": [
-          "t_nm_brain_corner_nw",
-          "t_nm_brain_corner_sw",
-          "t_nm_brain_corner_se",
-          "t_nm_brain_corner_ne"
-        ],
+        "fg": [ "t_nm_brain_corner_nw", "t_nm_brain_corner_ne", "t_nm_brain_corner_se", "t_nm_brain_corner_sw" ],
         "bg": "t_nm_floor_flesh"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_nm_brain_t_connection_n",
-          "t_nm_brain_t_connection_w",
-          "t_nm_brain_t_connection_s",
-          "t_nm_brain_t_connection_e"
-        ]
+        "fg": [ "t_nm_brain_t_connection_n", "t_nm_brain_t_connection_e", "t_nm_brain_t_connection_s", "t_nm_brain_t_connection_w" ]
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_nm_brain_edge_ns",
-          "t_nm_brain_edge_ew"
-        ]
-      },
+      { "id": "edge", "fg": [ "t_nm_brain_edge_ns", "t_nm_brain_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [
-          "t_nm_brain_end_piece_n",
-          "t_nm_brain_end_piece_w",
-          "t_nm_brain_end_piece_s",
-          "t_nm_brain_end_piece_e"
-        ]
+        "fg": [ "t_nm_brain_end_piece_n", "t_nm_brain_end_piece_e", "t_nm_brain_end_piece_s", "t_nm_brain_end_piece_w" ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_nm_brain_unconnected"
-      }
+      { "id": "unconnected", "fg": "t_nm_brain_unconnected" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_nm_ichor_sh/t_nm_ichor_sh.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_nm_ichor_sh/t_nm_ichor_sh.json
@@ -15,44 +15,26 @@
       },
       {
         "id": "corner",
-        "fg": [
-          "t_nm_ichor_sh_corner_nw",
-          "t_nm_ichor_sh_corner_sw",
-          "t_nm_ichor_sh_corner_se",
-          "t_nm_ichor_sh_corner_ne"
-        ],
+        "fg": [ "t_nm_ichor_sh_corner_nw", "t_nm_ichor_sh_corner_ne", "t_nm_ichor_sh_corner_se", "t_nm_ichor_sh_corner_sw" ],
         "bg": "t_nm_floor_flesh"
       },
       {
         "id": "t_connection",
         "fg": [
           "t_nm_ichor_sh_t_connection_n",
-          "t_nm_ichor_sh_t_connection_w",
+          "t_nm_ichor_sh_t_connection_e",
           "t_nm_ichor_sh_t_connection_s",
-          "t_nm_ichor_sh_t_connection_e"
+          "t_nm_ichor_sh_t_connection_w"
         ],
         "bg": "t_nm_floor_flesh"
       },
-      {
-        "id": "edge",
-        "fg": [ "t_nm_ichor_sh_edge_ns", "t_nm_ichor_sh_edge_ew" ],
-        "bg": "t_nm_floor_flesh"
-      },
+      { "id": "edge", "fg": [ "t_nm_ichor_sh_edge_ns", "t_nm_ichor_sh_edge_ew" ], "bg": "t_nm_floor_flesh" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_nm_ichor_sh_end_piece_n",
-          "t_nm_ichor_sh_end_piece_w",
-          "t_nm_ichor_sh_end_piece_s",
-          "t_nm_ichor_sh_end_piece_e"
-        ],
+        "fg": [ "t_nm_ichor_sh_end_piece_n", "t_nm_ichor_sh_end_piece_e", "t_nm_ichor_sh_end_piece_s", "t_nm_ichor_sh_end_piece_w" ],
         "bg": "t_nm_floor_flesh"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_nm_ichor_sh_unconnected",
-        "bg": "t_nm_floor_flesh"
-      }
+      { "id": "unconnected", "fg": "t_nm_ichor_sh_unconnected", "bg": "t_nm_floor_flesh" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_nm_wall_flesh/t_nm_wall_flesh.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_nm_wall_flesh/t_nm_wall_flesh.json
@@ -4,48 +4,31 @@
     "fg": "t_nm_wall_flesh_unconnected",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_nm_wall_flesh_center"
-      },
+      { "id": "center", "fg": "t_nm_wall_flesh_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_nm_wall_flesh_corner_nw",
-          "t_nm_wall_flesh_corner_sw",
-          "t_nm_wall_flesh_corner_se",
-          "t_nm_wall_flesh_corner_ne"
-        ]
+        "fg": [ "t_nm_wall_flesh_corner_nw", "t_nm_wall_flesh_corner_ne", "t_nm_wall_flesh_corner_se", "t_nm_wall_flesh_corner_sw" ]
       },
       {
         "id": "t_connection",
         "fg": [
           "t_nm_wall_flesh_t_connection_n",
-          "t_nm_wall_flesh_t_connection_w",
+          "t_nm_wall_flesh_t_connection_e",
           "t_nm_wall_flesh_t_connection_s",
-          "t_nm_wall_flesh_t_connection_e"
+          "t_nm_wall_flesh_t_connection_w"
         ]
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_nm_wall_flesh_edge_ns",
-          "t_nm_wall_flesh_edge_ew"
-        ]
-      },
+      { "id": "edge", "fg": [ "t_nm_wall_flesh_edge_ns", "t_nm_wall_flesh_edge_ew" ] },
       {
         "id": "end_piece",
         "fg": [
           "t_nm_wall_flesh_end_piece_n",
-          "t_nm_wall_flesh_end_piece_w",
+          "t_nm_wall_flesh_end_piece_e",
           "t_nm_wall_flesh_end_piece_s",
-          "t_nm_wall_flesh_end_piece_e"
+          "t_nm_wall_flesh_end_piece_w"
         ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_nm_wall_flesh_unconnected"
-      }
+      { "id": "unconnected", "fg": "t_nm_wall_flesh_unconnected" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_palisade/t_palisade.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_palisade/t_palisade.json
@@ -1,58 +1,28 @@
-[  
+[
   {
     "id": "t_palisade",
     "fg": "t_palisade_unconnected",
     "bg": "t_grass",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_palisade_center",
-        "bg": "t_grass"
-      },
+      { "id": "center", "fg": "t_palisade_center", "bg": "t_grass" },
       {
         "id": "corner",
-        "fg": [
-          "t_palisade_corner_nw",
-          "t_palisade_corner_sw",
-          "t_palisade_corner_se",
-          "t_palisade_corner_ne"
-        ],
+        "fg": [ "t_palisade_corner_nw", "t_palisade_corner_ne", "t_palisade_corner_se", "t_palisade_corner_sw" ],
         "bg": "t_grass"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_palisade_t_connection_n",
-          "t_palisade_t_connection_w",
-          "t_palisade_t_connection_s",
-          "t_palisade_t_connection_e"
-        ],
+        "fg": [ "t_palisade_t_connection_n", "t_palisade_t_connection_e", "t_palisade_t_connection_s", "t_palisade_t_connection_w" ],
         "bg": "t_grass"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_palisade_edge_ns",
-          "t_palisade_unconnected"
-        ],
-        "bg": "t_grass"
-      },
+      { "id": "edge", "fg": [ "t_palisade_edge_ns", "t_palisade_unconnected" ], "bg": "t_grass" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_palisade_end_piece_n",
-          "t_palisade_unconnected",
-          "t_palisade_end_piece_s",
-          "t_palisade_unconnected"
-        ],
+        "fg": [ "t_palisade_end_piece_n", "t_palisade_unconnected", "t_palisade_end_piece_s", "t_palisade_unconnected" ],
         "bg": "t_grass"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_palisade_unconnected",
-        "bg": "t_grass"
-      }
+      { "id": "unconnected", "fg": "t_palisade_unconnected", "bg": "t_grass" }
     ]
   },
   {
@@ -61,54 +31,24 @@
     "bg": "t_grass_summer",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_palisade_center",
-        "bg": "t_grass_summer"
-      },
+      { "id": "center", "fg": "t_palisade_center", "bg": "t_grass_summer" },
       {
         "id": "corner",
-        "fg": [
-          "t_palisade_corner_nw",
-          "t_palisade_corner_sw",
-          "t_palisade_corner_se",
-          "t_palisade_corner_ne"
-        ],
+        "fg": [ "t_palisade_corner_nw", "t_palisade_corner_ne", "t_palisade_corner_se", "t_palisade_corner_sw" ],
         "bg": "t_grass_summer"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_palisade_t_connection_n",
-          "t_palisade_t_connection_w",
-          "t_palisade_t_connection_s",
-          "t_palisade_t_connection_e"
-        ],
+        "fg": [ "t_palisade_t_connection_n", "t_palisade_t_connection_e", "t_palisade_t_connection_s", "t_palisade_t_connection_w" ],
         "bg": "t_grass_summer"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_palisade_edge_ns",
-          "t_palisade_unconnected"
-        ],
-        "bg": "t_grass_summer"
-      },
+      { "id": "edge", "fg": [ "t_palisade_edge_ns", "t_palisade_unconnected" ], "bg": "t_grass_summer" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_palisade_end_piece_n",
-          "t_palisade_unconnected",
-          "t_palisade_end_piece_s",
-          "t_palisade_unconnected"
-        ],
+        "fg": [ "t_palisade_end_piece_n", "t_palisade_unconnected", "t_palisade_end_piece_s", "t_palisade_unconnected" ],
         "bg": "t_grass_summer"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_palisade_unconnected",
-        "bg": "t_grass_summer"
-      }
+      { "id": "unconnected", "fg": "t_palisade_unconnected", "bg": "t_grass_summer" }
     ]
   },
   {
@@ -117,54 +57,24 @@
     "bg": "t_grass_autumn",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_palisade_center",
-        "bg": "t_grass_autumn"
-      },
+      { "id": "center", "fg": "t_palisade_center", "bg": "t_grass_autumn" },
       {
         "id": "corner",
-        "fg": [
-          "t_palisade_corner_nw",
-          "t_palisade_corner_sw",
-          "t_palisade_corner_se",
-          "t_palisade_corner_ne"
-        ],
+        "fg": [ "t_palisade_corner_nw", "t_palisade_corner_ne", "t_palisade_corner_se", "t_palisade_corner_sw" ],
         "bg": "t_grass_autumn"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_palisade_t_connection_n",
-          "t_palisade_t_connection_w",
-          "t_palisade_t_connection_s",
-          "t_palisade_t_connection_e"
-        ],
+        "fg": [ "t_palisade_t_connection_n", "t_palisade_t_connection_e", "t_palisade_t_connection_s", "t_palisade_t_connection_w" ],
         "bg": "t_grass_autumn"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_palisade_edge_ns",
-          "t_palisade_unconnected"
-        ],
-        "bg": "t_grass_autumn"
-      },
+      { "id": "edge", "fg": [ "t_palisade_edge_ns", "t_palisade_unconnected" ], "bg": "t_grass_autumn" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_palisade_end_piece_n",
-          "t_palisade_unconnected",
-          "t_palisade_end_piece_s",
-          "t_palisade_unconnected"
-        ],
+        "fg": [ "t_palisade_end_piece_n", "t_palisade_unconnected", "t_palisade_end_piece_s", "t_palisade_unconnected" ],
         "bg": "t_grass_autumn"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_palisade_unconnected",
-        "bg": "t_grass_autumn"
-      }
+      { "id": "unconnected", "fg": "t_palisade_unconnected", "bg": "t_grass_autumn" }
     ]
   },
   {
@@ -173,54 +83,24 @@
     "bg": "snow_shallow_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_palisade_center",
-        "bg": "snow_shallow_center"
-      },
+      { "id": "center", "fg": "t_palisade_center", "bg": "snow_shallow_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_palisade_corner_nw",
-          "t_palisade_corner_sw",
-          "t_palisade_corner_se",
-          "t_palisade_corner_ne"
-        ],
+        "fg": [ "t_palisade_corner_nw", "t_palisade_corner_ne", "t_palisade_corner_se", "t_palisade_corner_sw" ],
         "bg": "snow_shallow_center"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_palisade_t_connection_n",
-          "t_palisade_t_connection_w",
-          "t_palisade_t_connection_s",
-          "t_palisade_t_connection_e"
-        ],
+        "fg": [ "t_palisade_t_connection_n", "t_palisade_t_connection_e", "t_palisade_t_connection_s", "t_palisade_t_connection_w" ],
         "bg": "snow_shallow_center"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_palisade_edge_ns",
-          "t_palisade_unconnected"
-        ],
-        "bg": "snow_shallow_center"
-      },
+      { "id": "edge", "fg": [ "t_palisade_edge_ns", "t_palisade_unconnected" ], "bg": "snow_shallow_center" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_palisade_end_piece_n",
-          "t_palisade_unconnected",
-          "t_palisade_end_piece_s",
-          "t_palisade_unconnected"
-        ],
+        "fg": [ "t_palisade_end_piece_n", "t_palisade_unconnected", "t_palisade_end_piece_s", "t_palisade_unconnected" ],
         "bg": "snow_shallow_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_palisade_unconnected",
-        "bg": "snow_shallow_center"
-      }
+      { "id": "unconnected", "fg": "t_palisade_unconnected", "bg": "snow_shallow_center" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_palisade_embrasure/t_palisade_embrasure.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_palisade_embrasure/t_palisade_embrasure.json
@@ -5,18 +5,14 @@
     "bg": "t_grass",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_palisade_embrasure_center",
-        "bg": "t_grass"
-      },
+      { "id": "center", "fg": "t_palisade_embrasure_center", "bg": "t_grass" },
       {
         "id": "corner",
         "fg": [
           "t_palisade_embrasure_corner_nw",
-          "t_palisade_embrasure_corner_sw",
+          "t_palisade_embrasure_corner_ne",
           "t_palisade_embrasure_corner_se",
-          "t_palisade_embrasure_corner_ne"
+          "t_palisade_embrasure_corner_sw"
         ],
         "bg": "t_grass"
       },
@@ -24,20 +20,13 @@
         "id": "t_connection",
         "fg": [
           "t_palisade_embrasure_t_connection_n",
-          "t_palisade_embrasure_t_connection_w",
+          "t_palisade_embrasure_t_connection_e",
           "t_palisade_embrasure_t_connection_s",
-          "t_palisade_embrasure_t_connection_e"
+          "t_palisade_embrasure_t_connection_w"
         ],
         "bg": "t_grass"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_palisade_embrasure_edge_ns",
-          "t_palisade_embrasure_unconnected"
-        ],
-        "bg": "t_grass"
-      },
+      { "id": "edge", "fg": [ "t_palisade_embrasure_edge_ns", "t_palisade_embrasure_unconnected" ], "bg": "t_grass" },
       {
         "id": "end_piece",
         "fg": [
@@ -48,11 +37,7 @@
         ],
         "bg": "t_grass"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_palisade_embrasure_unconnected",
-        "bg": "t_grass"
-      }
+      { "id": "unconnected", "fg": "t_palisade_embrasure_unconnected", "bg": "t_grass" }
     ]
   },
   {
@@ -61,18 +46,14 @@
     "bg": "t_grass_summer",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_palisade_embrasure_center",
-        "bg": "t_grass_summer"
-      },
+      { "id": "center", "fg": "t_palisade_embrasure_center", "bg": "t_grass_summer" },
       {
         "id": "corner",
         "fg": [
           "t_palisade_embrasure_corner_nw",
-          "t_palisade_embrasure_corner_sw",
+          "t_palisade_embrasure_corner_ne",
           "t_palisade_embrasure_corner_se",
-          "t_palisade_embrasure_corner_ne"
+          "t_palisade_embrasure_corner_sw"
         ],
         "bg": "t_grass_summer"
       },
@@ -80,18 +61,15 @@
         "id": "t_connection",
         "fg": [
           "t_palisade_embrasure_t_connection_n",
-          "t_palisade_embrasure_t_connection_w",
+          "t_palisade_embrasure_t_connection_e",
           "t_palisade_embrasure_t_connection_s",
-          "t_palisade_embrasure_t_connection_e"
+          "t_palisade_embrasure_t_connection_w"
         ],
         "bg": "t_grass_summer"
       },
       {
         "id": "edge",
-        "fg": [
-          "t_palisade_embrasure_edge_ns",
-          "t_palisade_embrasure_unconnected"
-        ],
+        "fg": [ "t_palisade_embrasure_edge_ns", "t_palisade_embrasure_unconnected" ],
         "bg": "t_grass_summer"
       },
       {
@@ -104,31 +82,23 @@
         ],
         "bg": "t_grass_summer"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_palisade_embrasure_unconnected",
-        "bg": "t_grass_summer"
-      }
+      { "id": "unconnected", "fg": "t_palisade_embrasure_unconnected", "bg": "t_grass_summer" }
     ]
   },
-    {
+  {
     "id": "t_palisade_embrasure_season_autumn",
     "fg": "t_palisade_embrasure_unconnected",
     "bg": "t_grass_autumn",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_palisade_embrasure_center",
-        "bg": "t_grass_autumn"
-      },
+      { "id": "center", "fg": "t_palisade_embrasure_center", "bg": "t_grass_autumn" },
       {
         "id": "corner",
         "fg": [
           "t_palisade_embrasure_corner_nw",
-          "t_palisade_embrasure_corner_sw",
+          "t_palisade_embrasure_corner_ne",
           "t_palisade_embrasure_corner_se",
-          "t_palisade_embrasure_corner_ne"
+          "t_palisade_embrasure_corner_sw"
         ],
         "bg": "t_grass_autumn"
       },
@@ -136,18 +106,15 @@
         "id": "t_connection",
         "fg": [
           "t_palisade_embrasure_t_connection_n",
-          "t_palisade_embrasure_t_connection_w",
+          "t_palisade_embrasure_t_connection_e",
           "t_palisade_embrasure_t_connection_s",
-          "t_palisade_embrasure_t_connection_e"
+          "t_palisade_embrasure_t_connection_w"
         ],
         "bg": "t_grass_autumn"
       },
       {
         "id": "edge",
-        "fg": [
-          "t_palisade_embrasure_edge_ns",
-          "t_palisade_embrasure_unconnected"
-        ],
+        "fg": [ "t_palisade_embrasure_edge_ns", "t_palisade_embrasure_unconnected" ],
         "bg": "t_grass_autumn"
       },
       {
@@ -160,31 +127,23 @@
         ],
         "bg": "t_grass_autumn"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_palisade_embrasure_unconnected",
-        "bg": "t_grass_autumn"
-      }
+      { "id": "unconnected", "fg": "t_palisade_embrasure_unconnected", "bg": "t_grass_autumn" }
     ]
   },
-    {
+  {
     "id": "t_palisade_embrasure_season_winter",
     "fg": "t_palisade_embrasure_unconnected",
     "bg": "snow_shallow_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_palisade_embrasure_center",
-        "bg": "snow_shallow_center"
-      },
+      { "id": "center", "fg": "t_palisade_embrasure_center", "bg": "snow_shallow_center" },
       {
         "id": "corner",
         "fg": [
           "t_palisade_embrasure_corner_nw",
-          "t_palisade_embrasure_corner_sw",
+          "t_palisade_embrasure_corner_ne",
           "t_palisade_embrasure_corner_se",
-          "t_palisade_embrasure_corner_ne"
+          "t_palisade_embrasure_corner_sw"
         ],
         "bg": "snow_shallow_center"
       },
@@ -192,18 +151,15 @@
         "id": "t_connection",
         "fg": [
           "t_palisade_embrasure_t_connection_n",
-          "t_palisade_embrasure_t_connection_w",
+          "t_palisade_embrasure_t_connection_e",
           "t_palisade_embrasure_t_connection_s",
-          "t_palisade_embrasure_t_connection_e"
+          "t_palisade_embrasure_t_connection_w"
         ],
         "bg": "snow_shallow_center"
       },
       {
         "id": "edge",
-        "fg": [
-          "t_palisade_embrasure_edge_ns",
-          "t_palisade_embrasure_unconnected"
-        ],
+        "fg": [ "t_palisade_embrasure_edge_ns", "t_palisade_embrasure_unconnected" ],
         "bg": "snow_shallow_center"
       },
       {
@@ -216,11 +172,7 @@
         ],
         "bg": "snow_shallow_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_palisade_embrasure_unconnected",
-        "bg": "snow_shallow_center"
-      }
+      { "id": "unconnected", "fg": "t_palisade_embrasure_unconnected", "bg": "snow_shallow_center" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pavement/t_pavement.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pavement/t_pavement.json
@@ -18,14 +18,14 @@
       {
         "id": "corner",
         "bg": "t_grass",
-        "fg": [ "t_pavement_nw", "t_pavement_sw", "t_pavement_se", "t_pavement_ne" ]
+        "fg": [ "t_pavement_nw", "t_pavement_ne", "t_pavement_se", "t_pavement_sw" ]
       },
-      { "id": "t_connection", "bg": "", "fg": [ "t_pavement_n", "t_pavement_w", "t_pavement_s", "t_pavement_e" ] },
+      { "id": "t_connection", "bg": "", "fg": [ "t_pavement_n", "t_pavement_e", "t_pavement_s", "t_pavement_w" ] },
       { "id": "edge", "bg": "", "fg": [ "t_pavement_vertical", "t_pavement_horizontal" ] },
       {
         "id": "end_piece",
         "bg": "",
-        "fg": [ "t_pavement_end_piece_n", "t_pavement_end_piece_w", "t_pavement_end_piece_s", "t_pavement_end_piece_e" ]
+        "fg": [ "t_pavement_end_piece_n", "t_pavement_end_piece_e", "t_pavement_end_piece_s", "t_pavement_end_piece_w" ]
       },
       { "bg": "", "id": "unconnected", "fg": "t_pavement_unconnected" }
     ]
@@ -49,14 +49,14 @@
       {
         "id": "corner",
         "bg": "t_grass_summer",
-        "fg": [ "t_pavement_nw", "t_pavement_sw", "t_pavement_se", "t_pavement_ne" ]
+        "fg": [ "t_pavement_nw", "t_pavement_ne", "t_pavement_se", "t_pavement_sw" ]
       },
-      { "id": "t_connection", "bg": "", "fg": [ "t_pavement_n", "t_pavement_w", "t_pavement_s", "t_pavement_e" ] },
+      { "id": "t_connection", "bg": "", "fg": [ "t_pavement_n", "t_pavement_e", "t_pavement_s", "t_pavement_w" ] },
       { "id": "edge", "bg": "", "fg": [ "t_pavement_vertical", "t_pavement_horizontal" ] },
       {
         "id": "end_piece",
         "bg": "",
-        "fg": [ "t_pavement_end_piece_n", "t_pavement_end_piece_w", "t_pavement_end_piece_s", "t_pavement_end_piece_e" ]
+        "fg": [ "t_pavement_end_piece_n", "t_pavement_end_piece_e", "t_pavement_end_piece_s", "t_pavement_end_piece_w" ]
       },
       { "bg": "", "id": "unconnected", "fg": "t_pavement_unconnected" }
     ]
@@ -80,14 +80,14 @@
       {
         "id": "corner",
         "bg": "t_grass_autumn",
-        "fg": [ "t_pavement_nw", "t_pavement_sw", "t_pavement_se", "t_pavement_ne" ]
+        "fg": [ "t_pavement_nw", "t_pavement_ne", "t_pavement_se", "t_pavement_sw" ]
       },
-      { "id": "t_connection", "bg": "", "fg": [ "t_pavement_n", "t_pavement_w", "t_pavement_s", "t_pavement_e" ] },
+      { "id": "t_connection", "bg": "", "fg": [ "t_pavement_n", "t_pavement_e", "t_pavement_s", "t_pavement_w" ] },
       { "id": "edge", "bg": "", "fg": [ "t_pavement_vertical", "t_pavement_horizontal" ] },
       {
         "id": "end_piece",
         "bg": "",
-        "fg": [ "t_pavement_end_piece_n", "t_pavement_end_piece_w", "t_pavement_end_piece_s", "t_pavement_end_piece_e" ]
+        "fg": [ "t_pavement_end_piece_n", "t_pavement_end_piece_e", "t_pavement_end_piece_s", "t_pavement_end_piece_w" ]
       },
       { "bg": "", "id": "unconnected", "fg": "t_pavement_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit/t_pit.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit/t_pit.json
@@ -1,299 +1,154 @@
 [
-{
-  "id": "t_pit",
-  "fg": "t_pit_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass" },
-    { "weight": 100, "sprite": "t_grass_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_corner_nw",
-        "t_pit_corner_sw",
-        "t_pit_corner_se",
-        "t_pit_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_t_connection_n",
-        "t_pit_t_connection_w",
-        "t_pit_t_connection_s",
-        "t_pit_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_edge_ns",
-        "t_pit_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_end_piece_n",
-        "t_pit_end_piece_w",
-        "t_pit_end_piece_s",
-        "t_pit_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_unconnected",
-        "t_pit_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_season_summer",
-  "fg": "t_pit_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_summer" },
-    { "weight": 100, "sprite": "t_grass_summer_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_corner_nw",
-        "t_pit_corner_sw",
-        "t_pit_corner_se",
-        "t_pit_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_t_connection_n",
-        "t_pit_t_connection_w",
-        "t_pit_t_connection_s",
-        "t_pit_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_edge_ns",
-        "t_pit_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_end_piece_n",
-        "t_pit_end_piece_w",
-        "t_pit_end_piece_s",
-        "t_pit_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_unconnected",
-        "t_pit_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_season_autumn",
-  "fg": "t_pit_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_autumn" },
-    { "weight": 100, "sprite": "t_grass_autumn_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_corner_nw",
-        "t_pit_corner_sw",
-        "t_pit_corner_se",
-        "t_pit_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_t_connection_n",
-        "t_pit_t_connection_w",
-        "t_pit_t_connection_s",
-        "t_pit_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_edge_ns",
-        "t_pit_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_end_piece_n",
-        "t_pit_end_piece_w",
-        "t_pit_end_piece_s",
-        "t_pit_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_unconnected",
-        "t_pit_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_season_winter",
-  "fg": "t_pit_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "snow_shallow_center" },
-    { "weight": 100, "sprite": "snow_shallow_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_center",
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_corner_nw",
-        "t_pit_corner_sw",
-        "t_pit_corner_se",
-        "t_pit_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_t_connection_n",
-        "t_pit_t_connection_w",
-        "t_pit_t_connection_s",
-        "t_pit_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_edge_ns",
-        "t_pit_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_end_piece_n",
-        "t_pit_end_piece_w",
-        "t_pit_end_piece_s",
-        "t_pit_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_unconnected",
-        "t_pit_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }
-  ]
-}
+  {
+    "id": "t_pit",
+    "fg": "t_pit_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_corner_nw", "t_pit_corner_ne", "t_pit_corner_se", "t_pit_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [ "t_pit_t_connection_n", "t_pit_t_connection_e", "t_pit_t_connection_s", "t_pit_t_connection_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_edge_ns", "t_pit_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_end_piece_n", "t_pit_end_piece_e", "t_pit_end_piece_s", "t_pit_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_unconnected", "t_pit_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_season_summer",
+    "fg": "t_pit_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_corner_nw", "t_pit_corner_ne", "t_pit_corner_se", "t_pit_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [ "t_pit_t_connection_n", "t_pit_t_connection_e", "t_pit_t_connection_s", "t_pit_t_connection_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_edge_ns", "t_pit_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_end_piece_n", "t_pit_end_piece_e", "t_pit_end_piece_s", "t_pit_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_unconnected", "t_pit_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_season_autumn",
+    "fg": "t_pit_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_corner_nw", "t_pit_corner_ne", "t_pit_corner_se", "t_pit_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [ "t_pit_t_connection_n", "t_pit_t_connection_e", "t_pit_t_connection_s", "t_pit_t_connection_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_edge_ns", "t_pit_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_end_piece_n", "t_pit_end_piece_e", "t_pit_end_piece_s", "t_pit_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_unconnected", "t_pit_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_season_winter",
+    "fg": "t_pit_unconnected",
+    "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_center",
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_corner_nw", "t_pit_corner_ne", "t_pit_corner_se", "t_pit_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [ "t_pit_t_connection_n", "t_pit_t_connection_e", "t_pit_t_connection_s", "t_pit_t_connection_w" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_edge_ns", "t_pit_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_end_piece_n", "t_pit_end_piece_e", "t_pit_end_piece_s", "t_pit_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_unconnected", "t_pit_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_corpsed/t_pit_corpsed.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_corpsed/t_pit_corpsed.json
@@ -1,299 +1,174 @@
 [
-{
-  "id": "t_pit_corpsed",
-  "fg": "t_pit_corpsed_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass" },
-    { "weight": 100, "sprite": "t_grass_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_corpsed_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_corpsed_corner_nw",
-        "t_pit_corpsed_corner_sw",
-        "t_pit_corpsed_corner_se",
-        "t_pit_corpsed_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_corpsed_t_connection_n",
-        "t_pit_corpsed_t_connection_w",
-        "t_pit_corpsed_t_connection_s",
-        "t_pit_corpsed_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_corpsed_edge_ns",
-        "t_pit_corpsed_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_corpsed_end_piece_n",
-        "t_pit_corpsed_end_piece_w",
-        "t_pit_corpsed_end_piece_s",
-        "t_pit_corpsed_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_corpsed_unconnected",
-        "t_pit_corpsed_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_corpsed_season_summer",
-  "fg": "t_pit_corpsed_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_summer" },
-    { "weight": 100, "sprite": "t_grass_summer_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_corpsed_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_corpsed_corner_nw",
-        "t_pit_corpsed_corner_sw",
-        "t_pit_corpsed_corner_se",
-        "t_pit_corpsed_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_corpsed_t_connection_n",
-        "t_pit_corpsed_t_connection_w",
-        "t_pit_corpsed_t_connection_s",
-        "t_pit_corpsed_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_corpsed_edge_ns",
-        "t_pit_corpsed_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_corpsed_end_piece_n",
-        "t_pit_corpsed_end_piece_w",
-        "t_pit_corpsed_end_piece_s",
-        "t_pit_corpsed_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_corpsed_unconnected",
-        "t_pit_corpsed_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_corpsed_season_autumn",
-  "fg": "t_pit_corpsed_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_autumn" },
-    { "weight": 100, "sprite": "t_grass_autumn_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_corpsed_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_corpsed_corner_nw",
-        "t_pit_corpsed_corner_sw",
-        "t_pit_corpsed_corner_se",
-        "t_pit_corpsed_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_corpsed_t_connection_n",
-        "t_pit_corpsed_t_connection_w",
-        "t_pit_corpsed_t_connection_s",
-        "t_pit_corpsed_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_corpsed_edge_ns",
-        "t_pit_corpsed_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_corpsed_end_piece_n",
-        "t_pit_corpsed_end_piece_w",
-        "t_pit_corpsed_end_piece_s",
-        "t_pit_corpsed_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_corpsed_unconnected",
-        "t_pit_corpsed_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_corpsed_season_winter",
-  "fg": "t_pit_corpsed_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "snow_shallow_center" },
-    { "weight": 100, "sprite": "snow_shallow_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_corpsed_center",
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_corpsed_corner_nw",
-        "t_pit_corpsed_corner_sw",
-        "t_pit_corpsed_corner_se",
-        "t_pit_corpsed_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_corpsed_t_connection_n",
-        "t_pit_corpsed_t_connection_w",
-        "t_pit_corpsed_t_connection_s",
-        "t_pit_corpsed_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_corpsed_edge_ns",
-        "t_pit_corpsed_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_corpsed_end_piece_n",
-        "t_pit_corpsed_end_piece_w",
-        "t_pit_corpsed_end_piece_s",
-        "t_pit_corpsed_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_corpsed_unconnected",
-        "t_pit_corpsed_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }
-  ]
-}
+  {
+    "id": "t_pit_corpsed",
+    "fg": "t_pit_corpsed_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_corpsed_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_corpsed_corner_nw", "t_pit_corpsed_corner_ne", "t_pit_corpsed_corner_se", "t_pit_corpsed_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_corpsed_t_connection_n",
+          "t_pit_corpsed_t_connection_e",
+          "t_pit_corpsed_t_connection_s",
+          "t_pit_corpsed_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_corpsed_edge_ns", "t_pit_corpsed_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_corpsed_end_piece_n", "t_pit_corpsed_end_piece_e", "t_pit_corpsed_end_piece_s", "t_pit_corpsed_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_corpsed_unconnected", "t_pit_corpsed_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_corpsed_season_summer",
+    "fg": "t_pit_corpsed_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_corpsed_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_corpsed_corner_nw", "t_pit_corpsed_corner_ne", "t_pit_corpsed_corner_se", "t_pit_corpsed_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_corpsed_t_connection_n",
+          "t_pit_corpsed_t_connection_e",
+          "t_pit_corpsed_t_connection_s",
+          "t_pit_corpsed_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_corpsed_edge_ns", "t_pit_corpsed_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_corpsed_end_piece_n", "t_pit_corpsed_end_piece_e", "t_pit_corpsed_end_piece_s", "t_pit_corpsed_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_corpsed_unconnected", "t_pit_corpsed_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_corpsed_season_autumn",
+    "fg": "t_pit_corpsed_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_corpsed_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_corpsed_corner_nw", "t_pit_corpsed_corner_ne", "t_pit_corpsed_corner_se", "t_pit_corpsed_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_corpsed_t_connection_n",
+          "t_pit_corpsed_t_connection_e",
+          "t_pit_corpsed_t_connection_s",
+          "t_pit_corpsed_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_corpsed_edge_ns", "t_pit_corpsed_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_corpsed_end_piece_n", "t_pit_corpsed_end_piece_e", "t_pit_corpsed_end_piece_s", "t_pit_corpsed_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_corpsed_unconnected", "t_pit_corpsed_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_corpsed_season_winter",
+    "fg": "t_pit_corpsed_unconnected",
+    "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_corpsed_center",
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_corpsed_corner_nw", "t_pit_corpsed_corner_ne", "t_pit_corpsed_corner_se", "t_pit_corpsed_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_corpsed_t_connection_n",
+          "t_pit_corpsed_t_connection_e",
+          "t_pit_corpsed_t_connection_s",
+          "t_pit_corpsed_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_corpsed_edge_ns", "t_pit_corpsed_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_corpsed_end_piece_n", "t_pit_corpsed_end_piece_e", "t_pit_corpsed_end_piece_s", "t_pit_corpsed_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_corpsed_unconnected", "t_pit_corpsed_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_covered/t_pit_covered.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_covered/t_pit_covered.json
@@ -1,299 +1,174 @@
 [
-{
-  "id": "t_pit_covered",
-  "fg": "t_pit_covered_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass" },
-    { "weight": 100, "sprite": "t_grass_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_covered_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_covered_corner_nw",
-        "t_pit_covered_corner_sw",
-        "t_pit_covered_corner_se",
-        "t_pit_covered_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_covered_t_connection_n",
-        "t_pit_covered_t_connection_w",
-        "t_pit_covered_t_connection_s",
-        "t_pit_covered_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_covered_edge_ns",
-        "t_pit_covered_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_covered_end_piece_n",
-        "t_pit_covered_end_piece_w",
-        "t_pit_covered_end_piece_s",
-        "t_pit_covered_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_covered_unconnected",
-        "t_pit_covered_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_covered_season_summer",
-  "fg": "t_pit_covered_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_summer" },
-    { "weight": 100, "sprite": "t_grass_summer_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_covered_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_covered_corner_nw",
-        "t_pit_covered_corner_sw",
-        "t_pit_covered_corner_se",
-        "t_pit_covered_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_covered_t_connection_n",
-        "t_pit_covered_t_connection_w",
-        "t_pit_covered_t_connection_s",
-        "t_pit_covered_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_covered_edge_ns",
-        "t_pit_covered_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_covered_end_piece_n",
-        "t_pit_covered_end_piece_w",
-        "t_pit_covered_end_piece_s",
-        "t_pit_covered_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_covered_unconnected",
-        "t_pit_covered_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_covered_season_autumn",
-  "fg": "t_pit_covered_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_autumn" },
-    { "weight": 100, "sprite": "t_grass_autumn_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_covered_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_covered_corner_nw",
-        "t_pit_covered_corner_sw",
-        "t_pit_covered_corner_se",
-        "t_pit_covered_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_covered_t_connection_n",
-        "t_pit_covered_t_connection_w",
-        "t_pit_covered_t_connection_s",
-        "t_pit_covered_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_covered_edge_ns",
-        "t_pit_covered_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_covered_end_piece_n",
-        "t_pit_covered_end_piece_w",
-        "t_pit_covered_end_piece_s",
-        "t_pit_covered_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_covered_unconnected",
-        "t_pit_covered_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_covered_season_winter",
-  "fg": "t_pit_covered_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "snow_shallow_center" },
-    { "weight": 100, "sprite": "snow_shallow_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_covered_center",
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_covered_corner_nw",
-        "t_pit_covered_corner_sw",
-        "t_pit_covered_corner_se",
-        "t_pit_covered_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_covered_t_connection_n",
-        "t_pit_covered_t_connection_w",
-        "t_pit_covered_t_connection_s",
-        "t_pit_covered_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_covered_edge_ns",
-        "t_pit_covered_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_covered_end_piece_n",
-        "t_pit_covered_end_piece_w",
-        "t_pit_covered_end_piece_s",
-        "t_pit_covered_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_covered_unconnected",
-        "t_pit_covered_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }
-  ]
-}
+  {
+    "id": "t_pit_covered",
+    "fg": "t_pit_covered_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_covered_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_covered_corner_nw", "t_pit_covered_corner_ne", "t_pit_covered_corner_se", "t_pit_covered_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_covered_t_connection_n",
+          "t_pit_covered_t_connection_e",
+          "t_pit_covered_t_connection_s",
+          "t_pit_covered_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_covered_edge_ns", "t_pit_covered_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_covered_end_piece_n", "t_pit_covered_end_piece_e", "t_pit_covered_end_piece_s", "t_pit_covered_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_covered_unconnected", "t_pit_covered_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_covered_season_summer",
+    "fg": "t_pit_covered_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_covered_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_covered_corner_nw", "t_pit_covered_corner_ne", "t_pit_covered_corner_se", "t_pit_covered_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_covered_t_connection_n",
+          "t_pit_covered_t_connection_e",
+          "t_pit_covered_t_connection_s",
+          "t_pit_covered_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_covered_edge_ns", "t_pit_covered_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_covered_end_piece_n", "t_pit_covered_end_piece_e", "t_pit_covered_end_piece_s", "t_pit_covered_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_covered_unconnected", "t_pit_covered_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_covered_season_autumn",
+    "fg": "t_pit_covered_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_covered_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_covered_corner_nw", "t_pit_covered_corner_ne", "t_pit_covered_corner_se", "t_pit_covered_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_covered_t_connection_n",
+          "t_pit_covered_t_connection_e",
+          "t_pit_covered_t_connection_s",
+          "t_pit_covered_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_covered_edge_ns", "t_pit_covered_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_covered_end_piece_n", "t_pit_covered_end_piece_e", "t_pit_covered_end_piece_s", "t_pit_covered_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_covered_unconnected", "t_pit_covered_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_covered_season_winter",
+    "fg": "t_pit_covered_unconnected",
+    "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_covered_center",
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_covered_corner_nw", "t_pit_covered_corner_ne", "t_pit_covered_corner_se", "t_pit_covered_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_covered_t_connection_n",
+          "t_pit_covered_t_connection_e",
+          "t_pit_covered_t_connection_s",
+          "t_pit_covered_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_covered_edge_ns", "t_pit_covered_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_covered_end_piece_n", "t_pit_covered_end_piece_e", "t_pit_covered_end_piece_s", "t_pit_covered_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_covered_unconnected", "t_pit_covered_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_glass/t_pit_glass.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_glass/t_pit_glass.json
@@ -1,299 +1,174 @@
 [
-{
-  "id": "t_pit_glass",
-  "fg": "t_pit_glass_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass" },
-    { "weight": 100, "sprite": "t_grass_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_glass_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_glass_corner_nw",
-        "t_pit_glass_corner_sw",
-        "t_pit_glass_corner_se",
-        "t_pit_glass_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_glass_t_connection_n",
-        "t_pit_glass_t_connection_w",
-        "t_pit_glass_t_connection_s",
-        "t_pit_glass_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_glass_edge_ns",
-        "t_pit_glass_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_glass_end_piece_n",
-        "t_pit_glass_end_piece_w",
-        "t_pit_glass_end_piece_s",
-        "t_pit_glass_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_glass_unconnected",
-        "t_pit_glass_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_glass_season_summer",
-  "fg": "t_pit_glass_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_summer" },
-    { "weight": 100, "sprite": "t_grass_summer_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_glass_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_glass_corner_nw",
-        "t_pit_glass_corner_sw",
-        "t_pit_glass_corner_se",
-        "t_pit_glass_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_glass_t_connection_n",
-        "t_pit_glass_t_connection_w",
-        "t_pit_glass_t_connection_s",
-        "t_pit_glass_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_glass_edge_ns",
-        "t_pit_glass_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_glass_end_piece_n",
-        "t_pit_glass_end_piece_w",
-        "t_pit_glass_end_piece_s",
-        "t_pit_glass_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_glass_unconnected",
-        "t_pit_glass_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_glass_season_autumn",
-  "fg": "t_pit_glass_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_autumn" },
-    { "weight": 100, "sprite": "t_grass_autumn_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_glass_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_glass_corner_nw",
-        "t_pit_glass_corner_sw",
-        "t_pit_glass_corner_se",
-        "t_pit_glass_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_glass_t_connection_n",
-        "t_pit_glass_t_connection_w",
-        "t_pit_glass_t_connection_s",
-        "t_pit_glass_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_glass_edge_ns",
-        "t_pit_glass_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_glass_end_piece_n",
-        "t_pit_glass_end_piece_w",
-        "t_pit_glass_end_piece_s",
-        "t_pit_glass_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_glass_unconnected",
-        "t_pit_glass_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_glass_season_winter",
-  "fg": "t_pit_glass_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "snow_shallow_center" },
-    { "weight": 100, "sprite": "snow_shallow_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_glass_center",
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_glass_corner_nw",
-        "t_pit_glass_corner_sw",
-        "t_pit_glass_corner_se",
-        "t_pit_glass_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_glass_t_connection_n",
-        "t_pit_glass_t_connection_w",
-        "t_pit_glass_t_connection_s",
-        "t_pit_glass_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_glass_edge_ns",
-        "t_pit_glass_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_glass_end_piece_n",
-        "t_pit_glass_end_piece_w",
-        "t_pit_glass_end_piece_s",
-        "t_pit_glass_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_glass_unconnected",
-        "t_pit_glass_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }
-  ]
-}
+  {
+    "id": "t_pit_glass",
+    "fg": "t_pit_glass_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_glass_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_glass_corner_nw", "t_pit_glass_corner_ne", "t_pit_glass_corner_se", "t_pit_glass_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_glass_t_connection_n",
+          "t_pit_glass_t_connection_e",
+          "t_pit_glass_t_connection_s",
+          "t_pit_glass_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_glass_edge_ns", "t_pit_glass_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_glass_end_piece_n", "t_pit_glass_end_piece_e", "t_pit_glass_end_piece_s", "t_pit_glass_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_glass_unconnected", "t_pit_glass_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_glass_season_summer",
+    "fg": "t_pit_glass_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_glass_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_glass_corner_nw", "t_pit_glass_corner_ne", "t_pit_glass_corner_se", "t_pit_glass_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_glass_t_connection_n",
+          "t_pit_glass_t_connection_e",
+          "t_pit_glass_t_connection_s",
+          "t_pit_glass_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_glass_edge_ns", "t_pit_glass_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_glass_end_piece_n", "t_pit_glass_end_piece_e", "t_pit_glass_end_piece_s", "t_pit_glass_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_glass_unconnected", "t_pit_glass_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_glass_season_autumn",
+    "fg": "t_pit_glass_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_glass_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_glass_corner_nw", "t_pit_glass_corner_ne", "t_pit_glass_corner_se", "t_pit_glass_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_glass_t_connection_n",
+          "t_pit_glass_t_connection_e",
+          "t_pit_glass_t_connection_s",
+          "t_pit_glass_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_glass_edge_ns", "t_pit_glass_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_glass_end_piece_n", "t_pit_glass_end_piece_e", "t_pit_glass_end_piece_s", "t_pit_glass_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_glass_unconnected", "t_pit_glass_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_glass_season_winter",
+    "fg": "t_pit_glass_unconnected",
+    "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_glass_center",
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_glass_corner_nw", "t_pit_glass_corner_ne", "t_pit_glass_corner_se", "t_pit_glass_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_glass_t_connection_n",
+          "t_pit_glass_t_connection_e",
+          "t_pit_glass_t_connection_s",
+          "t_pit_glass_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_glass_edge_ns", "t_pit_glass_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_glass_end_piece_n", "t_pit_glass_end_piece_e", "t_pit_glass_end_piece_s", "t_pit_glass_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_glass_unconnected", "t_pit_glass_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_glass_covered/t_pit_glass_covered.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_glass_covered/t_pit_glass_covered.json
@@ -1,299 +1,214 @@
 [
-{
-  "id": "t_pit_glass_covered",
-  "fg": "t_pit_glass_covered_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass" },
-    { "weight": 100, "sprite": "t_grass_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_glass_covered_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_glass_covered_corner_nw",
-        "t_pit_glass_covered_corner_sw",
-        "t_pit_glass_covered_corner_se",
-        "t_pit_glass_covered_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_glass_covered_t_connection_n",
-        "t_pit_glass_covered_t_connection_w",
-        "t_pit_glass_covered_t_connection_s",
-        "t_pit_glass_covered_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_glass_covered_edge_ns",
-        "t_pit_glass_covered_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_glass_covered_end_piece_n",
-        "t_pit_glass_covered_end_piece_w",
-        "t_pit_glass_covered_end_piece_s",
-        "t_pit_glass_covered_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_glass_covered_unconnected",
-        "t_pit_glass_covered_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_glass_covered_season_summer",
-  "fg": "t_pit_glass_covered_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_summer" },
-    { "weight": 100, "sprite": "t_grass_summer_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_glass_covered_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_glass_covered_corner_nw",
-        "t_pit_glass_covered_corner_sw",
-        "t_pit_glass_covered_corner_se",
-        "t_pit_glass_covered_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_glass_covered_t_connection_n",
-        "t_pit_glass_covered_t_connection_w",
-        "t_pit_glass_covered_t_connection_s",
-        "t_pit_glass_covered_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_glass_covered_edge_ns",
-        "t_pit_glass_covered_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_glass_covered_end_piece_n",
-        "t_pit_glass_covered_end_piece_w",
-        "t_pit_glass_covered_end_piece_s",
-        "t_pit_glass_covered_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_glass_covered_unconnected",
-        "t_pit_glass_covered_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_glass_covered_season_autumn",
-  "fg": "t_pit_glass_covered_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_autumn" },
-    { "weight": 100, "sprite": "t_grass_autumn_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_glass_covered_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_glass_covered_corner_nw",
-        "t_pit_glass_covered_corner_sw",
-        "t_pit_glass_covered_corner_se",
-        "t_pit_glass_covered_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_glass_covered_t_connection_n",
-        "t_pit_glass_covered_t_connection_w",
-        "t_pit_glass_covered_t_connection_s",
-        "t_pit_glass_covered_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_glass_covered_edge_ns",
-        "t_pit_glass_covered_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_glass_covered_end_piece_n",
-        "t_pit_glass_covered_end_piece_w",
-        "t_pit_glass_covered_end_piece_s",
-        "t_pit_glass_covered_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_glass_covered_unconnected",
-        "t_pit_glass_covered_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_glass_covered_season_winter",
-  "fg": "t_pit_glass_covered_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "snow_shallow_center" },
-    { "weight": 100, "sprite": "snow_shallow_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_glass_covered_center",
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_glass_covered_corner_nw",
-        "t_pit_glass_covered_corner_sw",
-        "t_pit_glass_covered_corner_se",
-        "t_pit_glass_covered_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_glass_covered_t_connection_n",
-        "t_pit_glass_covered_t_connection_w",
-        "t_pit_glass_covered_t_connection_s",
-        "t_pit_glass_covered_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_glass_covered_edge_ns",
-        "t_pit_glass_covered_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_glass_covered_end_piece_n",
-        "t_pit_glass_covered_end_piece_w",
-        "t_pit_glass_covered_end_piece_s",
-        "t_pit_glass_covered_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_glass_covered_unconnected",
-        "t_pit_glass_covered_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }
-  ]
-}
+  {
+    "id": "t_pit_glass_covered",
+    "fg": "t_pit_glass_covered_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_glass_covered_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [
+          "t_pit_glass_covered_corner_nw",
+          "t_pit_glass_covered_corner_ne",
+          "t_pit_glass_covered_corner_se",
+          "t_pit_glass_covered_corner_sw"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_glass_covered_t_connection_n",
+          "t_pit_glass_covered_t_connection_e",
+          "t_pit_glass_covered_t_connection_s",
+          "t_pit_glass_covered_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_glass_covered_edge_ns", "t_pit_glass_covered_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [
+          "t_pit_glass_covered_end_piece_n",
+          "t_pit_glass_covered_end_piece_e",
+          "t_pit_glass_covered_end_piece_s",
+          "t_pit_glass_covered_end_piece_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_glass_covered_unconnected", "t_pit_glass_covered_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_glass_covered_season_summer",
+    "fg": "t_pit_glass_covered_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_glass_covered_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [
+          "t_pit_glass_covered_corner_nw",
+          "t_pit_glass_covered_corner_ne",
+          "t_pit_glass_covered_corner_se",
+          "t_pit_glass_covered_corner_sw"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_glass_covered_t_connection_n",
+          "t_pit_glass_covered_t_connection_e",
+          "t_pit_glass_covered_t_connection_s",
+          "t_pit_glass_covered_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_glass_covered_edge_ns", "t_pit_glass_covered_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [
+          "t_pit_glass_covered_end_piece_n",
+          "t_pit_glass_covered_end_piece_e",
+          "t_pit_glass_covered_end_piece_s",
+          "t_pit_glass_covered_end_piece_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_glass_covered_unconnected", "t_pit_glass_covered_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_glass_covered_season_autumn",
+    "fg": "t_pit_glass_covered_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_glass_covered_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [
+          "t_pit_glass_covered_corner_nw",
+          "t_pit_glass_covered_corner_ne",
+          "t_pit_glass_covered_corner_se",
+          "t_pit_glass_covered_corner_sw"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_glass_covered_t_connection_n",
+          "t_pit_glass_covered_t_connection_e",
+          "t_pit_glass_covered_t_connection_s",
+          "t_pit_glass_covered_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_glass_covered_edge_ns", "t_pit_glass_covered_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [
+          "t_pit_glass_covered_end_piece_n",
+          "t_pit_glass_covered_end_piece_e",
+          "t_pit_glass_covered_end_piece_s",
+          "t_pit_glass_covered_end_piece_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_glass_covered_unconnected", "t_pit_glass_covered_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_glass_covered_season_winter",
+    "fg": "t_pit_glass_covered_unconnected",
+    "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_glass_covered_center",
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [
+          "t_pit_glass_covered_corner_nw",
+          "t_pit_glass_covered_corner_ne",
+          "t_pit_glass_covered_corner_se",
+          "t_pit_glass_covered_corner_sw"
+        ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_glass_covered_t_connection_n",
+          "t_pit_glass_covered_t_connection_e",
+          "t_pit_glass_covered_t_connection_s",
+          "t_pit_glass_covered_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_glass_covered_edge_ns", "t_pit_glass_covered_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [
+          "t_pit_glass_covered_end_piece_n",
+          "t_pit_glass_covered_end_piece_e",
+          "t_pit_glass_covered_end_piece_s",
+          "t_pit_glass_covered_end_piece_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_glass_covered_unconnected", "t_pit_glass_covered_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_shallow/t_pit_shallow.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_shallow/t_pit_shallow.json
@@ -1,299 +1,174 @@
 [
-{
-  "id": "t_pit_shallow",
-  "fg": "t_pit_shallow_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass" },
-    { "weight": 100, "sprite": "t_grass_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_shallow_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_shallow_corner_nw",
-        "t_pit_shallow_corner_sw",
-        "t_pit_shallow_corner_se",
-        "t_pit_shallow_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_shallow_t_connection_n",
-        "t_pit_shallow_t_connection_w",
-        "t_pit_shallow_t_connection_s",
-        "t_pit_shallow_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_shallow_edge_ns",
-        "t_pit_shallow_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_shallow_end_piece_n",
-        "t_pit_shallow_end_piece_w",
-        "t_pit_shallow_end_piece_s",
-        "t_pit_shallow_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_shallow_unconnected",
-        "t_pit_shallow_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_shallow_season_summer",
-  "fg": "t_pit_shallow_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_summer" },
-    { "weight": 100, "sprite": "t_grass_summer_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_shallow_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_shallow_corner_nw",
-        "t_pit_shallow_corner_sw",
-        "t_pit_shallow_corner_se",
-        "t_pit_shallow_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_shallow_t_connection_n",
-        "t_pit_shallow_t_connection_w",
-        "t_pit_shallow_t_connection_s",
-        "t_pit_shallow_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_shallow_edge_ns",
-        "t_pit_shallow_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_shallow_end_piece_n",
-        "t_pit_shallow_end_piece_w",
-        "t_pit_shallow_end_piece_s",
-        "t_pit_shallow_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_shallow_unconnected",
-        "t_pit_shallow_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_shallow_season_autumn",
-  "fg": "t_pit_shallow_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_autumn" },
-    { "weight": 100, "sprite": "t_grass_autumn_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_shallow_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_shallow_corner_nw",
-        "t_pit_shallow_corner_sw",
-        "t_pit_shallow_corner_se",
-        "t_pit_shallow_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_shallow_t_connection_n",
-        "t_pit_shallow_t_connection_w",
-        "t_pit_shallow_t_connection_s",
-        "t_pit_shallow_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_shallow_edge_ns",
-        "t_pit_shallow_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_shallow_end_piece_n",
-        "t_pit_shallow_end_piece_w",
-        "t_pit_shallow_end_piece_s",
-        "t_pit_shallow_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_shallow_unconnected",
-        "t_pit_shallow_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_shallow_season_winter",
-  "fg": "t_pit_shallow_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "snow_shallow_center" },
-    { "weight": 100, "sprite": "snow_shallow_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_shallow_center",
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_shallow_corner_nw",
-        "t_pit_shallow_corner_sw",
-        "t_pit_shallow_corner_se",
-        "t_pit_shallow_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_shallow_t_connection_n",
-        "t_pit_shallow_t_connection_w",
-        "t_pit_shallow_t_connection_s",
-        "t_pit_shallow_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_shallow_edge_ns",
-        "t_pit_shallow_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_shallow_end_piece_n",
-        "t_pit_shallow_end_piece_w",
-        "t_pit_shallow_end_piece_s",
-        "t_pit_shallow_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_shallow_unconnected",
-        "t_pit_shallow_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }
-  ]
-}
+  {
+    "id": "t_pit_shallow",
+    "fg": "t_pit_shallow_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_shallow_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_shallow_corner_nw", "t_pit_shallow_corner_ne", "t_pit_shallow_corner_se", "t_pit_shallow_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_shallow_t_connection_n",
+          "t_pit_shallow_t_connection_e",
+          "t_pit_shallow_t_connection_s",
+          "t_pit_shallow_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_shallow_edge_ns", "t_pit_shallow_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_shallow_end_piece_n", "t_pit_shallow_end_piece_e", "t_pit_shallow_end_piece_s", "t_pit_shallow_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_shallow_unconnected", "t_pit_shallow_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_shallow_season_summer",
+    "fg": "t_pit_shallow_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_shallow_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_shallow_corner_nw", "t_pit_shallow_corner_ne", "t_pit_shallow_corner_se", "t_pit_shallow_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_shallow_t_connection_n",
+          "t_pit_shallow_t_connection_e",
+          "t_pit_shallow_t_connection_s",
+          "t_pit_shallow_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_shallow_edge_ns", "t_pit_shallow_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_shallow_end_piece_n", "t_pit_shallow_end_piece_e", "t_pit_shallow_end_piece_s", "t_pit_shallow_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_shallow_unconnected", "t_pit_shallow_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_shallow_season_autumn",
+    "fg": "t_pit_shallow_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_shallow_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_shallow_corner_nw", "t_pit_shallow_corner_ne", "t_pit_shallow_corner_se", "t_pit_shallow_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_shallow_t_connection_n",
+          "t_pit_shallow_t_connection_e",
+          "t_pit_shallow_t_connection_s",
+          "t_pit_shallow_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_shallow_edge_ns", "t_pit_shallow_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_shallow_end_piece_n", "t_pit_shallow_end_piece_e", "t_pit_shallow_end_piece_s", "t_pit_shallow_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_shallow_unconnected", "t_pit_shallow_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_shallow_season_winter",
+    "fg": "t_pit_shallow_unconnected",
+    "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_shallow_center",
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_shallow_corner_nw", "t_pit_shallow_corner_ne", "t_pit_shallow_corner_se", "t_pit_shallow_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_shallow_t_connection_n",
+          "t_pit_shallow_t_connection_e",
+          "t_pit_shallow_t_connection_s",
+          "t_pit_shallow_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_shallow_edge_ns", "t_pit_shallow_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_shallow_end_piece_n", "t_pit_shallow_end_piece_e", "t_pit_shallow_end_piece_s", "t_pit_shallow_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_shallow_unconnected", "t_pit_shallow_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_spiked/t_pit_spiked.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_spiked/t_pit_spiked.json
@@ -1,299 +1,174 @@
 [
-{
-  "id": "t_pit_spiked",
-  "fg": "t_pit_spiked_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass" },
-    { "weight": 100, "sprite": "t_grass_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_spiked_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_spiked_corner_nw",
-        "t_pit_spiked_corner_sw",
-        "t_pit_spiked_corner_se",
-        "t_pit_spiked_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_spiked_t_connection_n",
-        "t_pit_spiked_t_connection_w",
-        "t_pit_spiked_t_connection_s",
-        "t_pit_spiked_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_spiked_edge_ns",
-        "t_pit_spiked_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_spiked_end_piece_n",
-        "t_pit_spiked_end_piece_w",
-        "t_pit_spiked_end_piece_s",
-        "t_pit_spiked_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_spiked_unconnected",
-        "t_pit_spiked_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_spiked_season_summer",
-  "fg": "t_pit_spiked_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_summer" },
-    { "weight": 100, "sprite": "t_grass_summer_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_spiked_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_spiked_corner_nw",
-        "t_pit_spiked_corner_sw",
-        "t_pit_spiked_corner_se",
-        "t_pit_spiked_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_spiked_t_connection_n",
-        "t_pit_spiked_t_connection_w",
-        "t_pit_spiked_t_connection_s",
-        "t_pit_spiked_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_spiked_edge_ns",
-        "t_pit_spiked_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_spiked_end_piece_n",
-        "t_pit_spiked_end_piece_w",
-        "t_pit_spiked_end_piece_s",
-        "t_pit_spiked_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_spiked_unconnected",
-        "t_pit_spiked_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_spiked_season_autumn",
-  "fg": "t_pit_spiked_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_autumn" },
-    { "weight": 100, "sprite": "t_grass_autumn_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_spiked_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_spiked_corner_nw",
-        "t_pit_spiked_corner_sw",
-        "t_pit_spiked_corner_se",
-        "t_pit_spiked_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_spiked_t_connection_n",
-        "t_pit_spiked_t_connection_w",
-        "t_pit_spiked_t_connection_s",
-        "t_pit_spiked_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_spiked_edge_ns",
-        "t_pit_spiked_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_spiked_end_piece_n",
-        "t_pit_spiked_end_piece_w",
-        "t_pit_spiked_end_piece_s",
-        "t_pit_spiked_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_spiked_unconnected",
-        "t_pit_spiked_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_spiked_season_winter",
-  "fg": "t_pit_spiked_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "snow_shallow_center" },
-    { "weight": 100, "sprite": "snow_shallow_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_spiked_center",
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_spiked_corner_nw",
-        "t_pit_spiked_corner_sw",
-        "t_pit_spiked_corner_se",
-        "t_pit_spiked_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_spiked_t_connection_n",
-        "t_pit_spiked_t_connection_w",
-        "t_pit_spiked_t_connection_s",
-        "t_pit_spiked_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_spiked_edge_ns",
-        "t_pit_spiked_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_spiked_end_piece_n",
-        "t_pit_spiked_end_piece_w",
-        "t_pit_spiked_end_piece_s",
-        "t_pit_spiked_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_spiked_unconnected",
-        "t_pit_spiked_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }
-  ]
-}
+  {
+    "id": "t_pit_spiked",
+    "fg": "t_pit_spiked_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_spiked_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_spiked_corner_nw", "t_pit_spiked_corner_ne", "t_pit_spiked_corner_se", "t_pit_spiked_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_spiked_t_connection_n",
+          "t_pit_spiked_t_connection_e",
+          "t_pit_spiked_t_connection_s",
+          "t_pit_spiked_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_spiked_edge_ns", "t_pit_spiked_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_spiked_end_piece_n", "t_pit_spiked_end_piece_e", "t_pit_spiked_end_piece_s", "t_pit_spiked_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_spiked_unconnected", "t_pit_spiked_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_spiked_season_summer",
+    "fg": "t_pit_spiked_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_spiked_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_spiked_corner_nw", "t_pit_spiked_corner_ne", "t_pit_spiked_corner_se", "t_pit_spiked_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_spiked_t_connection_n",
+          "t_pit_spiked_t_connection_e",
+          "t_pit_spiked_t_connection_s",
+          "t_pit_spiked_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_spiked_edge_ns", "t_pit_spiked_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_spiked_end_piece_n", "t_pit_spiked_end_piece_e", "t_pit_spiked_end_piece_s", "t_pit_spiked_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_spiked_unconnected", "t_pit_spiked_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_spiked_season_autumn",
+    "fg": "t_pit_spiked_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_spiked_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_spiked_corner_nw", "t_pit_spiked_corner_ne", "t_pit_spiked_corner_se", "t_pit_spiked_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_spiked_t_connection_n",
+          "t_pit_spiked_t_connection_e",
+          "t_pit_spiked_t_connection_s",
+          "t_pit_spiked_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_spiked_edge_ns", "t_pit_spiked_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_spiked_end_piece_n", "t_pit_spiked_end_piece_e", "t_pit_spiked_end_piece_s", "t_pit_spiked_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_spiked_unconnected", "t_pit_spiked_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_spiked_season_winter",
+    "fg": "t_pit_spiked_unconnected",
+    "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_spiked_center",
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [ "t_pit_spiked_corner_nw", "t_pit_spiked_corner_ne", "t_pit_spiked_corner_se", "t_pit_spiked_corner_sw" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_spiked_t_connection_n",
+          "t_pit_spiked_t_connection_e",
+          "t_pit_spiked_t_connection_s",
+          "t_pit_spiked_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_spiked_edge_ns", "t_pit_spiked_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [ "t_pit_spiked_end_piece_n", "t_pit_spiked_end_piece_e", "t_pit_spiked_end_piece_s", "t_pit_spiked_end_piece_w" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_spiked_unconnected", "t_pit_spiked_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_spiked_covered/t_pit_spiked_covered.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_pit_spiked_covered/t_pit_spiked_covered.json
@@ -1,299 +1,214 @@
 [
-{
-  "id": "t_pit_spiked_covered",
-  "fg": "t_pit_spiked_covered_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass" },
-    { "weight": 100, "sprite": "t_grass_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_spiked_covered_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_spiked_covered_corner_nw",
-        "t_pit_spiked_covered_corner_sw",
-        "t_pit_spiked_covered_corner_se",
-        "t_pit_spiked_covered_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_spiked_covered_t_connection_n",
-        "t_pit_spiked_covered_t_connection_w",
-        "t_pit_spiked_covered_t_connection_s",
-        "t_pit_spiked_covered_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_spiked_covered_edge_ns",
-        "t_pit_spiked_covered_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_spiked_covered_end_piece_n",
-        "t_pit_spiked_covered_end_piece_w",
-        "t_pit_spiked_covered_end_piece_s",
-        "t_pit_spiked_covered_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_spiked_covered_unconnected",
-        "t_pit_spiked_covered_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass" },
-        { "weight": 100, "sprite": "t_grass_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_spiked_covered_season_summer",
-  "fg": "t_pit_spiked_covered_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_summer" },
-    { "weight": 100, "sprite": "t_grass_summer_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_spiked_covered_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_spiked_covered_corner_nw",
-        "t_pit_spiked_covered_corner_sw",
-        "t_pit_spiked_covered_corner_se",
-        "t_pit_spiked_covered_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_spiked_covered_t_connection_n",
-        "t_pit_spiked_covered_t_connection_w",
-        "t_pit_spiked_covered_t_connection_s",
-        "t_pit_spiked_covered_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_spiked_covered_edge_ns",
-        "t_pit_spiked_covered_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_spiked_covered_end_piece_n",
-        "t_pit_spiked_covered_end_piece_w",
-        "t_pit_spiked_covered_end_piece_s",
-        "t_pit_spiked_covered_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_spiked_covered_unconnected",
-        "t_pit_spiked_covered_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_summer" },
-        { "weight": 100, "sprite": "t_grass_summer_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_spiked_covered_season_autumn",
-  "fg": "t_pit_spiked_covered_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "t_grass_autumn" },
-    { "weight": 100, "sprite": "t_grass_autumn_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_spiked_covered_center",
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_spiked_covered_corner_nw",
-        "t_pit_spiked_covered_corner_sw",
-        "t_pit_spiked_covered_corner_se",
-        "t_pit_spiked_covered_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_spiked_covered_t_connection_n",
-        "t_pit_spiked_covered_t_connection_w",
-        "t_pit_spiked_covered_t_connection_s",
-        "t_pit_spiked_covered_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_spiked_covered_edge_ns",
-        "t_pit_spiked_covered_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_spiked_covered_end_piece_n",
-        "t_pit_spiked_covered_end_piece_w",
-        "t_pit_spiked_covered_end_piece_s",
-        "t_pit_spiked_covered_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_spiked_covered_unconnected",
-        "t_pit_spiked_covered_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "t_grass_autumn" },
-        { "weight": 100, "sprite": "t_grass_autumn_center2" }
-      ]
-    }
-  ]
-}, {
-  "id": "t_pit_spiked_covered_season_winter",
-  "fg": "t_pit_spiked_covered_unconnected",
-  "bg": [
-    { "weight": 100, "sprite": "snow_shallow_center" },
-    { "weight": 100, "sprite": "snow_shallow_center2" }
-  ],
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_pit_spiked_covered_center",
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "corner",
-      "fg": [
-        "t_pit_spiked_covered_corner_nw",
-        "t_pit_spiked_covered_corner_sw",
-        "t_pit_spiked_covered_corner_se",
-        "t_pit_spiked_covered_corner_ne"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "t_connection",
-      "fg": [
-        "t_pit_spiked_covered_t_connection_n",
-        "t_pit_spiked_covered_t_connection_w",
-        "t_pit_spiked_covered_t_connection_s",
-        "t_pit_spiked_covered_t_connection_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "edge",
-      "fg": [
-        "t_pit_spiked_covered_edge_ns",
-        "t_pit_spiked_covered_edge_ew"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "end_piece",
-      "fg": [
-        "t_pit_spiked_covered_end_piece_n",
-        "t_pit_spiked_covered_end_piece_w",
-        "t_pit_spiked_covered_end_piece_s",
-        "t_pit_spiked_covered_end_piece_e"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "t_pit_spiked_covered_unconnected",
-        "t_pit_spiked_covered_unconnected"
-      ],
-      "bg": [
-        { "weight": 100, "sprite": "snow_shallow_center" },
-        { "weight": 100, "sprite": "snow_shallow_center2" }
-      ]
-    }
-  ]
-}
+  {
+    "id": "t_pit_spiked_covered",
+    "fg": "t_pit_spiked_covered_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_spiked_covered_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [
+          "t_pit_spiked_covered_corner_nw",
+          "t_pit_spiked_covered_corner_ne",
+          "t_pit_spiked_covered_corner_se",
+          "t_pit_spiked_covered_corner_sw"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_spiked_covered_t_connection_n",
+          "t_pit_spiked_covered_t_connection_e",
+          "t_pit_spiked_covered_t_connection_s",
+          "t_pit_spiked_covered_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_spiked_covered_edge_ns", "t_pit_spiked_covered_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [
+          "t_pit_spiked_covered_end_piece_n",
+          "t_pit_spiked_covered_end_piece_e",
+          "t_pit_spiked_covered_end_piece_s",
+          "t_pit_spiked_covered_end_piece_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_spiked_covered_unconnected", "t_pit_spiked_covered_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass" }, { "weight": 100, "sprite": "t_grass_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_spiked_covered_season_summer",
+    "fg": "t_pit_spiked_covered_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_spiked_covered_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [
+          "t_pit_spiked_covered_corner_nw",
+          "t_pit_spiked_covered_corner_ne",
+          "t_pit_spiked_covered_corner_se",
+          "t_pit_spiked_covered_corner_sw"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_spiked_covered_t_connection_n",
+          "t_pit_spiked_covered_t_connection_e",
+          "t_pit_spiked_covered_t_connection_s",
+          "t_pit_spiked_covered_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_spiked_covered_edge_ns", "t_pit_spiked_covered_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [
+          "t_pit_spiked_covered_end_piece_n",
+          "t_pit_spiked_covered_end_piece_e",
+          "t_pit_spiked_covered_end_piece_s",
+          "t_pit_spiked_covered_end_piece_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_spiked_covered_unconnected", "t_pit_spiked_covered_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_summer" }, { "weight": 100, "sprite": "t_grass_summer_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_spiked_covered_season_autumn",
+    "fg": "t_pit_spiked_covered_unconnected",
+    "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_spiked_covered_center",
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [
+          "t_pit_spiked_covered_corner_nw",
+          "t_pit_spiked_covered_corner_ne",
+          "t_pit_spiked_covered_corner_se",
+          "t_pit_spiked_covered_corner_sw"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_spiked_covered_t_connection_n",
+          "t_pit_spiked_covered_t_connection_e",
+          "t_pit_spiked_covered_t_connection_s",
+          "t_pit_spiked_covered_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_spiked_covered_edge_ns", "t_pit_spiked_covered_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [
+          "t_pit_spiked_covered_end_piece_n",
+          "t_pit_spiked_covered_end_piece_e",
+          "t_pit_spiked_covered_end_piece_s",
+          "t_pit_spiked_covered_end_piece_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_spiked_covered_unconnected", "t_pit_spiked_covered_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "t_grass_autumn" }, { "weight": 100, "sprite": "t_grass_autumn_center2" } ]
+      }
+    ]
+  },
+  {
+    "id": "t_pit_spiked_covered_season_winter",
+    "fg": "t_pit_spiked_covered_unconnected",
+    "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "center",
+        "fg": "t_pit_spiked_covered_center",
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "corner",
+        "fg": [
+          "t_pit_spiked_covered_corner_nw",
+          "t_pit_spiked_covered_corner_ne",
+          "t_pit_spiked_covered_corner_se",
+          "t_pit_spiked_covered_corner_sw"
+        ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_pit_spiked_covered_t_connection_n",
+          "t_pit_spiked_covered_t_connection_e",
+          "t_pit_spiked_covered_t_connection_s",
+          "t_pit_spiked_covered_t_connection_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "edge",
+        "fg": [ "t_pit_spiked_covered_edge_ns", "t_pit_spiked_covered_edge_ew" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "end_piece",
+        "fg": [
+          "t_pit_spiked_covered_end_piece_n",
+          "t_pit_spiked_covered_end_piece_e",
+          "t_pit_spiked_covered_end_piece_s",
+          "t_pit_spiked_covered_end_piece_w"
+        ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_pit_spiked_covered_unconnected", "t_pit_spiked_covered_unconnected" ],
+        "bg": [ { "weight": 100, "sprite": "snow_shallow_center" }, { "weight": 100, "sprite": "snow_shallow_center2" } ]
+      }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_privacy_fence/t_privacy_fence.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_privacy_fence/t_privacy_fence.json
@@ -1,119 +1,78 @@
 [
-{
-  "id": "t_privacy_fence",
-  "multitile": true,
-  "fg": "t_privacy_fence_unconnected",
-  "bg": "t_grass",
-  "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "t_grass",
-      "fg": "t_privacy_fence_center"
-    },
-    {
-      "id": "corner",
-      "bg": "t_grass",
-      "fg": [
-        "t_privacy_fence_corner_nw",
-        "t_privacy_fence_corner_sw",
-        "t_privacy_fence_corner_se",
-        "t_privacy_fence_corner_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "bg": "t_grass",
-      "fg": [
-        "t_privacy_fence_t_connection_n",
-        "t_privacy_fence_t_connection_w",
-        "t_privacy_fence_t_connection_s",
-        "t_privacy_fence_t_connection_e"
-      ]
-    },
-    {
-      "id": "edge",
-      "bg": "t_grass",
-      "fg": [
-        "t_privacy_fence_edge_ns",
-        "t_privacy_fence_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "bg": "t_grass",
-      "fg": [
-        "t_privacy_fence_end_piece_n",
-        "t_privacy_fence_end_piece_w",
-        "t_privacy_fence_end_piece_s",
-        "t_privacy_fence_end_piece_e"
-      ]
-    },
-    {
-      "bg": "t_grass",
-      "id": "unconnected",
-      "fg": [
-        "t_privacy_fence_unconnected",
-        "t_privacy_fence_unconnected"
-      ]
-    }
-  ]
-},{
-  "id": "t_privacy_fence_season_winter",
-  "multitile": true,
-  "fg": "t_privacy_fence_unconnected",
-  "bg": "snow_shallow_center",
-  "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "snow_shallow_center",
-      "fg": "t_privacy_fence_center"
-    },
-    {
-      "id": "corner",
-      "bg": "snow_shallow_center",
-      "fg": [
-        "t_privacy_fence_corner_nw",
-        "t_privacy_fence_corner_sw",
-        "t_privacy_fence_corner_se",
-        "t_privacy_fence_corner_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "bg": "snow_shallow_center",
-      "fg": [
-        "t_privacy_fence_t_connection_n",
-        "t_privacy_fence_t_connection_w",
-        "t_privacy_fence_t_connection_s",
-        "t_privacy_fence_t_connection_e"
-      ]
-    },
-    {
-      "id": "edge",
-      "bg": "snow_shallow_center",
-      "fg": [
-        "t_privacy_fence_edge_ns",
-        "t_privacy_fence_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "bg": "snow_shallow_center",
-      "fg": [
-        "t_privacy_fence_end_piece_n",
-        "t_privacy_fence_end_piece_w",
-        "t_privacy_fence_end_piece_s",
-        "t_privacy_fence_end_piece_e"
-      ]
-    },
-    {
-      "bg": "snow_shallow_center",
-      "id": "unconnected",
-      "fg": [
-        "t_privacy_fence_unconnected",
-        "t_privacy_fence_unconnected"
-      ]
-    }
-  ]
-}
+  {
+    "id": "t_privacy_fence",
+    "multitile": true,
+    "fg": "t_privacy_fence_unconnected",
+    "bg": "t_grass",
+    "additional_tiles": [
+      { "id": "center", "bg": "t_grass", "fg": "t_privacy_fence_center" },
+      {
+        "id": "corner",
+        "bg": "t_grass",
+        "fg": [ "t_privacy_fence_corner_nw", "t_privacy_fence_corner_ne", "t_privacy_fence_corner_se", "t_privacy_fence_corner_sw" ]
+      },
+      {
+        "id": "t_connection",
+        "bg": "t_grass",
+        "fg": [
+          "t_privacy_fence_t_connection_n",
+          "t_privacy_fence_t_connection_e",
+          "t_privacy_fence_t_connection_s",
+          "t_privacy_fence_t_connection_w"
+        ]
+      },
+      { "id": "edge", "bg": "t_grass", "fg": [ "t_privacy_fence_edge_ns", "t_privacy_fence_edge_ew" ] },
+      {
+        "id": "end_piece",
+        "bg": "t_grass",
+        "fg": [
+          "t_privacy_fence_end_piece_n",
+          "t_privacy_fence_end_piece_e",
+          "t_privacy_fence_end_piece_s",
+          "t_privacy_fence_end_piece_w"
+        ]
+      },
+      { "bg": "t_grass", "id": "unconnected", "fg": [ "t_privacy_fence_unconnected", "t_privacy_fence_unconnected" ] }
+    ]
+  },
+  {
+    "id": "t_privacy_fence_season_winter",
+    "multitile": true,
+    "fg": "t_privacy_fence_unconnected",
+    "bg": "snow_shallow_center",
+    "additional_tiles": [
+      { "id": "center", "bg": "snow_shallow_center", "fg": "t_privacy_fence_center" },
+      {
+        "id": "corner",
+        "bg": "snow_shallow_center",
+        "fg": [ "t_privacy_fence_corner_nw", "t_privacy_fence_corner_ne", "t_privacy_fence_corner_se", "t_privacy_fence_corner_sw" ]
+      },
+      {
+        "id": "t_connection",
+        "bg": "snow_shallow_center",
+        "fg": [
+          "t_privacy_fence_t_connection_n",
+          "t_privacy_fence_t_connection_e",
+          "t_privacy_fence_t_connection_s",
+          "t_privacy_fence_t_connection_w"
+        ]
+      },
+      { "id": "edge", "bg": "snow_shallow_center", "fg": [ "t_privacy_fence_edge_ns", "t_privacy_fence_edge_ew" ] },
+      {
+        "id": "end_piece",
+        "bg": "snow_shallow_center",
+        "fg": [
+          "t_privacy_fence_end_piece_n",
+          "t_privacy_fence_end_piece_e",
+          "t_privacy_fence_end_piece_s",
+          "t_privacy_fence_end_piece_w"
+        ]
+      },
+      {
+        "bg": "snow_shallow_center",
+        "id": "unconnected",
+        "fg": [ "t_privacy_fence_unconnected", "t_privacy_fence_unconnected" ]
+      }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_railing/t_railing.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_railing/t_railing.json
@@ -4,56 +4,27 @@
   "fg": "t_railing_unconnected",
   "bg": "t_concrete_unconnected",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "t_concrete_unconnected",
-      "fg": "t_railing_center"
-    },
+    { "id": "center", "bg": "t_concrete_unconnected", "fg": "t_railing_center" },
     {
       "id": "corner",
       "bg": "t_concrete_unconnected",
-      "fg": [
-        "t_railing_corner_nw",
-        "t_railing_corner_sw",
-        "t_railing_corner_se",
-        "t_railing_corner_ne"
-      ]
+      "fg": [ "t_railing_corner_nw", "t_railing_corner_ne", "t_railing_corner_se", "t_railing_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "t_concrete_unconnected",
-      "fg": [
-        "t_railing_t_connection_n",
-        "t_railing_t_connection_w",
-        "t_railing_t_connection_s",
-        "t_railing_t_connection_e"
-      ]
+      "fg": [ "t_railing_t_connection_n", "t_railing_t_connection_e", "t_railing_t_connection_s", "t_railing_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "t_concrete_unconnected",
-      "fg": [
-        "t_railing_edge_ns",
-        "t_railing_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "t_concrete_unconnected", "fg": [ "t_railing_edge_ns", "t_railing_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "t_concrete_unconnected",
-      "fg": [
-        "t_railing_end_piece_n",
-        "t_railing_end_piece_w",
-        "t_railing_end_piece_s",
-        "t_railing_end_piece_e"
-      ]
+      "fg": [ "t_railing_end_piece_n", "t_railing_end_piece_e", "t_railing_end_piece_s", "t_railing_end_piece_w" ]
     },
     {
       "bg": "t_concrete_unconnected",
       "id": "unconnected",
-      "fg": [
-        "t_railing_unconnected",
-        "t_railing_unconnected"
-      ]
+      "fg": [ "t_railing_unconnected", "t_railing_unconnected" ]
     }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_railroad_rubble/t_railroad_rubble.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_railroad_rubble/t_railroad_rubble.json
@@ -1,154 +1,186 @@
 [
-{
-  "id": "t_railroad_rubble",
-  "multitile": true,
-  "fg": "t_railroad_rubble_unconnected",
-  "bg": "t_grass",
-  "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "t_grass",
-      "fg": [ { "weight": 1, "sprite": "t_railroad_rubble_center" }, { "weight": 1, "sprite": "t_railroad_rubble_center2" } ]
-    },
-    {
-      "id": "corner",
-      "bg": "t_grass",
-      "fg": [ "t_railroad_rubble_corner_nw", "t_railroad_rubble_corner_sw", "t_railroad_rubble_corner_se", "t_railroad_rubble_corner_ne" ]
-    },
-    {
-      "id": "t_connection",
-      "bg": "t_grass",
-      "fg": [ "t_railroad_rubble_t_connection_n", "t_railroad_rubble_t_connection_w", "t_railroad_rubble_t_connection_s", "t_railroad_rubble_t_connection_e" ]
-    },
-    {
-      "id": "edge",
-      "bg": "t_grass",
-      "fg": [ "t_railroad_rubble_edge_ns", "t_railroad_rubble_edge_ew" ]
-    },
-    {
-      "id": "end_piece",
-      "bg": "t_grass",
-      "fg": [ "t_railroad_rubble_end_piece_n", "t_railroad_rubble_end_piece_w", "t_railroad_rubble_end_piece_s", "t_railroad_rubble_end_piece_e" ]
-    },
-    {
-      "bg": "t_grass",
-      "id": "unconnected",
-      "fg": "t_railroad_rubble_unconnected"
-    }
-  ]
-},
-{
-  "id": "t_railroad_rubble_season_summer",
-  "multitile": true,
-  "fg": "t_railroad_rubble_unconnected",
-  "bg": "t_grass_summer",
-  "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "t_grass_summer",
-      "fg": [ { "weight": 1, "sprite": "t_railroad_rubble_center" }, { "weight": 1, "sprite": "t_railroad_rubble_center2" } ]
-    },
-    {
-      "id": "corner",
-      "bg": "t_grass_summer",
-      "fg": [ "t_railroad_rubble_corner_nw", "t_railroad_rubble_corner_sw", "t_railroad_rubble_corner_se", "t_railroad_rubble_corner_ne" ]
-    },
-    {
-      "id": "t_connection",
-      "bg": "t_grass_summer",
-      "fg": [ "t_railroad_rubble_t_connection_n", "t_railroad_rubble_t_connection_w", "t_railroad_rubble_t_connection_s", "t_railroad_rubble_t_connection_e" ]
-    },
-    {
-      "id": "edge",
-      "bg": "t_grass_summer",
-      "fg": [ "t_railroad_rubble_edge_ns", "t_railroad_rubble_edge_ew" ]
-    },
-    {
-      "id": "end_piece",
-      "bg": "t_grass_summer",
-      "fg": [ "t_railroad_rubble_end_piece_n", "t_railroad_rubble_end_piece_w", "t_railroad_rubble_end_piece_s", "t_railroad_rubble_end_piece_e" ]
-    },
-    {
-      "bg": "t_grass_summer",
-      "id": "unconnected",
-      "fg": "t_railroad_rubble_unconnected"
-    }
-  ]
-},
-{
-  "id": "t_railroad_rubble_season_autumn",
-  "multitile": true,
-  "fg": "t_railroad_rubble_unconnected",
-  "bg": "t_grass_autumn",
-  "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "t_grass_autumn",
-      "fg": [ { "weight": 1, "sprite": "t_railroad_rubble_center" }, { "weight": 1, "sprite": "t_railroad_rubble_center2" } ]
-    },
-    {
-      "id": "corner",
-      "bg": "t_grass_autumn",
-      "fg": [ "t_railroad_rubble_corner_nw", "t_railroad_rubble_corner_sw", "t_railroad_rubble_corner_se", "t_railroad_rubble_corner_ne" ]
-    },
-    {
-      "id": "t_connection",
-      "bg": "t_grass_autumn",
-      "fg": [ "t_railroad_rubble_t_connection_n", "t_railroad_rubble_t_connection_w", "t_railroad_rubble_t_connection_s", "t_railroad_rubble_t_connection_e" ]
-    },
-    {
-      "id": "edge",
-      "bg": "t_grass_autumn",
-      "fg": [ "t_railroad_rubble_edge_ns", "t_railroad_rubble_edge_ew" ]
-    },
-    {
-      "id": "end_piece",
-      "bg": "t_grass_autumn",
-      "fg": [ "t_railroad_rubble_end_piece_n", "t_railroad_rubble_end_piece_w", "t_railroad_rubble_end_piece_s", "t_railroad_rubble_end_piece_e" ]
-    },
-    {
-      "bg": "t_grass_autumn",
-      "id": "unconnected",
-      "fg": "t_railroad_rubble_unconnected"
-    }
-  ]
-},
-{
-  "id": "t_railroad_rubble_season_winter",
-  "multitile": true,
-  "fg": "t_railroad_rubble_unconnected",
-  "bg": "snow_shallow_center",
-  "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "snow_shallow_center",
-      "fg": [ { "weight": 1, "sprite": "t_railroad_rubble_center" }, { "weight": 1, "sprite": "t_railroad_rubble_center2" } ]
-    },
-    {
-      "id": "corner",
-      "bg": "snow_shallow_center",
-      "fg": [ "t_railroad_rubble_corner_nw", "t_railroad_rubble_corner_sw", "t_railroad_rubble_corner_se", "t_railroad_rubble_corner_ne" ]
-    },
-    {
-      "id": "t_connection",
-      "bg": "snow_shallow_center",
-      "fg": [ "t_railroad_rubble_t_connection_n", "t_railroad_rubble_t_connection_w", "t_railroad_rubble_t_connection_s", "t_railroad_rubble_t_connection_e" ]
-    },
-    {
-      "id": "edge",
-      "bg": "snow_shallow_center",
-      "fg": [ "t_railroad_rubble_edge_ns", "t_railroad_rubble_edge_ew" ]
-    },
-    {
-      "id": "end_piece",
-      "bg": "snow_shallow_center",
-      "fg": [ "t_railroad_rubble_end_piece_n", "t_railroad_rubble_end_piece_w", "t_railroad_rubble_end_piece_s", "t_railroad_rubble_end_piece_e" ]
-    },
-    {
-      "bg": "snow_shallow_center",
-      "id": "unconnected",
-      "fg": "t_railroad_rubble_unconnected"
-    }
-  ]
-}
+  {
+    "id": "t_railroad_rubble",
+    "multitile": true,
+    "fg": "t_railroad_rubble_unconnected",
+    "bg": "t_grass",
+    "additional_tiles": [
+      {
+        "id": "center",
+        "bg": "t_grass",
+        "fg": [ { "weight": 1, "sprite": "t_railroad_rubble_center" }, { "weight": 1, "sprite": "t_railroad_rubble_center2" } ]
+      },
+      {
+        "id": "corner",
+        "bg": "t_grass",
+        "fg": [
+          "t_railroad_rubble_corner_nw",
+          "t_railroad_rubble_corner_ne",
+          "t_railroad_rubble_corner_se",
+          "t_railroad_rubble_corner_sw"
+        ]
+      },
+      {
+        "id": "t_connection",
+        "bg": "t_grass",
+        "fg": [
+          "t_railroad_rubble_t_connection_n",
+          "t_railroad_rubble_t_connection_e",
+          "t_railroad_rubble_t_connection_s",
+          "t_railroad_rubble_t_connection_w"
+        ]
+      },
+      { "id": "edge", "bg": "t_grass", "fg": [ "t_railroad_rubble_edge_ns", "t_railroad_rubble_edge_ew" ] },
+      {
+        "id": "end_piece",
+        "bg": "t_grass",
+        "fg": [
+          "t_railroad_rubble_end_piece_n",
+          "t_railroad_rubble_end_piece_e",
+          "t_railroad_rubble_end_piece_s",
+          "t_railroad_rubble_end_piece_w"
+        ]
+      },
+      { "bg": "t_grass", "id": "unconnected", "fg": "t_railroad_rubble_unconnected" }
+    ]
+  },
+  {
+    "id": "t_railroad_rubble_season_summer",
+    "multitile": true,
+    "fg": "t_railroad_rubble_unconnected",
+    "bg": "t_grass_summer",
+    "additional_tiles": [
+      {
+        "id": "center",
+        "bg": "t_grass_summer",
+        "fg": [ { "weight": 1, "sprite": "t_railroad_rubble_center" }, { "weight": 1, "sprite": "t_railroad_rubble_center2" } ]
+      },
+      {
+        "id": "corner",
+        "bg": "t_grass_summer",
+        "fg": [
+          "t_railroad_rubble_corner_nw",
+          "t_railroad_rubble_corner_ne",
+          "t_railroad_rubble_corner_se",
+          "t_railroad_rubble_corner_sw"
+        ]
+      },
+      {
+        "id": "t_connection",
+        "bg": "t_grass_summer",
+        "fg": [
+          "t_railroad_rubble_t_connection_n",
+          "t_railroad_rubble_t_connection_e",
+          "t_railroad_rubble_t_connection_s",
+          "t_railroad_rubble_t_connection_w"
+        ]
+      },
+      { "id": "edge", "bg": "t_grass_summer", "fg": [ "t_railroad_rubble_edge_ns", "t_railroad_rubble_edge_ew" ] },
+      {
+        "id": "end_piece",
+        "bg": "t_grass_summer",
+        "fg": [
+          "t_railroad_rubble_end_piece_n",
+          "t_railroad_rubble_end_piece_e",
+          "t_railroad_rubble_end_piece_s",
+          "t_railroad_rubble_end_piece_w"
+        ]
+      },
+      { "bg": "t_grass_summer", "id": "unconnected", "fg": "t_railroad_rubble_unconnected" }
+    ]
+  },
+  {
+    "id": "t_railroad_rubble_season_autumn",
+    "multitile": true,
+    "fg": "t_railroad_rubble_unconnected",
+    "bg": "t_grass_autumn",
+    "additional_tiles": [
+      {
+        "id": "center",
+        "bg": "t_grass_autumn",
+        "fg": [ { "weight": 1, "sprite": "t_railroad_rubble_center" }, { "weight": 1, "sprite": "t_railroad_rubble_center2" } ]
+      },
+      {
+        "id": "corner",
+        "bg": "t_grass_autumn",
+        "fg": [
+          "t_railroad_rubble_corner_nw",
+          "t_railroad_rubble_corner_ne",
+          "t_railroad_rubble_corner_se",
+          "t_railroad_rubble_corner_sw"
+        ]
+      },
+      {
+        "id": "t_connection",
+        "bg": "t_grass_autumn",
+        "fg": [
+          "t_railroad_rubble_t_connection_n",
+          "t_railroad_rubble_t_connection_e",
+          "t_railroad_rubble_t_connection_s",
+          "t_railroad_rubble_t_connection_w"
+        ]
+      },
+      { "id": "edge", "bg": "t_grass_autumn", "fg": [ "t_railroad_rubble_edge_ns", "t_railroad_rubble_edge_ew" ] },
+      {
+        "id": "end_piece",
+        "bg": "t_grass_autumn",
+        "fg": [
+          "t_railroad_rubble_end_piece_n",
+          "t_railroad_rubble_end_piece_e",
+          "t_railroad_rubble_end_piece_s",
+          "t_railroad_rubble_end_piece_w"
+        ]
+      },
+      { "bg": "t_grass_autumn", "id": "unconnected", "fg": "t_railroad_rubble_unconnected" }
+    ]
+  },
+  {
+    "id": "t_railroad_rubble_season_winter",
+    "multitile": true,
+    "fg": "t_railroad_rubble_unconnected",
+    "bg": "snow_shallow_center",
+    "additional_tiles": [
+      {
+        "id": "center",
+        "bg": "snow_shallow_center",
+        "fg": [ { "weight": 1, "sprite": "t_railroad_rubble_center" }, { "weight": 1, "sprite": "t_railroad_rubble_center2" } ]
+      },
+      {
+        "id": "corner",
+        "bg": "snow_shallow_center",
+        "fg": [
+          "t_railroad_rubble_corner_nw",
+          "t_railroad_rubble_corner_ne",
+          "t_railroad_rubble_corner_se",
+          "t_railroad_rubble_corner_sw"
+        ]
+      },
+      {
+        "id": "t_connection",
+        "bg": "snow_shallow_center",
+        "fg": [
+          "t_railroad_rubble_t_connection_n",
+          "t_railroad_rubble_t_connection_e",
+          "t_railroad_rubble_t_connection_s",
+          "t_railroad_rubble_t_connection_w"
+        ]
+      },
+      {
+        "id": "edge",
+        "bg": "snow_shallow_center",
+        "fg": [ "t_railroad_rubble_edge_ns", "t_railroad_rubble_edge_ew" ]
+      },
+      {
+        "id": "end_piece",
+        "bg": "snow_shallow_center",
+        "fg": [
+          "t_railroad_rubble_end_piece_n",
+          "t_railroad_rubble_end_piece_e",
+          "t_railroad_rubble_end_piece_s",
+          "t_railroad_rubble_end_piece_w"
+        ]
+      },
+      { "bg": "snow_shallow_center", "id": "unconnected", "fg": "t_railroad_rubble_unconnected" }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_railroad_tie/t_railroad_tie.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_railroad_tie/t_railroad_tie.json
@@ -5,54 +5,29 @@
     "bg": "t_railroad_rubble_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_railroad_tie_edge_ns",
-        "bg": "t_railroad_rubble_center"
-      },
+      { "id": "center", "fg": "t_railroad_tie_edge_ns", "bg": "t_railroad_rubble_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_railroad_tie_corner_nw",
-          "t_railroad_tie_corner_sw",
-          "t_railroad_tie_corner_se",
-          "t_railroad_tie_corner_ne"
-        ],
+        "fg": [ "t_railroad_tie_corner_nw", "t_railroad_tie_corner_ne", "t_railroad_tie_corner_se", "t_railroad_tie_corner_sw" ],
         "bg": "t_railroad_rubble_center"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_railroad_tie_corner_nw",
-          "t_railroad_tie_corner_sw",
-          "t_railroad_tie_corner_se",
-          "t_railroad_tie_corner_ne"
-        ],
+        "fg": [ "t_railroad_tie_corner_nw", "t_railroad_tie_corner_ne", "t_railroad_tie_corner_se", "t_railroad_tie_corner_sw" ],
         "bg": "t_railroad_rubble_center"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_railroad_tie_edge_ns",
-          "t_railroad_tie_edge_ew"
-        ],
-        "bg": "t_railroad_rubble_center"
-      },
+      { "id": "edge", "fg": [ "t_railroad_tie_edge_ns", "t_railroad_tie_edge_ew" ], "bg": "t_railroad_rubble_center" },
       {
         "id": "end_piece",
         "fg": [
           "t_railroad_tie_end_piece_n",
-          "t_railroad_tie_end_piece_w",
+          "t_railroad_tie_end_piece_e",
           "t_railroad_tie_end_piece_s",
-          "t_railroad_tie_end_piece_e"
+          "t_railroad_tie_end_piece_w"
         ],
         "bg": "t_railroad_rubble_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_railroad_tie_edge_ns",
-        "bg": "t_railroad_rubble_center"
-      }
+      { "id": "unconnected", "fg": "t_railroad_tie_edge_ns", "bg": "t_railroad_rubble_center" }
     ]
   },
   {
@@ -61,49 +36,24 @@
     "bg": "t_railroad_rubble_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_railroad_tie_corner_ne",
-        "bg": "t_railroad_rubble_center"
-      },
+      { "id": "center", "fg": "t_railroad_tie_corner_ne", "bg": "t_railroad_rubble_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_railroad_tie_corner_nw",
-          "t_railroad_tie_corner_sw",
-          "t_railroad_tie_corner_se",
-          "t_railroad_tie_corner_ne"
-        ],
+        "fg": [ "t_railroad_tie_corner_nw", "t_railroad_tie_corner_ne", "t_railroad_tie_corner_se", "t_railroad_tie_corner_sw" ],
         "bg": "t_railroad_rubble_center"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_railroad_tie_corner_nw",
-          "t_railroad_tie_corner_sw",
-          "t_railroad_tie_corner_se",
-          "t_railroad_tie_corner_nw"
-        ],
+        "fg": [ "t_railroad_tie_corner_nw", "t_railroad_tie_corner_nw", "t_railroad_tie_corner_se", "t_railroad_tie_corner_sw" ],
         "bg": "t_railroad_rubble_center"
       },
       {
         "id": "edge",
-        "fg": [
-          "t_railroad_tie_corner_ne",
-          "t_railroad_tie_corner_sw"
-        ],
+        "fg": [ "t_railroad_tie_corner_ne", "t_railroad_tie_corner_sw" ],
         "bg": "t_railroad_rubble_center"
       },
-      {
-        "id": "end_piece",
-        "fg": "t_railroad_tie_corner_ne",
-        "bg": "t_railroad_rubble_center"
-      },
-      {
-        "id": "unconnected",
-        "fg": "t_railroad_tie_corner_ne",
-        "bg": "t_railroad_rubble_center"
-      }
+      { "id": "end_piece", "fg": "t_railroad_tie_corner_ne", "bg": "t_railroad_rubble_center" },
+      { "id": "unconnected", "fg": "t_railroad_tie_corner_ne", "bg": "t_railroad_rubble_center" }
     ]
   },
   {

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_railroad_track/t_railroad_track.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_railroad_track/t_railroad_track.json
@@ -5,54 +5,33 @@
     "bg": "t_railroad_rubble_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_railroad_track_edge_ns",
-        "bg": "t_railroad_rubble_center"
-      },
+      { "id": "center", "fg": "t_railroad_track_edge_ns", "bg": "t_railroad_rubble_center" },
       {
         "id": "corner",
         "fg": [
           "t_railroad_track_corner_nw",
-          "t_railroad_track_corner_sw",
+          "t_railroad_track_corner_ne",
           "t_railroad_track_corner_se",
-          "t_railroad_track_corner_ne"
+          "t_railroad_track_corner_sw"
         ],
         "bg": "t_railroad_rubble_center"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_railroad_track_edge_ew",
-          "t_railroad_track_edge_ns",
-          "t_railroad_track_edge_ew",
-          "t_railroad_track_edge_ns"
-        ],
+        "fg": [ "t_railroad_track_edge_ew", "t_railroad_track_edge_ns", "t_railroad_track_edge_ew", "t_railroad_track_edge_ns" ],
         "bg": "t_railroad_rubble_center"
       },
       {
         "id": "edge",
-        "fg": [
-          "t_railroad_track_edge_ns",
-          "t_railroad_track_edge_ew"
-        ],
+        "fg": [ "t_railroad_track_edge_ns", "t_railroad_track_edge_ew" ],
         "bg": "t_railroad_rubble_center"
       },
       {
         "id": "end_piece",
-        "fg": [
-          "t_railroad_track_edge_ns",
-          "t_railroad_track_edge_ew",
-          "t_railroad_track_edge_ns",
-          "t_railroad_track_edge_ew"
-        ],
+        "fg": [ "t_railroad_track_edge_ns", "t_railroad_track_edge_ew", "t_railroad_track_edge_ns", "t_railroad_track_edge_ew" ],
         "bg": "t_railroad_rubble_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_railroad_track_edge_ns",
-        "bg": "t_railroad_rubble_center"
-      }
+      { "id": "unconnected", "fg": "t_railroad_track_edge_ns", "bg": "t_railroad_rubble_center" }
     ]
   },
   {
@@ -61,49 +40,29 @@
     "bg": "t_railroad_rubble_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_railroad_track_corner_ne",
-        "bg": "t_railroad_rubble_center"
-      },
+      { "id": "center", "fg": "t_railroad_track_corner_ne", "bg": "t_railroad_rubble_center" },
       {
         "id": "corner",
         "fg": [
           "t_railroad_track_corner_nw",
-          "t_railroad_track_corner_sw",
+          "t_railroad_track_corner_ne",
           "t_railroad_track_corner_se",
-          "t_railroad_track_corner_ne"
+          "t_railroad_track_corner_sw"
         ],
         "bg": "t_railroad_rubble_center"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_railroad_track_corner_ne",
-          "t_railroad_track_corner_nw",
-          "t_railroad_track_corner_se",
-          "t_railroad_track_edge_ns"
-        ],
+        "fg": [ "t_railroad_track_corner_ne", "t_railroad_track_edge_ns", "t_railroad_track_corner_se", "t_railroad_track_corner_nw" ],
         "bg": "t_railroad_rubble_center"
       },
       {
         "id": "edge",
-        "fg": [
-          "t_railroad_track_edge_ns",
-          "t_railroad_track_edge_ew"
-        ],
+        "fg": [ "t_railroad_track_edge_ns", "t_railroad_track_edge_ew" ],
         "bg": "t_railroad_rubble_center"
       },
-      {
-        "id": "end_piece",
-        "fg": "t_railroad_track_corner_ne",
-        "bg": "t_railroad_rubble_center"
-      },
-      {
-        "id": "unconnected",
-        "fg": "t_railroad_track_corner_ne",
-        "bg": "t_railroad_rubble_center"
-      }
+      { "id": "end_piece", "fg": "t_railroad_track_corner_ne", "bg": "t_railroad_rubble_center" },
+      { "id": "unconnected", "fg": "t_railroad_track_corner_ne", "bg": "t_railroad_rubble_center" }
     ]
   },
   {

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_railroad_track_on_tie/t_railroad_track_on_tie.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_railroad_track_on_tie/t_railroad_track_on_tie.json
@@ -5,18 +5,14 @@
     "bg": "t_railroad_rubble_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_railroad_track_on_tie_edge_ns",
-        "bg": "t_railroad_rubble_center"
-      },
+      { "id": "center", "fg": "t_railroad_track_on_tie_edge_ns", "bg": "t_railroad_rubble_center" },
       {
         "id": "corner",
         "fg": [
           "t_railroad_track_on_tie_corner_nw",
-          "t_railroad_track_on_tie_corner_sw",
+          "t_railroad_track_on_tie_corner_ne",
           "t_railroad_track_on_tie_corner_se",
-          "t_railroad_track_on_tie_corner_ne"
+          "t_railroad_track_on_tie_corner_sw"
         ],
         "bg": "t_railroad_rubble_center"
       },
@@ -24,30 +20,19 @@
         "id": "t_connection",
         "fg": [
           "t_railroad_track_on_tie_corner_nw",
-          "t_railroad_track_on_tie_corner_sw",
           "t_railroad_track_on_tie_corner_se",
-          "t_railroad_track_on_tie_corner_se"
+          "t_railroad_track_on_tie_corner_se",
+          "t_railroad_track_on_tie_corner_sw"
         ],
         "bg": "t_railroad_rubble_center"
       },
       {
         "id": "edge",
-        "fg": [
-          "t_railroad_track_on_tie_edge_ns",
-          "t_railroad_track_on_tie_edge_ew"
-        ],
+        "fg": [ "t_railroad_track_on_tie_edge_ns", "t_railroad_track_on_tie_edge_ew" ],
         "bg": "t_railroad_rubble_center"
       },
-      {
-        "id": "end_piece",
-        "fg": "t_railroad_track_on_tie_corner_ne",
-        "bg": "t_railroad_rubble_center"
-      },
-      {
-        "id": "unconnected",
-        "fg": "t_railroad_track_on_tie_edge_ns",
-        "bg": "t_railroad_rubble_center"
-      }
+      { "id": "end_piece", "fg": "t_railroad_track_on_tie_corner_ne", "bg": "t_railroad_rubble_center" },
+      { "id": "unconnected", "fg": "t_railroad_track_on_tie_edge_ns", "bg": "t_railroad_rubble_center" }
     ]
   },
   {
@@ -56,18 +41,14 @@
     "bg": "t_railroad_rubble_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_railroad_track_on_tie_corner_ne",
-        "bg": "t_railroad_rubble_center"
-      },
+      { "id": "center", "fg": "t_railroad_track_on_tie_corner_ne", "bg": "t_railroad_rubble_center" },
       {
         "id": "corner",
         "fg": [
           "t_railroad_track_on_tie_corner_nw",
-          "t_railroad_track_on_tie_corner_sw",
+          "t_railroad_track_on_tie_corner_ne",
           "t_railroad_track_on_tie_corner_se",
-          "t_railroad_track_on_tie_corner_ne"
+          "t_railroad_track_on_tie_corner_sw"
         ],
         "bg": "t_railroad_rubble_center"
       },
@@ -75,30 +56,19 @@
         "id": "t_connection",
         "fg": [
           "t_railroad_track_on_tie_corner_nw",
-          "t_railroad_track_on_tie_corner_sw",
-          "t_railroad_track_on_tie_corner_se",
-          "t_railroad_track_on_tie_corner_ne"
-        ],
-        "bg": "t_railroad_rubble_center"
-      },
-      {
-        "id": "edge",
-        "fg": [
           "t_railroad_track_on_tie_corner_ne",
+          "t_railroad_track_on_tie_corner_se",
           "t_railroad_track_on_tie_corner_sw"
         ],
         "bg": "t_railroad_rubble_center"
       },
       {
-        "id": "end_piece",
-        "fg": "t_railroad_track_on_tie_corner_ne",
+        "id": "edge",
+        "fg": [ "t_railroad_track_on_tie_corner_ne", "t_railroad_track_on_tie_corner_sw" ],
         "bg": "t_railroad_rubble_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_railroad_track_on_tie_corner_ne",
-        "bg": "t_railroad_rubble_center"
-      }
+      { "id": "end_piece", "fg": "t_railroad_track_on_tie_corner_ne", "bg": "t_railroad_rubble_center" },
+      { "id": "unconnected", "fg": "t_railroad_track_on_tie_corner_ne", "bg": "t_railroad_rubble_center" }
     ]
   },
   {

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_railroad_track_small/t_railroad_track_small.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_railroad_track_small/t_railroad_track_small.json
@@ -5,18 +5,14 @@
     "bg": "t_railroad_rubble_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_railroad_track_small_center",
-        "bg": "t_railroad_rubble_center"
-      },
+      { "id": "center", "fg": "t_railroad_track_small_center", "bg": "t_railroad_rubble_center" },
       {
         "id": "corner",
         "fg": [
           "t_railroad_track_small_corner_nw",
-          "t_railroad_track_small_corner_sw",
+          "t_railroad_track_small_corner_ne",
           "t_railroad_track_small_corner_se",
-          "t_railroad_track_small_corner_ne"
+          "t_railroad_track_small_corner_sw"
         ],
         "bg": "t_railroad_rubble_center"
       },
@@ -24,18 +20,15 @@
         "id": "t_connection",
         "fg": [
           "t_railroad_track_small_t_connection_n",
-          "t_railroad_track_small_t_connection_w",
+          "t_railroad_track_small_t_connection_e",
           "t_railroad_track_small_t_connection_s",
-          "t_railroad_track_small_t_connection_e"
+          "t_railroad_track_small_t_connection_w"
         ],
         "bg": "t_railroad_rubble_center"
       },
       {
         "id": "edge",
-        "fg": [
-          "t_railroad_track_small_edge_ns",
-          "t_railroad_track_small_edge_ew"
-        ],
+        "fg": [ "t_railroad_track_small_edge_ns", "t_railroad_track_small_edge_ew" ],
         "bg": "t_railroad_rubble_center"
       },
       {
@@ -48,11 +41,7 @@
         ],
         "bg": "t_railroad_rubble_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_railroad_track_small_edge_ns",
-        "bg": "t_railroad_rubble_center"
-      }
+      { "id": "unconnected", "fg": "t_railroad_track_small_edge_ns", "bg": "t_railroad_rubble_center" }
     ]
   },
   {
@@ -61,18 +50,14 @@
     "bg": "t_railroad_rubble_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_railroad_track_small_d_corner_ne",
-        "bg": "t_railroad_rubble_center"
-      },
+      { "id": "center", "fg": "t_railroad_track_small_d_corner_ne", "bg": "t_railroad_rubble_center" },
       {
         "id": "corner",
         "fg": [
           "t_railroad_track_small_d_corner_nw",
-          "t_railroad_track_small_d_corner_sw",
+          "t_railroad_track_small_d_corner_ne",
           "t_railroad_track_small_d_corner_se",
-          "t_railroad_track_small_d_corner_ne"
+          "t_railroad_track_small_d_corner_sw"
         ],
         "bg": "t_railroad_rubble_center"
       },
@@ -80,30 +65,19 @@
         "id": "t_connection",
         "fg": [
           "t_railroad_track_small_d_corner_nw",
-          "t_railroad_track_small_d_corner_sw",
+          "t_railroad_track_small_d_corner_ne",
           "t_railroad_track_small_d_corner_se",
-          "t_railroad_track_small_d_corner_ne"
+          "t_railroad_track_small_d_corner_sw"
         ],
         "bg": "t_railroad_rubble_center"
       },
       {
         "id": "edge",
-        "fg": [
-          "t_railroad_track_small_edge_ns",
-          "t_railroad_track_small_edge_ew"
-        ],
+        "fg": [ "t_railroad_track_small_edge_ns", "t_railroad_track_small_edge_ew" ],
         "bg": "t_railroad_rubble_center"
       },
-      {
-        "id": "end_piece",
-        "fg": "t_railroad_track_small_d_corner_ne",
-        "bg": "t_railroad_rubble_center"
-      },
-      {
-        "id": "unconnected",
-        "fg": "t_railroad_track_small_d_corner_ne",
-        "bg": "t_railroad_rubble_center"
-      }
+      { "id": "end_piece", "fg": "t_railroad_track_small_d_corner_ne", "bg": "t_railroad_rubble_center" },
+      { "id": "unconnected", "fg": "t_railroad_track_small_d_corner_ne", "bg": "t_railroad_rubble_center" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_reb_cage/t_reb_cage.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_reb_cage/t_reb_cage.json
@@ -4,53 +4,23 @@
   "bg": "t_thconc_floor_center",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_reb_cage_center",
-      "bg": "t_thconc_floor_center"
-    },
+    { "id": "center", "fg": "t_reb_cage_center", "bg": "t_thconc_floor_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_reb_cage_corner_nw",
-        "t_reb_cage_corner_sw",
-        "t_reb_cage_corner_se",
-        "t_reb_cage_corner_ne"
-      ],
+      "fg": [ "t_reb_cage_corner_nw", "t_reb_cage_corner_ne", "t_reb_cage_corner_se", "t_reb_cage_corner_sw" ],
       "bg": "t_thconc_floor_center"
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_reb_cage_t_connection_n",
-        "t_reb_cage_t_connection_w",
-        "t_reb_cage_t_connection_s",
-        "t_reb_cage_t_connection_e"
-      ],
+      "fg": [ "t_reb_cage_t_connection_n", "t_reb_cage_t_connection_e", "t_reb_cage_t_connection_s", "t_reb_cage_t_connection_w" ],
       "bg": "t_thconc_floor_center"
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_reb_cage_edge_ns",
-        "t_reb_cage_edge_ew"
-      ],
-      "bg": "t_thconc_floor_center"
-    },
+    { "id": "edge", "fg": [ "t_reb_cage_edge_ns", "t_reb_cage_edge_ew" ], "bg": "t_thconc_floor_center" },
     {
       "id": "end_piece",
-      "fg": [
-        "t_reb_cage_end_piece_n",
-        "t_reb_cage_end_piece_w",
-        "t_reb_cage_end_piece_s",
-        "t_reb_cage_end_piece_e"
-      ],
+      "fg": [ "t_reb_cage_end_piece_n", "t_reb_cage_end_piece_e", "t_reb_cage_end_piece_s", "t_reb_cage_end_piece_w" ],
       "bg": "t_thconc_floor_center"
     },
-    {
-      "id": "unconnected",
-      "fg": "t_reb_cage_unconnected",
-      "bg": "t_thconc_floor_center"
-    }
+    { "id": "unconnected", "fg": "t_reb_cage_unconnected", "bg": "t_thconc_floor_center" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_reinforced_glass/t_reinforced_glass.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_reinforced_glass/t_reinforced_glass.json
@@ -4,19 +4,15 @@
   "fg": "t_reinforced_glass_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_reinforced_glass_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_reinforced_glass_center" },
     {
       "id": "corner",
       "bg": "",
       "fg": [
         "t_reinforced_glass_corner_nw",
-        "t_reinforced_glass_corner_sw",
+        "t_reinforced_glass_corner_ne",
         "t_reinforced_glass_corner_se",
-        "t_reinforced_glass_corner_ne"
+        "t_reinforced_glass_corner_sw"
       ]
     },
     {
@@ -24,33 +20,22 @@
       "bg": "",
       "fg": [
         "t_reinforced_glass_t_connection_n",
-        "t_reinforced_glass_t_connection_w",
+        "t_reinforced_glass_t_connection_e",
         "t_reinforced_glass_t_connection_s",
-        "t_reinforced_glass_t_connection_e"
+        "t_reinforced_glass_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_reinforced_glass_edge_ns",
-        "t_reinforced_glass_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_reinforced_glass_edge_ns", "t_reinforced_glass_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "t_reinforced_glass_end_piece_n",
-        "t_reinforced_glass_end_piece_w",
+        "t_reinforced_glass_end_piece_e",
         "t_reinforced_glass_end_piece_s",
-        "t_reinforced_glass_end_piece_e"
+        "t_reinforced_glass_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_reinforced_glass_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_reinforced_glass_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock/t_rock.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock/t_rock.json
@@ -4,53 +4,23 @@
   "fg": "t_rock_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_rock_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_rock_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_rock_corner_nw",
-        "t_rock_corner_sw",
-        "t_rock_corner_se",
-        "t_rock_corner_ne"
-      ]
+      "fg": [ "t_rock_corner_nw", "t_rock_corner_ne", "t_rock_corner_se", "t_rock_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "t_rock_t_connection_n",
-        "t_rock_t_connection_w",
-        "t_rock_t_connection_s",
-        "t_rock_t_connection_e"
-      ]
+      "fg": [ "t_rock_t_connection_n", "t_rock_t_connection_e", "t_rock_t_connection_s", "t_rock_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_rock_edge_ns",
-        "t_rock_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_rock_edge_ns", "t_rock_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_rock_end_piece_n",
-        "t_rock_end_piece_w",
-        "t_rock_end_piece_s",
-        "t_rock_end_piece_e"
-      ]
+      "fg": [ "t_rock_end_piece_n", "t_rock_end_piece_e", "t_rock_end_piece_s", "t_rock_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_rock_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_rock_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock_blue/t_rock_blue.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock_blue/t_rock_blue.json
@@ -3,47 +3,25 @@
   "fg": "t_rock_blue_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_rock_blue_center"
-    },
+    { "id": "center", "fg": "t_rock_blue_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_rock_blue_corner_nw",
-        "t_rock_blue_corner_sw",
-        "t_rock_blue_corner_se",
-        "t_rock_blue_corner_ne"
-      ]
+      "fg": [ "t_rock_blue_corner_nw", "t_rock_blue_corner_ne", "t_rock_blue_corner_se", "t_rock_blue_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_rock_blue_t_connection_n",
-        "t_rock_blue_t_connection_w",
+        "t_rock_blue_t_connection_e",
         "t_rock_blue_t_connection_s",
-        "t_rock_blue_t_connection_e"
+        "t_rock_blue_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_rock_blue_edge_ns",
-        "t_rock_blue_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_rock_blue_edge_ns", "t_rock_blue_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_rock_blue_end_piece_n",
-        "t_rock_blue_end_piece_w",
-        "t_rock_blue_end_piece_s",
-        "t_rock_blue_end_piece_e"
-      ]
+      "fg": [ "t_rock_blue_end_piece_n", "t_rock_blue_end_piece_e", "t_rock_blue_end_piece_s", "t_rock_blue_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_rock_blue_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_rock_blue_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock_floor/t_rock_floor.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock_floor/t_rock_floor.json
@@ -16,45 +16,24 @@
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_rock_floor_corner_nw",
-        "t_rock_floor_corner_sw",
-        "t_rock_floor_corner_se",
-        "t_rock_floor_corner_ne"
-      ]
+      "fg": [ "t_rock_floor_corner_nw", "t_rock_floor_corner_ne", "t_rock_floor_corner_se", "t_rock_floor_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_rock_floor_t_connection_n",
-        "t_rock_floor_t_connection_w",
+        "t_rock_floor_t_connection_e",
         "t_rock_floor_t_connection_s",
-        "t_rock_floor_t_connection_e"
+        "t_rock_floor_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_rock_floor_edge_ns",
-        "t_rock_floor_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_rock_floor_edge_ns", "t_rock_floor_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_rock_floor_end_piece_n",
-        "t_rock_floor_end_piece_w",
-        "t_rock_floor_end_piece_s",
-        "t_rock_floor_end_piece_e"
-      ]
+      "fg": [ "t_rock_floor_end_piece_n", "t_rock_floor_end_piece_e", "t_rock_floor_end_piece_s", "t_rock_floor_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_rock_floor_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_rock_floor_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock_green/t_rock_green.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock_green/t_rock_green.json
@@ -3,47 +3,25 @@
   "fg": "t_rock_green_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_rock_green_center"
-    },
+    { "id": "center", "fg": "t_rock_green_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_rock_green_corner_nw",
-        "t_rock_green_corner_sw",
-        "t_rock_green_corner_se",
-        "t_rock_green_corner_ne"
-      ]
+      "fg": [ "t_rock_green_corner_nw", "t_rock_green_corner_ne", "t_rock_green_corner_se", "t_rock_green_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_rock_green_t_connection_n",
-        "t_rock_green_t_connection_w",
+        "t_rock_green_t_connection_e",
         "t_rock_green_t_connection_s",
-        "t_rock_green_t_connection_e"
+        "t_rock_green_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_rock_green_edge_ns",
-        "t_rock_green_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_rock_green_edge_ns", "t_rock_green_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_rock_green_end_piece_n",
-        "t_rock_green_end_piece_w",
-        "t_rock_green_end_piece_s",
-        "t_rock_green_end_piece_e"
-      ]
+      "fg": [ "t_rock_green_end_piece_n", "t_rock_green_end_piece_e", "t_rock_green_end_piece_s", "t_rock_green_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_rock_green_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_rock_green_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock_red/t_rock_red.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock_red/t_rock_red.json
@@ -3,47 +3,20 @@
   "fg": "t_rock_red_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_rock_red_center"
-    },
+    { "id": "center", "fg": "t_rock_red_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_rock_red_corner_nw",
-        "t_rock_red_corner_sw",
-        "t_rock_red_corner_se",
-        "t_rock_red_corner_ne"
-      ]
+      "fg": [ "t_rock_red_corner_nw", "t_rock_red_corner_ne", "t_rock_red_corner_se", "t_rock_red_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_rock_red_t_connection_n",
-        "t_rock_red_t_connection_w",
-        "t_rock_red_t_connection_s",
-        "t_rock_red_t_connection_e"
-      ]
+      "fg": [ "t_rock_red_t_connection_n", "t_rock_red_t_connection_e", "t_rock_red_t_connection_s", "t_rock_red_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_rock_red_edge_ns",
-        "t_rock_red_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_rock_red_edge_ns", "t_rock_red_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_rock_red_end_piece_n",
-        "t_rock_red_end_piece_w",
-        "t_rock_red_end_piece_s",
-        "t_rock_red_end_piece_e"
-      ]
+      "fg": [ "t_rock_red_end_piece_n", "t_rock_red_end_piece_e", "t_rock_red_end_piece_s", "t_rock_red_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_rock_red_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_rock_red_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock_wall/t_rock_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock_wall/t_rock_wall.json
@@ -4,53 +4,28 @@
   "fg": "t_rock_wall_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_rock_wall_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_rock_wall_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_rock_wall_corner_nw",
-        "t_rock_wall_corner_sw",
-        "t_rock_wall_corner_se",
-        "t_rock_wall_corner_ne"
-      ]
+      "fg": [ "t_rock_wall_corner_nw", "t_rock_wall_corner_ne", "t_rock_wall_corner_se", "t_rock_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_rock_wall_t_connection_n",
-        "t_rock_wall_t_connection_w",
+        "t_rock_wall_t_connection_e",
         "t_rock_wall_t_connection_s",
-        "t_rock_wall_t_connection_e"
+        "t_rock_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_rock_wall_edge_ns",
-        "t_rock_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_rock_wall_edge_ns", "t_rock_wall_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_rock_wall_end_piece_n",
-        "t_rock_wall_end_piece_w",
-        "t_rock_wall_end_piece_s",
-        "t_rock_wall_end_piece_e"
-      ]
+      "fg": [ "t_rock_wall_end_piece_n", "t_rock_wall_end_piece_e", "t_rock_wall_end_piece_s", "t_rock_wall_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_rock_wall_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_rock_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock_wall_half/t_rock_wall_half.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_rock_wall_half/t_rock_wall_half.json
@@ -1,49 +1,40 @@
 {
-  "id": [ "t_rock_wall_half", "t_drystone_wall_half" ],
+  "id": [
+    "t_rock_wall_half",
+    "t_drystone_wall_half"
+  ],
   "fg": "t_rock_wall_half_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_rock_wall_half_center"
-    },
+    { "id": "center", "fg": "t_rock_wall_half_center" },
     {
       "id": "corner",
       "fg": [
         "t_rock_wall_half_corner_nw",
-        "t_rock_wall_half_corner_sw",
+        "t_rock_wall_half_corner_ne",
         "t_rock_wall_half_corner_se",
-        "t_rock_wall_half_corner_ne"
+        "t_rock_wall_half_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_rock_wall_half_t_connection_n",
-        "t_rock_wall_half_t_connection_w",
+        "t_rock_wall_half_t_connection_e",
         "t_rock_wall_half_t_connection_s",
-        "t_rock_wall_half_t_connection_e"
+        "t_rock_wall_half_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_rock_wall_half_edge_ns",
-        "t_rock_wall_half_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_rock_wall_half_edge_ns", "t_rock_wall_half_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_rock_wall_half_end_piece_n",
-        "t_rock_wall_half_end_piece_w",
+        "t_rock_wall_half_end_piece_e",
         "t_rock_wall_half_end_piece_s",
-        "t_rock_wall_half_end_piece_e"
+        "t_rock_wall_half_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_rock_wall_half_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_rock_wall_half_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sand/t_sand.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sand/t_sand.json
@@ -6,30 +6,30 @@
     "bg": "t_grass",
     "additional_tiles": [
       {
-          "id": "center",
-          "bg": "t_grass",
-          "fg": [
-            { "weight": 1, "sprite": "t_sand_center" },
-            { "weight": 1, "sprite": "t_sand_center2" },
-            { "weight": 1, "sprite": "t_sand_center3" },
-            { "weight": 1, "sprite": "t_sand_center4" }
-          ]
+        "id": "center",
+        "bg": "t_grass",
+        "fg": [
+          { "weight": 1, "sprite": "t_sand_center" },
+          { "weight": 1, "sprite": "t_sand_center2" },
+          { "weight": 1, "sprite": "t_sand_center3" },
+          { "weight": 1, "sprite": "t_sand_center4" }
+        ]
       },
       {
         "id": "corner",
         "bg": "t_grass",
-        "fg": [ "t_sand_corner_nw", "t_sand_corner_sw", "t_sand_corner_se", "t_sand_corner_ne" ]
+        "fg": [ "t_sand_corner_nw", "t_sand_corner_ne", "t_sand_corner_se", "t_sand_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass",
-        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_w", "t_sand_t_connection_s", "t_sand_t_connection_e" ]
+        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_e", "t_sand_t_connection_s", "t_sand_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_grass", "fg": [ "t_sand_edge_ns", "t_sand_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass",
-        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_w", "t_sand_end_piece_s", "t_sand_end_piece_e" ]
+        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_e", "t_sand_end_piece_s", "t_sand_end_piece_w" ]
       },
       { "bg": "t_grass", "id": "unconnected", "fg": "t_sand_unconnected" }
     ]
@@ -41,28 +41,25 @@
     "bg": "t_grass_summer",
     "additional_tiles": [
       {
-          "id": "center",
-          "bg": "t_grass_summer",
-          "fg": [
-            { "weight": 1, "sprite": "t_sand_center" },
-            { "weight": 1, "sprite": "t_sand_center2" }
-          ]
+        "id": "center",
+        "bg": "t_grass_summer",
+        "fg": [ { "weight": 1, "sprite": "t_sand_center" }, { "weight": 1, "sprite": "t_sand_center2" } ]
       },
       {
         "id": "corner",
         "bg": "t_grass_summer",
-        "fg": [ "t_sand_corner_nw", "t_sand_corner_sw", "t_sand_corner_se", "t_sand_corner_ne" ]
+        "fg": [ "t_sand_corner_nw", "t_sand_corner_ne", "t_sand_corner_se", "t_sand_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_summer",
-        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_w", "t_sand_t_connection_s", "t_sand_t_connection_e" ]
+        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_e", "t_sand_t_connection_s", "t_sand_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_grass_summer", "fg": [ "t_sand_edge_ns", "t_sand_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_summer",
-        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_w", "t_sand_end_piece_s", "t_sand_end_piece_e" ]
+        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_e", "t_sand_end_piece_s", "t_sand_end_piece_w" ]
       },
       { "bg": "t_grass_summer", "id": "unconnected", "fg": "t_sand_unconnected" }
     ]
@@ -74,28 +71,25 @@
     "bg": "t_grass_autumn",
     "additional_tiles": [
       {
-          "id": "center",
-          "bg": "t_grass_autumn",
-          "fg": [
-            { "weight": 1, "sprite": "t_sand_center" },
-            { "weight": 1, "sprite": "t_sand_center2" }
-          ]
+        "id": "center",
+        "bg": "t_grass_autumn",
+        "fg": [ { "weight": 1, "sprite": "t_sand_center" }, { "weight": 1, "sprite": "t_sand_center2" } ]
       },
       {
         "id": "corner",
         "bg": "t_grass_autumn",
-        "fg": [ "t_sand_corner_nw", "t_sand_corner_sw", "t_sand_corner_se", "t_sand_corner_ne" ]
+        "fg": [ "t_sand_corner_nw", "t_sand_corner_ne", "t_sand_corner_se", "t_sand_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_autumn",
-        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_w", "t_sand_t_connection_s", "t_sand_t_connection_e" ]
+        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_e", "t_sand_t_connection_s", "t_sand_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_grass_autumn", "fg": [ "t_sand_edge_ns", "t_sand_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_autumn",
-        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_w", "t_sand_end_piece_s", "t_sand_end_piece_e" ]
+        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_e", "t_sand_end_piece_s", "t_sand_end_piece_w" ]
       },
       { "bg": "t_grass_autumn", "id": "unconnected", "fg": "t_sand_unconnected" }
     ]
@@ -107,28 +101,25 @@
     "bg": "snow_shallow_center",
     "additional_tiles": [
       {
-          "id": "center",
-          "bg": "snow_shallow_center",
-          "fg": [
-            { "weight": 1, "sprite": "t_sand_center" },
-            { "weight": 1, "sprite": "t_sand_center2" }
-          ]
+        "id": "center",
+        "bg": "snow_shallow_center",
+        "fg": [ { "weight": 1, "sprite": "t_sand_center" }, { "weight": 1, "sprite": "t_sand_center2" } ]
       },
       {
         "id": "corner",
         "bg": "snow_shallow_center",
-        "fg": [ "t_sand_corner_nw", "t_sand_corner_sw", "t_sand_corner_se", "t_sand_corner_ne" ]
+        "fg": [ "t_sand_corner_nw", "t_sand_corner_ne", "t_sand_corner_se", "t_sand_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "snow_shallow_center",
-        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_w", "t_sand_t_connection_s", "t_sand_t_connection_e" ]
+        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_e", "t_sand_t_connection_s", "t_sand_t_connection_w" ]
       },
       { "id": "edge", "bg": "snow_shallow_center", "fg": [ "t_sand_edge_ns", "t_sand_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "snow_shallow_center",
-        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_w", "t_sand_end_piece_s", "t_sand_end_piece_e" ]
+        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_e", "t_sand_end_piece_s", "t_sand_end_piece_w" ]
       },
       { "bg": "snow_shallow_center", "id": "unconnected", "fg": "t_sand_unconnected" }
     ]
@@ -140,30 +131,30 @@
     "bg": "t_rock_floor_center",
     "additional_tiles": [
       {
-          "id": "center",
-          "bg": "t_rock_floor_center",
-          "fg": [
-            { "weight": 1, "sprite": "t_sand_center" },
-            { "weight": 1, "sprite": "t_sand_center2" },
-            { "weight": 1, "sprite": "t_sand_center3" },
-            { "weight": 1, "sprite": "t_sand_center4" }
-          ]
+        "id": "center",
+        "bg": "t_rock_floor_center",
+        "fg": [
+          { "weight": 1, "sprite": "t_sand_center" },
+          { "weight": 1, "sprite": "t_sand_center2" },
+          { "weight": 1, "sprite": "t_sand_center3" },
+          { "weight": 1, "sprite": "t_sand_center4" }
+        ]
       },
       {
         "id": "corner",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_sand_corner_nw", "t_sand_corner_sw", "t_sand_corner_se", "t_sand_corner_ne" ]
+        "fg": [ "t_sand_corner_nw", "t_sand_corner_ne", "t_sand_corner_se", "t_sand_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_w", "t_sand_t_connection_s", "t_sand_t_connection_e" ]
+        "fg": [ "t_sand_t_connection_n", "t_sand_t_connection_e", "t_sand_t_connection_s", "t_sand_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_rock_floor_center", "fg": [ "t_sand_edge_ns", "t_sand_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_w", "t_sand_end_piece_s", "t_sand_end_piece_e" ]
+        "fg": [ "t_sand_end_piece_n", "t_sand_end_piece_e", "t_sand_end_piece_s", "t_sand_end_piece_w" ]
       },
       { "bg": "t_rock_floor_center", "id": "unconnected", "fg": "t_sand_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall/t_sconc_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall/t_sconc_wall.json
@@ -3,47 +3,25 @@
   "multitile": true,
   "fg": "t_sconc_wall_unconnected",
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_sconc_wall_corner_nw",
-        "t_sconc_wall_corner_sw",
-        "t_sconc_wall_corner_se",
-        "t_sconc_wall_corner_ne"
-      ]
+      "fg": [ "t_sconc_wall_corner_nw", "t_sconc_wall_corner_ne", "t_sconc_wall_corner_se", "t_sconc_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_t_connection_n",
-        "t_sconc_wall_t_connection_w",
+        "t_sconc_wall_t_connection_e",
         "t_sconc_wall_t_connection_s",
-        "t_sconc_wall_t_connection_e"
+        "t_sconc_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_edge_ns",
-        "t_sconc_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_edge_ns", "t_sconc_wall_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_sconc_wall_end_piece_n",
-        "t_sconc_wall_end_piece_w",
-        "t_sconc_wall_end_piece_s",
-        "t_sconc_wall_end_piece_e"
-      ]
+      "fg": [ "t_sconc_wall_end_piece_n", "t_sconc_wall_end_piece_e", "t_sconc_wall_end_piece_s", "t_sconc_wall_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_Pi/t_sconc_wall_Pi.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_Pi/t_sconc_wall_Pi.json
@@ -3,47 +3,30 @@
   "fg": "t_sconc_wall_Pi_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_Pi_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_Pi_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_sconc_wall_Pi_corner_nw",
-        "t_sconc_wall_Pi_corner_sw",
-        "t_sconc_wall_Pi_corner_se",
-        "t_sconc_wall_Pi_corner_ne"
-      ]
+      "fg": [ "t_sconc_wall_Pi_corner_nw", "t_sconc_wall_Pi_corner_ne", "t_sconc_wall_Pi_corner_se", "t_sconc_wall_Pi_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_Pi_t_connection_n",
-        "t_sconc_wall_Pi_t_connection_w",
+        "t_sconc_wall_Pi_t_connection_e",
         "t_sconc_wall_Pi_t_connection_s",
-        "t_sconc_wall_Pi_t_connection_e"
+        "t_sconc_wall_Pi_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_Pi_edge_ns",
-        "t_sconc_wall_Pi_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_Pi_edge_ns", "t_sconc_wall_Pi_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_sconc_wall_Pi_end_piece_n",
-        "t_sconc_wall_Pi_end_piece_w",
+        "t_sconc_wall_Pi_end_piece_e",
         "t_sconc_wall_Pi_end_piece_s",
-        "t_sconc_wall_Pi_end_piece_e"
+        "t_sconc_wall_Pi_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_Pi_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_Pi_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_b/t_sconc_wall_b.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_b/t_sconc_wall_b.json
@@ -3,47 +3,30 @@
   "fg": "t_sconc_wall_b_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_b_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_b_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_sconc_wall_b_corner_nw",
-        "t_sconc_wall_b_corner_sw",
-        "t_sconc_wall_b_corner_se",
-        "t_sconc_wall_b_corner_ne"
-      ]
+      "fg": [ "t_sconc_wall_b_corner_nw", "t_sconc_wall_b_corner_ne", "t_sconc_wall_b_corner_se", "t_sconc_wall_b_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_b_t_connection_n",
-        "t_sconc_wall_b_t_connection_w",
+        "t_sconc_wall_b_t_connection_e",
         "t_sconc_wall_b_t_connection_s",
-        "t_sconc_wall_b_t_connection_e"
+        "t_sconc_wall_b_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_b_edge_ns",
-        "t_sconc_wall_b_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_b_edge_ns", "t_sconc_wall_b_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_sconc_wall_b_end_piece_n",
-        "t_sconc_wall_b_end_piece_w",
+        "t_sconc_wall_b_end_piece_e",
         "t_sconc_wall_b_end_piece_s",
-        "t_sconc_wall_b_end_piece_e"
+        "t_sconc_wall_b_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_b_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_b_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_b/t_sconc_wall_cyan.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_b/t_sconc_wall_cyan.json
@@ -3,47 +3,35 @@
   "fg": "t_sconc_wall_cyan_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_cyan_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_cyan_center" },
     {
       "id": "corner",
       "fg": [
         "t_sconc_wall_cyan_corner_nw",
-        "t_sconc_wall_cyan_corner_sw",
+        "t_sconc_wall_cyan_corner_ne",
         "t_sconc_wall_cyan_corner_se",
-        "t_sconc_wall_cyan_corner_ne"
+        "t_sconc_wall_cyan_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_cyan_t_connection_n",
-        "t_sconc_wall_cyan_t_connection_w",
+        "t_sconc_wall_cyan_t_connection_e",
         "t_sconc_wall_cyan_t_connection_s",
-        "t_sconc_wall_cyan_t_connection_e"
+        "t_sconc_wall_cyan_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_cyan_edge_ns",
-        "t_sconc_wall_cyan_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_cyan_edge_ns", "t_sconc_wall_cyan_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_sconc_wall_cyan_end_piece_n",
-        "t_sconc_wall_cyan_end_piece_w",
+        "t_sconc_wall_cyan_end_piece_e",
         "t_sconc_wall_cyan_end_piece_s",
-        "t_sconc_wall_cyan_end_piece_e"
+        "t_sconc_wall_cyan_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_cyan_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_cyan_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_black/t_sconc_wall_black.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_black/t_sconc_wall_black.json
@@ -3,47 +3,35 @@
   "fg": "t_sconc_wall_black_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_black_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_black_center" },
     {
       "id": "corner",
       "fg": [
         "t_sconc_wall_black_corner_nw",
-        "t_sconc_wall_black_corner_sw",
+        "t_sconc_wall_black_corner_ne",
         "t_sconc_wall_black_corner_se",
-        "t_sconc_wall_black_corner_ne"
+        "t_sconc_wall_black_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_black_t_connection_n",
-        "t_sconc_wall_black_t_connection_w",
+        "t_sconc_wall_black_t_connection_e",
         "t_sconc_wall_black_t_connection_s",
-        "t_sconc_wall_black_t_connection_e"
+        "t_sconc_wall_black_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_black_edge_ns",
-        "t_sconc_wall_black_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_black_edge_ns", "t_sconc_wall_black_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_sconc_wall_black_end_piece_n",
-        "t_sconc_wall_black_end_piece_w",
+        "t_sconc_wall_black_end_piece_e",
         "t_sconc_wall_black_end_piece_s",
-        "t_sconc_wall_black_end_piece_e"
+        "t_sconc_wall_black_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_black_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_black_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_brown/t_sconc_wall_brown.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_brown/t_sconc_wall_brown.json
@@ -3,47 +3,35 @@
   "fg": "t_sconc_wall_brown_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_brown_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_brown_center" },
     {
       "id": "corner",
       "fg": [
         "t_sconc_wall_brown_corner_nw",
-        "t_sconc_wall_brown_corner_sw",
+        "t_sconc_wall_brown_corner_ne",
         "t_sconc_wall_brown_corner_se",
-        "t_sconc_wall_brown_corner_ne"
+        "t_sconc_wall_brown_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_brown_t_connection_n",
-        "t_sconc_wall_brown_t_connection_w",
+        "t_sconc_wall_brown_t_connection_e",
         "t_sconc_wall_brown_t_connection_s",
-        "t_sconc_wall_brown_t_connection_e"
+        "t_sconc_wall_brown_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_brown_edge_ns",
-        "t_sconc_wall_brown_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_brown_edge_ns", "t_sconc_wall_brown_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_sconc_wall_brown_end_piece_n",
-        "t_sconc_wall_brown_end_piece_w",
+        "t_sconc_wall_brown_end_piece_e",
         "t_sconc_wall_brown_end_piece_s",
-        "t_sconc_wall_brown_end_piece_e"
+        "t_sconc_wall_brown_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_brown_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_brown_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_g/t_sconc_wall_g.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_g/t_sconc_wall_g.json
@@ -3,47 +3,30 @@
   "fg": "t_sconc_wall_g_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_g_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_g_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_sconc_wall_g_corner_nw",
-        "t_sconc_wall_g_corner_sw",
-        "t_sconc_wall_g_corner_se",
-        "t_sconc_wall_g_corner_ne"
-      ]
+      "fg": [ "t_sconc_wall_g_corner_nw", "t_sconc_wall_g_corner_ne", "t_sconc_wall_g_corner_se", "t_sconc_wall_g_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_g_t_connection_n",
-        "t_sconc_wall_g_t_connection_w",
+        "t_sconc_wall_g_t_connection_e",
         "t_sconc_wall_g_t_connection_s",
-        "t_sconc_wall_g_t_connection_e"
+        "t_sconc_wall_g_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_g_edge_ns",
-        "t_sconc_wall_g_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_g_edge_ns", "t_sconc_wall_g_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_sconc_wall_g_end_piece_n",
-        "t_sconc_wall_g_end_piece_w",
+        "t_sconc_wall_g_end_piece_e",
         "t_sconc_wall_g_end_piece_s",
-        "t_sconc_wall_g_end_piece_e"
+        "t_sconc_wall_g_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_g_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_g_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_gray/t_sconc_wall_gray.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_gray/t_sconc_wall_gray.json
@@ -3,47 +3,35 @@
   "fg": "t_sconc_wall_gray_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_gray_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_gray_center" },
     {
       "id": "corner",
       "fg": [
         "t_sconc_wall_gray_corner_nw",
-        "t_sconc_wall_gray_corner_sw",
+        "t_sconc_wall_gray_corner_ne",
         "t_sconc_wall_gray_corner_se",
-        "t_sconc_wall_gray_corner_ne"
+        "t_sconc_wall_gray_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_gray_t_connection_n",
-        "t_sconc_wall_gray_t_connection_w",
+        "t_sconc_wall_gray_t_connection_e",
         "t_sconc_wall_gray_t_connection_s",
-        "t_sconc_wall_gray_t_connection_e"
+        "t_sconc_wall_gray_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_gray_edge_ns",
-        "t_sconc_wall_gray_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_gray_edge_ns", "t_sconc_wall_gray_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_sconc_wall_gray_end_piece_n",
-        "t_sconc_wall_gray_end_piece_w",
+        "t_sconc_wall_gray_end_piece_e",
         "t_sconc_wall_gray_end_piece_s",
-        "t_sconc_wall_gray_end_piece_e"
+        "t_sconc_wall_gray_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_gray_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_gray_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_halfway/t_sconc_wall_halfway.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_halfway/t_sconc_wall_halfway.json
@@ -3,47 +3,35 @@
   "fg": "t_sconc_wall_halfway_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_halfway_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_halfway_center" },
     {
       "id": "corner",
       "fg": [
         "t_sconc_wall_halfway_corner_nw",
-        "t_sconc_wall_halfway_corner_sw",
+        "t_sconc_wall_halfway_corner_ne",
         "t_sconc_wall_halfway_corner_se",
-        "t_sconc_wall_halfway_corner_ne"
+        "t_sconc_wall_halfway_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_halfway_t_connection_n",
-        "t_sconc_wall_halfway_t_connection_w",
+        "t_sconc_wall_halfway_t_connection_e",
         "t_sconc_wall_halfway_t_connection_s",
-        "t_sconc_wall_halfway_t_connection_e"
+        "t_sconc_wall_halfway_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_halfway_edge_ns",
-        "t_sconc_wall_halfway_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_halfway_edge_ns", "t_sconc_wall_halfway_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_sconc_wall_halfway_end_piece_n",
-        "t_sconc_wall_halfway_end_piece_w",
+        "t_sconc_wall_halfway_end_piece_e",
         "t_sconc_wall_halfway_end_piece_s",
-        "t_sconc_wall_halfway_end_piece_e"
+        "t_sconc_wall_halfway_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_halfway_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_halfway_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_orange/t_sconc_wall_orange.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_orange/t_sconc_wall_orange.json
@@ -3,47 +3,35 @@
   "fg": "t_sconc_wall_orange_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_orange_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_orange_center" },
     {
       "id": "corner",
       "fg": [
         "t_sconc_wall_orange_corner_nw",
-        "t_sconc_wall_orange_corner_sw",
+        "t_sconc_wall_orange_corner_ne",
         "t_sconc_wall_orange_corner_se",
-        "t_sconc_wall_orange_corner_ne"
+        "t_sconc_wall_orange_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_orange_t_connection_n",
-        "t_sconc_wall_orange_t_connection_w",
+        "t_sconc_wall_orange_t_connection_e",
         "t_sconc_wall_orange_t_connection_s",
-        "t_sconc_wall_orange_t_connection_e"
+        "t_sconc_wall_orange_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_orange_edge_ns",
-        "t_sconc_wall_orange_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_orange_edge_ns", "t_sconc_wall_orange_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_sconc_wall_orange_end_piece_n",
-        "t_sconc_wall_orange_end_piece_w",
+        "t_sconc_wall_orange_end_piece_e",
         "t_sconc_wall_orange_end_piece_s",
-        "t_sconc_wall_orange_end_piece_e"
+        "t_sconc_wall_orange_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_orange_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_orange_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_p/t_sconc_wall_p.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_p/t_sconc_wall_p.json
@@ -3,47 +3,30 @@
   "fg": "t_sconc_wall_p_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_p_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_p_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_sconc_wall_p_corner_nw",
-        "t_sconc_wall_p_corner_sw",
-        "t_sconc_wall_p_corner_se",
-        "t_sconc_wall_p_corner_ne"
-      ]
+      "fg": [ "t_sconc_wall_p_corner_nw", "t_sconc_wall_p_corner_ne", "t_sconc_wall_p_corner_se", "t_sconc_wall_p_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_p_t_connection_n",
-        "t_sconc_wall_p_t_connection_w",
+        "t_sconc_wall_p_t_connection_e",
         "t_sconc_wall_p_t_connection_s",
-        "t_sconc_wall_p_t_connection_e"
+        "t_sconc_wall_p_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_p_edge_ns",
-        "t_sconc_wall_p_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_p_edge_ns", "t_sconc_wall_p_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_sconc_wall_p_end_piece_n",
-        "t_sconc_wall_p_end_piece_w",
+        "t_sconc_wall_p_end_piece_e",
         "t_sconc_wall_p_end_piece_s",
-        "t_sconc_wall_p_end_piece_e"
+        "t_sconc_wall_p_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_p_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_p_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_r/t_sconc_wall_r.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_r/t_sconc_wall_r.json
@@ -3,47 +3,30 @@
   "fg": "t_sconc_wall_r_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_r_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_r_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_sconc_wall_r_corner_nw",
-        "t_sconc_wall_r_corner_sw",
-        "t_sconc_wall_r_corner_se",
-        "t_sconc_wall_r_corner_ne"
-      ]
+      "fg": [ "t_sconc_wall_r_corner_nw", "t_sconc_wall_r_corner_ne", "t_sconc_wall_r_corner_se", "t_sconc_wall_r_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_r_t_connection_n",
-        "t_sconc_wall_r_t_connection_w",
+        "t_sconc_wall_r_t_connection_e",
         "t_sconc_wall_r_t_connection_s",
-        "t_sconc_wall_r_t_connection_e"
+        "t_sconc_wall_r_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_r_edge_ns",
-        "t_sconc_wall_r_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_r_edge_ns", "t_sconc_wall_r_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_sconc_wall_r_end_piece_n",
-        "t_sconc_wall_r_end_piece_w",
+        "t_sconc_wall_r_end_piece_e",
         "t_sconc_wall_r_end_piece_s",
-        "t_sconc_wall_r_end_piece_e"
+        "t_sconc_wall_r_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_r_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_r_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_w/t_sconc_wall_w.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_w/t_sconc_wall_w.json
@@ -3,47 +3,30 @@
   "fg": "t_sconc_wall_w_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_w_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_w_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_sconc_wall_w_corner_nw",
-        "t_sconc_wall_w_corner_sw",
-        "t_sconc_wall_w_corner_se",
-        "t_sconc_wall_w_corner_ne"
-      ]
+      "fg": [ "t_sconc_wall_w_corner_nw", "t_sconc_wall_w_corner_ne", "t_sconc_wall_w_corner_se", "t_sconc_wall_w_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_w_t_connection_n",
-        "t_sconc_wall_w_t_connection_w",
+        "t_sconc_wall_w_t_connection_e",
         "t_sconc_wall_w_t_connection_s",
-        "t_sconc_wall_w_t_connection_e"
+        "t_sconc_wall_w_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_w_edge_ns",
-        "t_sconc_wall_w_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_w_edge_ns", "t_sconc_wall_w_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_sconc_wall_w_end_piece_n",
-        "t_sconc_wall_w_end_piece_w",
+        "t_sconc_wall_w_end_piece_e",
         "t_sconc_wall_w_end_piece_s",
-        "t_sconc_wall_w_end_piece_e"
+        "t_sconc_wall_w_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_w_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_w_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_y/t_sconc_wall_y.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sconc_wall_y/t_sconc_wall_y.json
@@ -3,47 +3,30 @@
   "fg": "t_sconc_wall_y_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_sconc_wall_y_center"
-    },
+    { "id": "center", "fg": "t_sconc_wall_y_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_sconc_wall_y_corner_nw",
-        "t_sconc_wall_y_corner_sw",
-        "t_sconc_wall_y_corner_se",
-        "t_sconc_wall_y_corner_ne"
-      ]
+      "fg": [ "t_sconc_wall_y_corner_nw", "t_sconc_wall_y_corner_ne", "t_sconc_wall_y_corner_se", "t_sconc_wall_y_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_sconc_wall_y_t_connection_n",
-        "t_sconc_wall_y_t_connection_w",
+        "t_sconc_wall_y_t_connection_e",
         "t_sconc_wall_y_t_connection_s",
-        "t_sconc_wall_y_t_connection_e"
+        "t_sconc_wall_y_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_sconc_wall_y_edge_ns",
-        "t_sconc_wall_y_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_sconc_wall_y_edge_ns", "t_sconc_wall_y_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_sconc_wall_y_end_piece_n",
-        "t_sconc_wall_y_end_piece_w",
+        "t_sconc_wall_y_end_piece_e",
         "t_sconc_wall_y_end_piece_s",
-        "t_sconc_wall_y_end_piece_e"
+        "t_sconc_wall_y_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_sconc_wall_y_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_sconc_wall_y_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_scrap_floor/t_floor_scrap.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_scrap_floor/t_floor_scrap.json
@@ -15,11 +15,11 @@
       "fg": [
         {
           "weight": 1,
-          "sprite": [ "t_scrap_floor_corner_nw_1", "t_scrap_floor_corner_sw_1", "t_scrap_floor_corner_ne_1", "t_scrap_floor_corner_se_1" ]
+          "sprite": [ "t_scrap_floor_corner_nw_1", "t_scrap_floor_corner_se_1", "t_scrap_floor_corner_ne_1", "t_scrap_floor_corner_sw_1" ]
         },
         {
           "weight": 1,
-          "sprite": [ "t_scrap_floor_corner_nw_2", "t_scrap_floor_corner_sw_2", "t_scrap_floor_corner_ne_2", "t_scrap_floor_corner_se_2" ]
+          "sprite": [ "t_scrap_floor_corner_nw_2", "t_scrap_floor_corner_se_2", "t_scrap_floor_corner_ne_2", "t_scrap_floor_corner_sw_2" ]
         }
       ]
     },
@@ -31,18 +31,18 @@
           "weight": 1,
           "sprite": [
             "t_scrap_floor_t_connection_n_1",
-            "t_scrap_floor_t_connection_w_1",
+            "t_scrap_floor_t_connection_e_1",
             "t_scrap_floor_t_connection_s_1",
-            "t_scrap_floor_t_connection_e_1"
+            "t_scrap_floor_t_connection_w_1"
           ]
         },
         {
           "weight": 1,
           "sprite": [
             "t_scrap_floor_t_connection_n_2",
-            "t_scrap_floor_t_connection_w_2",
+            "t_scrap_floor_t_connection_e_2",
             "t_scrap_floor_t_connection_s_2",
-            "t_scrap_floor_t_connection_e_2"
+            "t_scrap_floor_t_connection_w_2"
           ]
         }
       ]
@@ -63,18 +63,18 @@
           "weight": 1,
           "sprite": [
             "t_scrap_floor_end_piece_n_1",
-            "t_scrap_floor_end_piece_w_1",
+            "t_scrap_floor_end_piece_e_1",
             "t_scrap_floor_end_piece_s_1",
-            "t_scrap_floor_end_piece_e_1"
+            "t_scrap_floor_end_piece_w_1"
           ]
         },
         {
           "weight": 1,
           "sprite": [
             "t_scrap_floor_end_piece_n_2",
-            "t_scrap_floor_end_piece_w_2",
+            "t_scrap_floor_end_piece_e_2",
             "t_scrap_floor_end_piece_s_2",
-            "t_scrap_floor_end_piece_e_2"
+            "t_scrap_floor_end_piece_w_2"
           ]
         }
       ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_scrap_wall/t_scrap_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_scrap_wall/t_scrap_wall.json
@@ -4,53 +4,28 @@
   "fg": "f_scrap_wall_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_scrap_wall_center"
-    },
+    { "id": "center", "bg": "", "fg": "f_scrap_wall_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_scrap_wall_corner_nw",
-        "f_scrap_wall_corner_sw",
-        "f_scrap_wall_corner_se",
-        "f_scrap_wall_corner_ne"
-      ]
+      "fg": [ "f_scrap_wall_corner_nw", "f_scrap_wall_corner_ne", "f_scrap_wall_corner_se", "f_scrap_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "f_scrap_wall_t_connection_n",
-        "f_scrap_wall_t_connection_w",
+        "f_scrap_wall_t_connection_e",
         "f_scrap_wall_t_connection_s",
-        "f_scrap_wall_t_connection_e"
+        "f_scrap_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_scrap_wall_edge_ns",
-        "f_scrap_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_scrap_wall_edge_ns", "f_scrap_wall_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_scrap_wall_end_piece_n",
-        "f_scrap_wall_end_piece_w",
-        "f_scrap_wall_end_piece_s",
-        "f_scrap_wall_end_piece_e"
-      ]
+      "fg": [ "f_scrap_wall_end_piece_n", "f_scrap_wall_end_piece_e", "f_scrap_wall_end_piece_s", "f_scrap_wall_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "f_scrap_wall_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "f_scrap_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_scrap_wall_halfway/t_scrap_wall_halfway.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_scrap_wall_halfway/t_scrap_wall_halfway.json
@@ -4,71 +4,52 @@
   "bg": "t_scrap_floor_unconnected_2",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_scrap_wall_halfway_t_connection_n",
-      "bg": "t_scrap_floor_center_2"
-    },
+    { "id": "center", "fg": "t_scrap_wall_halfway_t_connection_n", "bg": "t_scrap_floor_center_2" },
     {
       "id": "corner",
       "fg": [
         "t_scrap_wall_halfway_corner_nw",
-        "t_scrap_wall_halfway_corner_sw",
+        "t_scrap_wall_halfway_corner_ne",
         "t_scrap_wall_halfway_corner_se",
-        "t_scrap_wall_halfway_corner_ne"
+        "t_scrap_wall_halfway_corner_sw"
       ],
-      "bg": [
-        "t_scrap_floor_corner_nw_2",
-        "t_scrap_floor_corner_sw_2",
-        "t_scrap_floor_corner_se_2",
-        "t_scrap_floor_corner_ne_2"
-      ]
+      "bg": [ "t_scrap_floor_corner_nw_2", "t_scrap_floor_corner_ne_2", "t_scrap_floor_corner_se_2", "t_scrap_floor_corner_sw_2" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_scrap_wall_halfway_t_connection_n",
-        "t_scrap_wall_halfway_t_connection_w",
+        "t_scrap_wall_halfway_t_connection_e",
         "t_scrap_wall_halfway_t_connection_s",
-        "t_scrap_wall_halfway_t_connection_e"
+        "t_scrap_wall_halfway_t_connection_w"
       ],
       "bg": [
         "t_scrap_floor_t_connection_n_2",
-        "t_scrap_floor_t_connection_w_2",
+        "t_scrap_floor_t_connection_e_2",
         "t_scrap_floor_t_connection_s_2",
-        "t_scrap_floor_t_connection_e_2"
+        "t_scrap_floor_t_connection_w_2"
       ]
     },
     {
       "id": "edge",
-      "fg": [
-        "t_scrap_wall_halfway_edge_ns",
-        "t_scrap_wall_halfway_edge_ew"
-      ],
-      "bg": [
-        "t_scrap_floor_edge_ns_2",
-        "t_scrap_floor_edge_ew_2"
-      ]
+      "fg": [ "t_scrap_wall_halfway_edge_ns", "t_scrap_wall_halfway_edge_ew" ],
+      "bg": [ "t_scrap_floor_edge_ns_2", "t_scrap_floor_edge_ew_2" ]
     },
     {
       "id": "end_piece",
       "fg": [
         "t_scrap_wall_halfway_end_piece_n",
-        "t_scrap_wall_halfway_end_piece_w",
+        "t_scrap_wall_halfway_end_piece_e",
         "t_scrap_wall_halfway_end_piece_s",
-        "t_scrap_wall_halfway_end_piece_e"
+        "t_scrap_wall_halfway_end_piece_w"
       ],
       "bg": [
         "t_scrap_floor_end_piece_n_2",
-        "t_scrap_floor_end_piece_w_2",
+        "t_scrap_floor_end_piece_e_2",
         "t_scrap_floor_end_piece_s_2",
-        "t_scrap_floor_end_piece_e_2"
+        "t_scrap_floor_end_piece_w_2"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_scrap_wall_halfway_edge_ew",
-      "bg": "t_scrap_floor_unconnected_2"
-    }
+    { "id": "unconnected", "fg": "t_scrap_wall_halfway_edge_ew", "bg": "t_scrap_floor_unconnected_2" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_screened_porch_wall/t_screened_porch_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_screened_porch_wall/t_screened_porch_wall.json
@@ -4,19 +4,15 @@
   "fg": "t_screened_porch_wall_unconnected",
   "bg": "t_floor_center",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "t_floor_center",
-      "fg": "t_screened_porch_wall_center"
-    },
+    { "id": "center", "bg": "t_floor_center", "fg": "t_screened_porch_wall_center" },
     {
       "id": "corner",
       "bg": "t_floor_center",
       "fg": [
         "t_screened_porch_wall_corner_nw",
-        "t_screened_porch_wall_corner_sw",
+        "t_screened_porch_wall_corner_ne",
         "t_screened_porch_wall_corner_se",
-        "t_screened_porch_wall_corner_ne"
+        "t_screened_porch_wall_corner_sw"
       ]
     },
     {
@@ -24,36 +20,30 @@
       "bg": "t_floor_center",
       "fg": [
         "t_screened_porch_wall_t_connection_n",
-        "t_screened_porch_wall_t_connection_w",
+        "t_screened_porch_wall_t_connection_e",
         "t_screened_porch_wall_t_connection_s",
-        "t_screened_porch_wall_t_connection_e"
+        "t_screened_porch_wall_t_connection_w"
       ]
     },
     {
       "id": "edge",
       "bg": "t_floor_center",
-      "fg": [
-        "t_screened_porch_wall_edge_ns",
-        "t_screened_porch_wall_edge_ew"
-      ]
+      "fg": [ "t_screened_porch_wall_edge_ns", "t_screened_porch_wall_edge_ew" ]
     },
     {
       "id": "end_piece",
       "bg": "t_floor_center",
       "fg": [
         "t_screened_porch_wall_end_piece_n",
-        "t_screened_porch_wall_end_piece_w",
+        "t_screened_porch_wall_end_piece_e",
         "t_screened_porch_wall_end_piece_s",
-        "t_screened_porch_wall_end_piece_e"
+        "t_screened_porch_wall_end_piece_w"
       ]
     },
     {
       "bg": "t_floor_center",
       "id": "unconnected",
-      "fg": [
-        "t_screened_porch_wall_unconnected",
-        "t_screened_porch_wall_unconnected"
-      ]
+      "fg": [ "t_screened_porch_wall_unconnected", "t_screened_porch_wall_unconnected" ]
     }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sewage/t_sewage.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sewage/t_sewage.json
@@ -4,56 +4,23 @@
   "fg": "t_sewage_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_sewage_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_sewage_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_sewage_corner_nw",
-        "t_sewage_corner_sw",
-        "t_sewage_corner_se",
-        "t_sewage_corner_ne"
-      ]
+      "fg": [ "t_sewage_corner_nw", "t_sewage_corner_ne", "t_sewage_corner_se", "t_sewage_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "t_sewage_t_connection_n",
-        "t_sewage_t_connection_w",
-        "t_sewage_t_connection_s",
-        "t_sewage_t_connection_e"
-      ]
+      "fg": [ "t_sewage_t_connection_n", "t_sewage_t_connection_e", "t_sewage_t_connection_s", "t_sewage_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_sewage_edge_ns",
-        "t_sewage_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_sewage_edge_ns", "t_sewage_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_sewage_end_piece_n",
-        "t_sewage_end_piece_w",
-        "t_sewage_end_piece_s",
-        "t_sewage_end_piece_e"
-      ]
+      "fg": [ "t_sewage_end_piece_n", "t_sewage_end_piece_e", "t_sewage_end_piece_s", "t_sewage_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [
-        "t_sewage_unconnected",
-        "t_sewage_unconnected"
-      ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "t_sewage_unconnected", "t_sewage_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sewage_pipe/t_sewage_pipe.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sewage_pipe/t_sewage_pipe.json
@@ -4,56 +4,28 @@
   "fg": "t_sewage_pipe_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_sewage_pipe_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_sewage_pipe_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_sewage_pipe_corner_nw",
-        "t_sewage_pipe_corner_sw",
-        "t_sewage_pipe_corner_se",
-        "t_sewage_pipe_corner_ne"
-      ]
+      "fg": [ "t_sewage_pipe_corner_nw", "t_sewage_pipe_corner_ne", "t_sewage_pipe_corner_se", "t_sewage_pipe_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_sewage_pipe_t_connection_n",
-        "t_sewage_pipe_t_connection_w",
+        "t_sewage_pipe_t_connection_e",
         "t_sewage_pipe_t_connection_s",
-        "t_sewage_pipe_t_connection_e"
+        "t_sewage_pipe_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_sewage_pipe_edge_ns",
-        "t_sewage_pipe_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_sewage_pipe_edge_ns", "t_sewage_pipe_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_sewage_pipe_end_piece_n",
-        "t_sewage_pipe_end_piece_w",
-        "t_sewage_pipe_end_piece_s",
-        "t_sewage_pipe_end_piece_e"
-      ]
+      "fg": [ "t_sewage_pipe_end_piece_n", "t_sewage_pipe_end_piece_e", "t_sewage_pipe_end_piece_s", "t_sewage_pipe_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [
-        "t_sewage_pipe_unconnected",
-        "t_sewage_pipe_unconnected"
-      ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "t_sewage_pipe_unconnected", "t_sewage_pipe_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_shingle_flat_roof/t_shingle_flat_roof.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_shingle_flat_roof/t_shingle_flat_roof.json
@@ -4,19 +4,15 @@
   "fg": "t_shingle_flat_roof_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_shingle_flat_roof_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_shingle_flat_roof_center" },
     {
       "id": "corner",
       "bg": "",
       "fg": [
         "t_shingle_flat_roof_corner_nw",
-        "t_shingle_flat_roof_corner_sw",
+        "t_shingle_flat_roof_corner_ne",
         "t_shingle_flat_roof_corner_se",
-        "t_shingle_flat_roof_corner_ne"
+        "t_shingle_flat_roof_corner_sw"
       ]
     },
     {
@@ -24,33 +20,22 @@
       "bg": "",
       "fg": [
         "t_shingle_flat_roof_t_connection_n",
-        "t_shingle_flat_roof_t_connection_w",
+        "t_shingle_flat_roof_t_connection_e",
         "t_shingle_flat_roof_t_connection_s",
-        "t_shingle_flat_roof_t_connection_e"
+        "t_shingle_flat_roof_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_shingle_flat_roof_edge_ns",
-        "t_shingle_flat_roof_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_shingle_flat_roof_edge_ns", "t_shingle_flat_roof_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "t_shingle_flat_roof_end_piece_n",
-        "t_shingle_flat_roof_end_piece_w",
+        "t_shingle_flat_roof_end_piece_e",
         "t_shingle_flat_roof_end_piece_s",
-        "t_shingle_flat_roof_end_piece_e"
+        "t_shingle_flat_roof_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_shingle_flat_roof_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_shingle_flat_roof_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sidewalk/t_sidewalk.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_sidewalk/t_sidewalk.json
@@ -9,18 +9,18 @@
       {
         "id": "corner",
         "bg": "",
-        "fg": [ "t_sidewalk_corner_nw", "t_sidewalk_corner_sw", "t_sidewalk_corner_se", "t_sidewalk_corner_ne" ]
+        "fg": [ "t_sidewalk_corner_nw", "t_sidewalk_corner_ne", "t_sidewalk_corner_se", "t_sidewalk_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "",
-        "fg": [ "t_sidewalk_t_connection_n", "t_sidewalk_t_connection_w", "t_sidewalk_t_connection_s", "t_sidewalk_t_connection_e" ]
+        "fg": [ "t_sidewalk_t_connection_n", "t_sidewalk_t_connection_e", "t_sidewalk_t_connection_s", "t_sidewalk_t_connection_w" ]
       },
       { "id": "edge", "bg": "", "fg": [ "t_sidewalk_edge_ns", "t_sidewalk_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "",
-        "fg": [ "t_sidewalk_end_piece_n", "t_sidewalk_end_piece_w", "t_sidewalk_end_piece_s", "t_sidewalk_end_piece_e" ]
+        "fg": [ "t_sidewalk_end_piece_n", "t_sidewalk_end_piece_e", "t_sidewalk_end_piece_s", "t_sidewalk_end_piece_w" ]
       },
       { "bg": "", "id": "unconnected", "fg": "t_sidewalk_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_skylight_frame/t_skylight_frame.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_skylight_frame/t_skylight_frame.json
@@ -3,47 +3,35 @@
   "fg": "t_skylight_frame_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_skylight_frame_center"
-    },
+    { "id": "center", "fg": "t_skylight_frame_center" },
     {
       "id": "corner",
       "fg": [
         "t_skylight_frame_corner_nw",
-        "t_skylight_frame_corner_sw",
+        "t_skylight_frame_corner_ne",
         "t_skylight_frame_corner_se",
-        "t_skylight_frame_corner_ne"
+        "t_skylight_frame_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_skylight_frame_t_connection_n",
-        "t_skylight_frame_t_connection_w",
+        "t_skylight_frame_t_connection_e",
         "t_skylight_frame_t_connection_s",
-        "t_skylight_frame_t_connection_e"
+        "t_skylight_frame_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_skylight_frame_edge_ns",
-        "t_skylight_frame_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_skylight_frame_edge_ns", "t_skylight_frame_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_skylight_frame_end_piece_n",
-        "t_skylight_frame_end_piece_w",
+        "t_skylight_frame_end_piece_e",
         "t_skylight_frame_end_piece_s",
-        "t_skylight_frame_end_piece_e"
+        "t_skylight_frame_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_skylight_frame_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_skylight_frame_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_slide/t_slide.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_slide/t_slide.json
@@ -5,54 +5,24 @@
     "bg": "t_grass_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_slide_edge_ns",
-        "bg": "t_grass_center"
-      },
+      { "id": "center", "fg": "t_slide_edge_ns", "bg": "t_grass_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_slide_end_piece_n",
-          "t_slide_end_piece_s",
-          "t_slide_end_piece_s",
-          "t_slide_end_piece_n"
-        ],
+        "fg": [ "t_slide_end_piece_n", "t_slide_end_piece_n", "t_slide_end_piece_s", "t_slide_end_piece_s" ],
         "bg": "t_grass_center"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_slide_end_piece_n",
-          "t_slide_edge_ns",
-          "t_slide_end_piece_s",
-          "t_slide_edge_ns"
-        ],
+        "fg": [ "t_slide_end_piece_n", "t_slide_edge_ns", "t_slide_end_piece_s", "t_slide_edge_ns" ],
         "bg": "t_grass_center"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_slide_edge_ns",
-          "t_slide_edge_ew"
-        ],
-        "bg": "t_grass_center"
-      },
+      { "id": "edge", "fg": [ "t_slide_edge_ns", "t_slide_edge_ew" ], "bg": "t_grass_center" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_slide_end_piece_n",
-          "t_slide_end_piece_w",
-          "t_slide_end_piece_s",
-          "t_slide_end_piece_e"
-        ],
+        "fg": [ "t_slide_end_piece_n", "t_slide_end_piece_e", "t_slide_end_piece_s", "t_slide_end_piece_w" ],
         "bg": "t_grass_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_slide_unconnected",
-        "bg": "t_grass_center"
-      }
+      { "id": "unconnected", "fg": "t_slide_unconnected", "bg": "t_grass_center" }
     ]
   },
   {
@@ -61,54 +31,24 @@
     "bg": "t_grass_summer_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_slide_edge_ns",
-        "bg": "t_grass_summer_center"
-      },
+      { "id": "center", "fg": "t_slide_edge_ns", "bg": "t_grass_summer_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_slide_end_piece_n",
-          "t_slide_end_piece_s",
-          "t_slide_end_piece_s",
-          "t_slide_end_piece_n"
-        ],
+        "fg": [ "t_slide_end_piece_n", "t_slide_end_piece_n", "t_slide_end_piece_s", "t_slide_end_piece_w" ],
         "bg": "t_grass_summer_center"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_slide_end_piece_n",
-          "t_slide_edge_ns",
-          "t_slide_end_piece_s",
-          "t_slide_edge_ns"
-        ],
+        "fg": [ "t_slide_end_piece_n", "t_slide_edge_ns", "t_slide_end_piece_s", "t_slide_edge_ns" ],
         "bg": "t_grass_summer_center"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_slide_edge_ns",
-          "t_slide_edge_ew"
-        ],
-        "bg": "t_grass_summer_center"
-      },
+      { "id": "edge", "fg": [ "t_slide_edge_ns", "t_slide_edge_ew" ], "bg": "t_grass_summer_center" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_slide_end_piece_n",
-          "t_slide_end_piece_w",
-          "t_slide_end_piece_s",
-          "t_slide_end_piece_e"
-        ],
+        "fg": [ "t_slide_end_piece_n", "t_slide_end_piece_e", "t_slide_end_piece_s", "t_slide_end_piece_w" ],
         "bg": "t_grass_summer_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_slide_unconnected",
-        "bg": "t_grass_summer_center"
-      }
+      { "id": "unconnected", "fg": "t_slide_unconnected", "bg": "t_grass_summer_center" }
     ]
   },
   {
@@ -117,54 +57,24 @@
     "bg": "t_grass_autumn_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_slide_edge_ns",
-        "bg": "t_grass_autumn_center"
-      },
+      { "id": "center", "fg": "t_slide_edge_ns", "bg": "t_grass_autumn_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_slide_end_piece_n",
-          "t_slide_end_piece_s",
-          "t_slide_end_piece_s",
-          "t_slide_end_piece_n"
-        ],
+        "fg": [ "t_slide_end_piece_n", "t_slide_end_piece_n", "t_slide_end_piece_s", "t_slide_end_piece_s" ],
         "bg": "t_grass_autumn_center"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_slide_end_piece_n",
-          "t_slide_edge_ns",
-          "t_slide_end_piece_s",
-          "t_slide_edge_ns"
-        ],
+        "fg": [ "t_slide_end_piece_n", "t_slide_edge_ns", "t_slide_end_piece_s", "t_slide_edge_ns" ],
         "bg": "t_grass_autumn_center"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_slide_edge_ns",
-          "t_slide_edge_ew"
-        ],
-        "bg": "t_grass_autumn_center"
-      },
+      { "id": "edge", "fg": [ "t_slide_edge_ns", "t_slide_edge_ew" ], "bg": "t_grass_autumn_center" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_slide_end_piece_n",
-          "t_slide_end_piece_w",
-          "t_slide_end_piece_s",
-          "t_slide_end_piece_e"
-        ],
+        "fg": [ "t_slide_end_piece_n", "t_slide_end_piece_e", "t_slide_end_piece_s", "t_slide_end_piece_w" ],
         "bg": "t_grass_autumn_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_slide_unconnected",
-        "bg": "t_grass_autumn_center"
-      }
+      { "id": "unconnected", "fg": "t_slide_unconnected", "bg": "t_grass_autumn_center" }
     ]
   },
   {
@@ -173,54 +83,24 @@
     "bg": "snow_shallow_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_slide_edge_ns",
-        "bg": "snow_shallow_center"
-      },
+      { "id": "center", "fg": "t_slide_edge_ns", "bg": "snow_shallow_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_slide_end_piece_n",
-          "t_slide_end_piece_s",
-          "t_slide_end_piece_s",
-          "t_slide_end_piece_n"
-        ],
+        "fg": [ "t_slide_end_piece_n", "t_slide_end_piece_n", "t_slide_end_piece_s", "t_slide_end_piece_s" ],
         "bg": "snow_shallow_center"
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_slide_end_piece_n",
-          "t_slide_edge_ns",
-          "t_slide_end_piece_s",
-          "t_slide_edge_ns"
-        ],
+        "fg": [ "t_slide_end_piece_n", "t_slide_edge_ns", "t_slide_end_piece_s", "t_slide_edge_ns" ],
         "bg": "snow_shallow_center"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_slide_edge_ns",
-          "t_slide_edge_ew"
-        ],
-        "bg": "snow_shallow_center"
-      },
+      { "id": "edge", "fg": [ "t_slide_edge_ns", "t_slide_edge_ew" ], "bg": "snow_shallow_center" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_slide_end_piece_n",
-          "t_slide_end_piece_w",
-          "t_slide_end_piece_s",
-          "t_slide_end_piece_e"
-        ],
+        "fg": [ "t_slide_end_piece_n", "t_slide_end_piece_e", "t_slide_end_piece_s", "t_slide_end_piece_w" ],
         "bg": "snow_shallow_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_slide_unconnected",
-        "bg": "snow_shallow_center"
-      }
+      { "id": "unconnected", "fg": "t_slide_unconnected", "bg": "snow_shallow_center" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_soil/t_soil.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_soil/t_soil.json
@@ -3,50 +3,17 @@
   "fg": "t_soil_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_soil_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_soil_corner_nw",
-        "t_soil_corner_sw",
-        "t_soil_corner_se",
-        "t_soil_corner_ne"
-      ]
-    },
+    { "id": "center", "fg": "t_soil_center" },
+    { "id": "corner", "fg": [ "t_soil_corner_nw", "t_soil_corner_ne", "t_soil_corner_se", "t_soil_corner_sw" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "t_soil_t_connection_n",
-        "t_soil_t_connection_w",
-        "t_soil_t_connection_s",
-        "t_soil_t_connection_e"
-      ]
+      "fg": [ "t_soil_t_connection_n", "t_soil_t_connection_e", "t_soil_t_connection_s", "t_soil_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_soil_edge_ns",
-        "t_soil_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_soil_edge_ns", "t_soil_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_soil_end_piece_n",
-        "t_soil_end_piece_w",
-        "t_soil_end_piece_s",
-        "t_soil_end_piece_e"
-      ]
+      "fg": [ "t_soil_end_piece_n", "t_soil_end_piece_e", "t_soil_end_piece_s", "t_soil_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_soil_unconnected",
-        "t_soil_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_soil_unconnected", "t_soil_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_floor/t_strconc_floor.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_floor/t_strconc_floor.json
@@ -4,53 +4,33 @@
   "fg": "t_strconc_floor_unconnected",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "t_strconc_floor_center"
-    },
+    { "id": "center", "bg": "", "fg": "t_strconc_floor_center" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_strconc_floor_corner_nw",
-        "t_strconc_floor_corner_sw",
-        "t_strconc_floor_corner_se",
-        "t_strconc_floor_corner_ne"
-      ]
+      "fg": [ "t_strconc_floor_corner_nw", "t_strconc_floor_corner_ne", "t_strconc_floor_corner_se", "t_strconc_floor_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_strconc_floor_t_connection_n",
-        "t_strconc_floor_t_connection_w",
+        "t_strconc_floor_t_connection_e",
         "t_strconc_floor_t_connection_s",
-        "t_strconc_floor_t_connection_e"
+        "t_strconc_floor_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_strconc_floor_edge_ns",
-        "t_strconc_floor_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_strconc_floor_edge_ns", "t_strconc_floor_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
       "fg": [
         "t_strconc_floor_end_piece_n",
-        "t_strconc_floor_end_piece_w",
+        "t_strconc_floor_end_piece_e",
         "t_strconc_floor_end_piece_s",
-        "t_strconc_floor_end_piece_e"
+        "t_strconc_floor_end_piece_w"
       ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": "t_strconc_floor_unconnected"
-    }
+    { "bg": "", "id": "unconnected", "fg": "t_strconc_floor_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall/t_strconc_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall/t_strconc_wall.json
@@ -3,47 +3,30 @@
   "fg": "t_strconc_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_strconc_wall_corner_nw",
-        "t_strconc_wall_corner_sw",
-        "t_strconc_wall_corner_se",
-        "t_strconc_wall_corner_ne"
-      ]
+      "fg": [ "t_strconc_wall_corner_nw", "t_strconc_wall_corner_ne", "t_strconc_wall_corner_se", "t_strconc_wall_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_t_connection_n",
-        "t_strconc_wall_t_connection_w",
+        "t_strconc_wall_t_connection_e",
         "t_strconc_wall_t_connection_s",
-        "t_strconc_wall_t_connection_e"
+        "t_strconc_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_edge_ns",
-        "t_strconc_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_edge_ns", "t_strconc_wall_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_end_piece_n",
-        "t_strconc_wall_end_piece_w",
+        "t_strconc_wall_end_piece_e",
         "t_strconc_wall_end_piece_s",
-        "t_strconc_wall_end_piece_e"
+        "t_strconc_wall_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_Pi/t_strconc_wall_Pi.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_Pi/t_strconc_wall_Pi.json
@@ -3,47 +3,35 @@
   "fg": "t_strconc_wall_Pi_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_Pi_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_Pi_center" },
     {
       "id": "corner",
       "fg": [
         "t_strconc_wall_Pi_corner_nw",
-        "t_strconc_wall_Pi_corner_sw",
+        "t_strconc_wall_Pi_corner_ne",
         "t_strconc_wall_Pi_corner_se",
-        "t_strconc_wall_Pi_corner_ne"
+        "t_strconc_wall_Pi_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_Pi_t_connection_n",
-        "t_strconc_wall_Pi_t_connection_w",
+        "t_strconc_wall_Pi_t_connection_e",
         "t_strconc_wall_Pi_t_connection_s",
-        "t_strconc_wall_Pi_t_connection_e"
+        "t_strconc_wall_Pi_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_Pi_edge_ns",
-        "t_strconc_wall_Pi_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_Pi_edge_ns", "t_strconc_wall_Pi_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_Pi_end_piece_n",
-        "t_strconc_wall_Pi_end_piece_w",
+        "t_strconc_wall_Pi_end_piece_e",
         "t_strconc_wall_Pi_end_piece_s",
-        "t_strconc_wall_Pi_end_piece_e"
+        "t_strconc_wall_Pi_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_Pi_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_Pi_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_b/t_strconc_wall_b.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_b/t_strconc_wall_b.json
@@ -3,47 +3,35 @@
   "fg": "t_strconc_wall_b_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_b_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_b_center" },
     {
       "id": "corner",
       "fg": [
         "t_strconc_wall_b_corner_nw",
-        "t_strconc_wall_b_corner_sw",
+        "t_strconc_wall_b_corner_ne",
         "t_strconc_wall_b_corner_se",
-        "t_strconc_wall_b_corner_ne"
+        "t_strconc_wall_b_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_b_t_connection_n",
-        "t_strconc_wall_b_t_connection_w",
+        "t_strconc_wall_b_t_connection_e",
         "t_strconc_wall_b_t_connection_s",
-        "t_strconc_wall_b_t_connection_e"
+        "t_strconc_wall_b_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_b_edge_ns",
-        "t_strconc_wall_b_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_b_edge_ns", "t_strconc_wall_b_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_b_end_piece_n",
-        "t_strconc_wall_b_end_piece_w",
+        "t_strconc_wall_b_end_piece_e",
         "t_strconc_wall_b_end_piece_s",
-        "t_strconc_wall_b_end_piece_e"
+        "t_strconc_wall_b_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_b_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_b_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_black/t_strconc_wall_black.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_black/t_strconc_wall_black.json
@@ -3,47 +3,35 @@
   "fg": "t_strconc_wall_black_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_black_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_black_center" },
     {
       "id": "corner",
       "fg": [
         "t_strconc_wall_black_corner_nw",
-        "t_strconc_wall_black_corner_sw",
+        "t_strconc_wall_black_corner_ne",
         "t_strconc_wall_black_corner_se",
-        "t_strconc_wall_black_corner_ne"
+        "t_strconc_wall_black_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_black_t_connection_n",
-        "t_strconc_wall_black_t_connection_w",
+        "t_strconc_wall_black_t_connection_e",
         "t_strconc_wall_black_t_connection_s",
-        "t_strconc_wall_black_t_connection_e"
+        "t_strconc_wall_black_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_black_edge_ns",
-        "t_strconc_wall_black_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_black_edge_ns", "t_strconc_wall_black_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_black_end_piece_n",
-        "t_strconc_wall_black_end_piece_w",
+        "t_strconc_wall_black_end_piece_e",
         "t_strconc_wall_black_end_piece_s",
-        "t_strconc_wall_black_end_piece_e"
+        "t_strconc_wall_black_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_black_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_black_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_brown/t_strconc_wall_brown.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_brown/t_strconc_wall_brown.json
@@ -3,47 +3,35 @@
   "fg": "t_strconc_wall_brown_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_brown_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_brown_center" },
     {
       "id": "corner",
       "fg": [
         "t_strconc_wall_brown_corner_nw",
-        "t_strconc_wall_brown_corner_sw",
+        "t_strconc_wall_brown_corner_ne",
         "t_strconc_wall_brown_corner_se",
-        "t_strconc_wall_brown_corner_ne"
+        "t_strconc_wall_brown_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_brown_t_connection_n",
-        "t_strconc_wall_brown_t_connection_w",
+        "t_strconc_wall_brown_t_connection_e",
         "t_strconc_wall_brown_t_connection_s",
-        "t_strconc_wall_brown_t_connection_e"
+        "t_strconc_wall_brown_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_brown_edge_ns",
-        "t_strconc_wall_brown_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_brown_edge_ns", "t_strconc_wall_brown_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_brown_end_piece_n",
-        "t_strconc_wall_brown_end_piece_w",
+        "t_strconc_wall_brown_end_piece_e",
         "t_strconc_wall_brown_end_piece_s",
-        "t_strconc_wall_brown_end_piece_e"
+        "t_strconc_wall_brown_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_brown_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_brown_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_cyan/t_strconc_wall_cyan.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_cyan/t_strconc_wall_cyan.json
@@ -3,47 +3,35 @@
   "fg": "t_strconc_wall_cyan_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_cyan_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_cyan_center" },
     {
       "id": "corner",
       "fg": [
         "t_strconc_wall_cyan_corner_nw",
-        "t_strconc_wall_cyan_corner_sw",
+        "t_strconc_wall_cyan_corner_ne",
         "t_strconc_wall_cyan_corner_se",
-        "t_strconc_wall_cyan_corner_ne"
+        "t_strconc_wall_cyan_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_cyan_t_connection_n",
-        "t_strconc_wall_cyan_t_connection_w",
+        "t_strconc_wall_cyan_t_connection_e",
         "t_strconc_wall_cyan_t_connection_s",
-        "t_strconc_wall_cyan_t_connection_e"
+        "t_strconc_wall_cyan_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_cyan_edge_ns",
-        "t_strconc_wall_cyan_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_cyan_edge_ns", "t_strconc_wall_cyan_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_cyan_end_piece_n",
-        "t_strconc_wall_cyan_end_piece_w",
+        "t_strconc_wall_cyan_end_piece_e",
         "t_strconc_wall_cyan_end_piece_s",
-        "t_strconc_wall_cyan_end_piece_e"
+        "t_strconc_wall_cyan_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_cyan_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_cyan_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_g/t_strconc_wall_g.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_g/t_strconc_wall_g.json
@@ -3,47 +3,35 @@
   "fg": "t_strconc_wall_g_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_g_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_g_center" },
     {
       "id": "corner",
       "fg": [
         "t_strconc_wall_g_corner_nw",
-        "t_strconc_wall_g_corner_sw",
+        "t_strconc_wall_g_corner_ne",
         "t_strconc_wall_g_corner_se",
-        "t_strconc_wall_g_corner_ne"
+        "t_strconc_wall_g_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_g_t_connection_n",
-        "t_strconc_wall_g_t_connection_w",
+        "t_strconc_wall_g_t_connection_e",
         "t_strconc_wall_g_t_connection_s",
-        "t_strconc_wall_g_t_connection_e"
+        "t_strconc_wall_g_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_g_edge_ns",
-        "t_strconc_wall_g_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_g_edge_ns", "t_strconc_wall_g_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_g_end_piece_n",
-        "t_strconc_wall_g_end_piece_w",
+        "t_strconc_wall_g_end_piece_e",
         "t_strconc_wall_g_end_piece_s",
-        "t_strconc_wall_g_end_piece_e"
+        "t_strconc_wall_g_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_g_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_g_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_gray/t_strconc_wall_gray.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_gray/t_strconc_wall_gray.json
@@ -3,47 +3,35 @@
   "fg": "t_strconc_wall_gray_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_gray_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_gray_center" },
     {
       "id": "corner",
       "fg": [
         "t_strconc_wall_gray_corner_nw",
-        "t_strconc_wall_gray_corner_sw",
+        "t_strconc_wall_gray_corner_ne",
         "t_strconc_wall_gray_corner_se",
-        "t_strconc_wall_gray_corner_ne"
+        "t_strconc_wall_gray_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_gray_t_connection_n",
-        "t_strconc_wall_gray_t_connection_w",
+        "t_strconc_wall_gray_t_connection_e",
         "t_strconc_wall_gray_t_connection_s",
-        "t_strconc_wall_gray_t_connection_e"
+        "t_strconc_wall_gray_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_gray_edge_ns",
-        "t_strconc_wall_gray_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_gray_edge_ns", "t_strconc_wall_gray_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_gray_end_piece_n",
-        "t_strconc_wall_gray_end_piece_w",
+        "t_strconc_wall_gray_end_piece_e",
         "t_strconc_wall_gray_end_piece_s",
-        "t_strconc_wall_gray_end_piece_e"
+        "t_strconc_wall_gray_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_gray_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_gray_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_halfway/t_strconc_wall_halfway.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_halfway/t_strconc_wall_halfway.json
@@ -3,47 +3,35 @@
   "fg": "t_strconc_wall_halfway_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_halfway_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_halfway_center" },
     {
       "id": "corner",
       "fg": [
         "t_strconc_wall_halfway_corner_nw",
-        "t_strconc_wall_halfway_corner_sw",
+        "t_strconc_wall_halfway_corner_ne",
         "t_strconc_wall_halfway_corner_se",
-        "t_strconc_wall_halfway_corner_ne"
+        "t_strconc_wall_halfway_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_halfway_t_connection_n",
-        "t_strconc_wall_halfway_t_connection_w",
+        "t_strconc_wall_halfway_t_connection_e",
         "t_strconc_wall_halfway_t_connection_s",
-        "t_strconc_wall_halfway_t_connection_e"
+        "t_strconc_wall_halfway_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_halfway_edge_ns",
-        "t_strconc_wall_halfway_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_halfway_edge_ns", "t_strconc_wall_halfway_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_halfway_end_piece_n",
-        "t_strconc_wall_halfway_end_piece_w",
+        "t_strconc_wall_halfway_end_piece_e",
         "t_strconc_wall_halfway_end_piece_s",
-        "t_strconc_wall_halfway_end_piece_e"
+        "t_strconc_wall_halfway_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_halfway_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_halfway_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_orange/t_strconc_wall_orange.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_orange/t_strconc_wall_orange.json
@@ -3,47 +3,35 @@
   "fg": "t_strconc_wall_orange_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_orange_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_orange_center" },
     {
       "id": "corner",
       "fg": [
         "t_strconc_wall_orange_corner_nw",
-        "t_strconc_wall_orange_corner_sw",
+        "t_strconc_wall_orange_corner_ne",
         "t_strconc_wall_orange_corner_se",
-        "t_strconc_wall_orange_corner_ne"
+        "t_strconc_wall_orange_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_orange_t_connection_n",
-        "t_strconc_wall_orange_t_connection_w",
+        "t_strconc_wall_orange_t_connection_e",
         "t_strconc_wall_orange_t_connection_s",
-        "t_strconc_wall_orange_t_connection_e"
+        "t_strconc_wall_orange_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_orange_edge_ns",
-        "t_strconc_wall_orange_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_orange_edge_ns", "t_strconc_wall_orange_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_orange_end_piece_n",
-        "t_strconc_wall_orange_end_piece_w",
+        "t_strconc_wall_orange_end_piece_e",
         "t_strconc_wall_orange_end_piece_s",
-        "t_strconc_wall_orange_end_piece_e"
+        "t_strconc_wall_orange_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_orange_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_orange_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_p/t_strconc_wall_p.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_p/t_strconc_wall_p.json
@@ -3,47 +3,35 @@
   "fg": "t_strconc_wall_p_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_p_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_p_center" },
     {
       "id": "corner",
       "fg": [
         "t_strconc_wall_p_corner_nw",
-        "t_strconc_wall_p_corner_sw",
+        "t_strconc_wall_p_corner_ne",
         "t_strconc_wall_p_corner_se",
-        "t_strconc_wall_p_corner_ne"
+        "t_strconc_wall_p_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_p_t_connection_n",
-        "t_strconc_wall_p_t_connection_w",
+        "t_strconc_wall_p_t_connection_e",
         "t_strconc_wall_p_t_connection_s",
-        "t_strconc_wall_p_t_connection_e"
+        "t_strconc_wall_p_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_p_edge_ns",
-        "t_strconc_wall_p_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_p_edge_ns", "t_strconc_wall_p_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_p_end_piece_n",
-        "t_strconc_wall_p_end_piece_w",
+        "t_strconc_wall_p_end_piece_e",
         "t_strconc_wall_p_end_piece_s",
-        "t_strconc_wall_p_end_piece_e"
+        "t_strconc_wall_p_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_p_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_p_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_r/t_strconc_wall_r.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_r/t_strconc_wall_r.json
@@ -3,47 +3,35 @@
   "fg": "t_strconc_wall_r_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_r_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_r_center" },
     {
       "id": "corner",
       "fg": [
         "t_strconc_wall_r_corner_nw",
-        "t_strconc_wall_r_corner_sw",
+        "t_strconc_wall_r_corner_ne",
         "t_strconc_wall_r_corner_se",
-        "t_strconc_wall_r_corner_ne"
+        "t_strconc_wall_r_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_r_t_connection_n",
-        "t_strconc_wall_r_t_connection_w",
+        "t_strconc_wall_r_t_connection_e",
         "t_strconc_wall_r_t_connection_s",
-        "t_strconc_wall_r_t_connection_e"
+        "t_strconc_wall_r_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_r_edge_ns",
-        "t_strconc_wall_r_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_r_edge_ns", "t_strconc_wall_r_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_r_end_piece_n",
-        "t_strconc_wall_r_end_piece_w",
+        "t_strconc_wall_r_end_piece_e",
         "t_strconc_wall_r_end_piece_s",
-        "t_strconc_wall_r_end_piece_e"
+        "t_strconc_wall_r_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_r_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_r_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_w/t_strconc_wall_w.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_w/t_strconc_wall_w.json
@@ -3,47 +3,35 @@
   "fg": "t_strconc_wall_w_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_w_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_w_center" },
     {
       "id": "corner",
       "fg": [
         "t_strconc_wall_w_corner_nw",
-        "t_strconc_wall_w_corner_sw",
+        "t_strconc_wall_w_corner_ne",
         "t_strconc_wall_w_corner_se",
-        "t_strconc_wall_w_corner_ne"
+        "t_strconc_wall_w_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_w_t_connection_n",
-        "t_strconc_wall_w_t_connection_w",
+        "t_strconc_wall_w_t_connection_e",
         "t_strconc_wall_w_t_connection_s",
-        "t_strconc_wall_w_t_connection_e"
+        "t_strconc_wall_w_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_w_edge_ns",
-        "t_strconc_wall_w_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_w_edge_ns", "t_strconc_wall_w_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_w_end_piece_n",
-        "t_strconc_wall_w_end_piece_w",
+        "t_strconc_wall_w_end_piece_e",
         "t_strconc_wall_w_end_piece_s",
-        "t_strconc_wall_w_end_piece_e"
+        "t_strconc_wall_w_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_w_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_w_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_y/t_strconc_wall_y.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_strconc_wall_y/t_strconc_wall_y.json
@@ -3,47 +3,35 @@
   "fg": "t_strconc_wall_y_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_strconc_wall_y_center"
-    },
+    { "id": "center", "fg": "t_strconc_wall_y_center" },
     {
       "id": "corner",
       "fg": [
         "t_strconc_wall_y_corner_nw",
-        "t_strconc_wall_y_corner_sw",
+        "t_strconc_wall_y_corner_ne",
         "t_strconc_wall_y_corner_se",
-        "t_strconc_wall_y_corner_ne"
+        "t_strconc_wall_y_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_strconc_wall_y_t_connection_n",
-        "t_strconc_wall_y_t_connection_w",
+        "t_strconc_wall_y_t_connection_e",
         "t_strconc_wall_y_t_connection_s",
-        "t_strconc_wall_y_t_connection_e"
+        "t_strconc_wall_y_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_strconc_wall_y_edge_ns",
-        "t_strconc_wall_y_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_strconc_wall_y_edge_ns", "t_strconc_wall_y_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_strconc_wall_y_end_piece_n",
-        "t_strconc_wall_y_end_piece_w",
+        "t_strconc_wall_y_end_piece_e",
         "t_strconc_wall_y_end_piece_s",
-        "t_strconc_wall_y_end_piece_e"
+        "t_strconc_wall_y_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_strconc_wall_y_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_strconc_wall_y_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_triffid_bark_wall/t_triffid_bark_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_triffid_bark_wall/t_triffid_bark_wall.json
@@ -3,47 +3,35 @@
   "fg": "t_triffid_bark_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_triffid_bark_wall_center"
-    },
+    { "id": "center", "fg": "t_triffid_bark_wall_center" },
     {
       "id": "corner",
       "fg": [
         "t_triffid_bark_wall_corner_nw",
-        "t_triffid_bark_wall_corner_sw",
+        "t_triffid_bark_wall_corner_ne",
         "t_triffid_bark_wall_corner_se",
-        "t_triffid_bark_wall_corner_ne"
+        "t_triffid_bark_wall_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_triffid_bark_wall_t_connection_n",
-        "t_triffid_bark_wall_t_connection_w",
+        "t_triffid_bark_wall_t_connection_e",
         "t_triffid_bark_wall_t_connection_s",
-        "t_triffid_bark_wall_t_connection_e"
+        "t_triffid_bark_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_triffid_bark_wall_edge_ns",
-        "t_triffid_bark_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_triffid_bark_wall_edge_ns", "t_triffid_bark_wall_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_triffid_bark_wall_end_piece_n",
-        "t_triffid_bark_wall_end_piece_w",
+        "t_triffid_bark_wall_end_piece_e",
         "t_triffid_bark_wall_end_piece_s",
-        "t_triffid_bark_wall_end_piece_e"
+        "t_triffid_bark_wall_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_triffid_bark_wall_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_triffid_bark_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_triffid_wood_wall/t_triffid_wood_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_triffid_wood_wall/t_triffid_wood_wall.json
@@ -3,47 +3,35 @@
   "fg": "t_triffid_wood_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_triffid_wood_wall_center"
-    },
+    { "id": "center", "fg": "t_triffid_wood_wall_center" },
     {
       "id": "corner",
       "fg": [
         "t_triffid_wood_wall_corner_nw",
-        "t_triffid_wood_wall_corner_sw",
+        "t_triffid_wood_wall_corner_ne",
         "t_triffid_wood_wall_corner_se",
-        "t_triffid_wood_wall_corner_ne"
+        "t_triffid_wood_wall_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_triffid_wood_wall_t_connection_n",
-        "t_triffid_wood_wall_t_connection_w",
+        "t_triffid_wood_wall_t_connection_e",
         "t_triffid_wood_wall_t_connection_s",
-        "t_triffid_wood_wall_t_connection_e"
+        "t_triffid_wood_wall_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_triffid_wood_wall_edge_ns",
-        "t_triffid_wood_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_triffid_wood_wall_edge_ns", "t_triffid_wood_wall_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_triffid_wood_wall_end_piece_n",
-        "t_triffid_wood_wall_end_piece_w",
+        "t_triffid_wood_wall_end_piece_e",
         "t_triffid_wood_wall_end_piece_s",
-        "t_triffid_wood_wall_end_piece_e"
+        "t_triffid_wood_wall_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_triffid_wood_wall_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_triffid_wood_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall/t_wall.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall/t_wall.json
@@ -3,47 +3,17 @@
   "fg": "t_wall_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_t_connection_n"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_wall_corner_nw",
-        "t_wall_corner_sw",
-        "t_wall_corner_se",
-        "t_wall_corner_ne"
-      ]
-    },
+    { "id": "center", "fg": "t_wall_t_connection_n" },
+    { "id": "corner", "fg": [ "t_wall_corner_nw", "t_wall_corner_ne", "t_wall_corner_se", "t_wall_corner_sw" ] },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_t_connection_n",
-        "t_wall_t_connection_w",
-        "t_wall_t_connection_s",
-        "t_wall_t_connection_e"
-      ]
+      "fg": [ "t_wall_t_connection_n", "t_wall_t_connection_e", "t_wall_t_connection_s", "t_wall_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_edge_ns",
-        "t_wall_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_edge_ns", "t_wall_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_end_piece_n",
-        "t_wall_end_piece_w",
-        "t_wall_end_piece_s",
-        "t_wall_end_piece_e"
-      ]
+      "fg": [ "t_wall_end_piece_n", "t_wall_end_piece_e", "t_wall_end_piece_s", "t_wall_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_Pi/t_wall_Pi.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_Pi/t_wall_Pi.json
@@ -3,47 +3,20 @@
   "fg": "t_wall_Pi_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_Pi_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wall_Pi_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_Pi_corner_nw",
-        "t_wall_Pi_corner_sw",
-        "t_wall_Pi_corner_se",
-        "t_wall_Pi_corner_ne"
-      ]
+      "fg": [ "t_wall_Pi_corner_nw", "t_wall_Pi_corner_ne", "t_wall_Pi_corner_se", "t_wall_Pi_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_Pi_t_connection_n",
-        "t_wall_Pi_t_connection_w",
-        "t_wall_Pi_t_connection_s",
-        "t_wall_Pi_t_connection_e"
-      ]
+      "fg": [ "t_wall_Pi_t_connection_n", "t_wall_Pi_t_connection_e", "t_wall_Pi_t_connection_s", "t_wall_Pi_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_Pi_edge_ns",
-        "t_wall_Pi_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_Pi_edge_ns", "t_wall_Pi_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_Pi_end_piece_n",
-        "t_wall_Pi_end_piece_w",
-        "t_wall_Pi_end_piece_s",
-        "t_wall_Pi_end_piece_e"
-      ]
+      "fg": [ "t_wall_Pi_end_piece_n", "t_wall_Pi_end_piece_e", "t_wall_Pi_end_piece_s", "t_wall_Pi_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_Pi_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_Pi_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_b/t_wall_b.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_b/t_wall_b.json
@@ -3,47 +3,20 @@
   "fg": "t_wall_b_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_b_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wall_b_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_b_corner_nw",
-        "t_wall_b_corner_sw",
-        "t_wall_b_corner_se",
-        "t_wall_b_corner_ne"
-      ]
+      "fg": [ "t_wall_b_corner_nw", "t_wall_b_corner_ne", "t_wall_b_corner_se", "t_wall_b_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_b_t_connection_n",
-        "t_wall_b_t_connection_w",
-        "t_wall_b_t_connection_s",
-        "t_wall_b_t_connection_e"
-      ]
+      "fg": [ "t_wall_b_t_connection_n", "t_wall_b_t_connection_e", "t_wall_b_t_connection_s", "t_wall_b_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_b_edge_ns",
-        "t_wall_b_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_b_edge_ns", "t_wall_b_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_b_end_piece_n",
-        "t_wall_b_end_piece_w",
-        "t_wall_b_end_piece_s",
-        "t_wall_b_end_piece_e"
-      ]
+      "fg": [ "t_wall_b_end_piece_n", "t_wall_b_end_piece_e", "t_wall_b_end_piece_s", "t_wall_b_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_b_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_b_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_black/t_wall_black.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_black/t_wall_black.json
@@ -3,47 +3,25 @@
   "fg": "t_wall_black_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_black_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wall_black_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_black_corner_nw",
-        "t_wall_black_corner_sw",
-        "t_wall_black_corner_se",
-        "t_wall_black_corner_ne"
-      ]
+      "fg": [ "t_wall_black_corner_nw", "t_wall_black_corner_ne", "t_wall_black_corner_se", "t_wall_black_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_black_t_connection_n",
-        "t_wall_black_t_connection_w",
+        "t_wall_black_t_connection_e",
         "t_wall_black_t_connection_s",
-        "t_wall_black_t_connection_e"
+        "t_wall_black_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_black_edge_ns",
-        "t_wall_black_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_black_edge_ns", "t_wall_black_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_black_end_piece_n",
-        "t_wall_black_end_piece_w",
-        "t_wall_black_end_piece_s",
-        "t_wall_black_end_piece_e"
-      ]
+      "fg": [ "t_wall_black_end_piece_n", "t_wall_black_end_piece_e", "t_wall_black_end_piece_s", "t_wall_black_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_black_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_black_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_brown/t_wall_brown.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_brown/t_wall_brown.json
@@ -3,47 +3,25 @@
   "fg": "t_wall_brown_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_brown_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wall_brown_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_brown_corner_nw",
-        "t_wall_brown_corner_sw",
-        "t_wall_brown_corner_se",
-        "t_wall_brown_corner_ne"
-      ]
+      "fg": [ "t_wall_brown_corner_nw", "t_wall_brown_corner_ne", "t_wall_brown_corner_se", "t_wall_brown_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_brown_t_connection_n",
-        "t_wall_brown_t_connection_w",
+        "t_wall_brown_t_connection_e",
         "t_wall_brown_t_connection_s",
-        "t_wall_brown_t_connection_e"
+        "t_wall_brown_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_brown_edge_ns",
-        "t_wall_brown_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_brown_edge_ns", "t_wall_brown_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_brown_end_piece_n",
-        "t_wall_brown_end_piece_w",
-        "t_wall_brown_end_piece_s",
-        "t_wall_brown_end_piece_e"
-      ]
+      "fg": [ "t_wall_brown_end_piece_n", "t_wall_brown_end_piece_e", "t_wall_brown_end_piece_s", "t_wall_brown_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_brown_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_brown_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_cyan/t_wall_cyan.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_cyan/t_wall_cyan.json
@@ -3,47 +3,25 @@
   "fg": "t_wall_cyan_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_cyan_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wall_cyan_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_cyan_corner_nw",
-        "t_wall_cyan_corner_sw",
-        "t_wall_cyan_corner_se",
-        "t_wall_cyan_corner_ne"
-      ]
+      "fg": [ "t_wall_cyan_corner_nw", "t_wall_cyan_corner_ne", "t_wall_cyan_corner_se", "t_wall_cyan_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_cyan_t_connection_n",
-        "t_wall_cyan_t_connection_w",
+        "t_wall_cyan_t_connection_e",
         "t_wall_cyan_t_connection_s",
-        "t_wall_cyan_t_connection_e"
+        "t_wall_cyan_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_cyan_edge_ns",
-        "t_wall_cyan_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_cyan_edge_ns", "t_wall_cyan_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_cyan_end_piece_n",
-        "t_wall_cyan_end_piece_w",
-        "t_wall_cyan_end_piece_s",
-        "t_wall_cyan_end_piece_e"
-      ]
+      "fg": [ "t_wall_cyan_end_piece_n", "t_wall_cyan_end_piece_e", "t_wall_cyan_end_piece_s", "t_wall_cyan_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_cyan_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_cyan_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_g/t_wall_g.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_g/t_wall_g.json
@@ -3,47 +3,20 @@
   "fg": "t_wall_g_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_g_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wall_g_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_g_corner_nw",
-        "t_wall_g_corner_sw",
-        "t_wall_g_corner_se",
-        "t_wall_g_corner_ne"
-      ]
+      "fg": [ "t_wall_g_corner_nw", "t_wall_g_corner_ne", "t_wall_g_corner_se", "t_wall_g_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_g_t_connection_n",
-        "t_wall_g_t_connection_w",
-        "t_wall_g_t_connection_s",
-        "t_wall_g_t_connection_e"
-      ]
+      "fg": [ "t_wall_g_t_connection_n", "t_wall_g_t_connection_e", "t_wall_g_t_connection_s", "t_wall_g_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_g_edge_ns",
-        "t_wall_g_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_g_edge_ns", "t_wall_g_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_g_end_piece_n",
-        "t_wall_g_end_piece_w",
-        "t_wall_g_end_piece_s",
-        "t_wall_g_end_piece_e"
-      ]
+      "fg": [ "t_wall_g_end_piece_n", "t_wall_g_end_piece_e", "t_wall_g_end_piece_s", "t_wall_g_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_g_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_g_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_glass/t_wall_glass.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_glass/t_wall_glass.json
@@ -1,5 +1,8 @@
 {
-  "id": [ "t_wall_glass", "t_wall_glass_alarm" ],
+  "id": [
+    "t_wall_glass",
+    "t_wall_glass_alarm"
+  ],
   "multitile": true,
   "fg": "t_wall_glass_unconnected",
   "bg": "",
@@ -8,23 +11,23 @@
     {
       "id": "corner",
       "bg": "",
-      "fg": [ "t_wall_glass_corner_nw", "t_wall_glass_corner_sw", "t_wall_glass_corner_se", "t_wall_glass_corner_ne" ]
+      "fg": [ "t_wall_glass_corner_nw", "t_wall_glass_corner_ne", "t_wall_glass_corner_se", "t_wall_glass_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_wall_glass_t_connection_n",
-        "t_wall_glass_t_connection_w",
+        "t_wall_glass_t_connection_e",
         "t_wall_glass_t_connection_s",
-        "t_wall_glass_t_connection_e"
+        "t_wall_glass_t_connection_w"
       ]
     },
     { "id": "edge", "bg": "", "fg": [ "t_wall_glass_edge_ns", "t_wall_glass_edge_ew_0" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [ "t_wall_glass_end_piece_n", "t_wall_glass_end_piece_w", "t_wall_glass_end_piece_s", "t_wall_glass_end_piece_e" ]
+      "fg": [ "t_wall_glass_end_piece_n", "t_wall_glass_end_piece_e", "t_wall_glass_end_piece_s", "t_wall_glass_end_piece_w" ]
     },
     { "bg": "", "id": "unconnected", "fg": "t_wall_glass_unconnected" }
   ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_gray/t_wall_gray.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_gray/t_wall_gray.json
@@ -3,47 +3,25 @@
   "fg": "t_wall_gray_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_gray_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wall_gray_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_gray_corner_nw",
-        "t_wall_gray_corner_sw",
-        "t_wall_gray_corner_se",
-        "t_wall_gray_corner_ne"
-      ]
+      "fg": [ "t_wall_gray_corner_nw", "t_wall_gray_corner_ne", "t_wall_gray_corner_se", "t_wall_gray_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_gray_t_connection_n",
-        "t_wall_gray_t_connection_w",
+        "t_wall_gray_t_connection_e",
         "t_wall_gray_t_connection_s",
-        "t_wall_gray_t_connection_e"
+        "t_wall_gray_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_gray_edge_ns",
-        "t_wall_gray_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_gray_edge_ns", "t_wall_gray_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_gray_end_piece_n",
-        "t_wall_gray_end_piece_w",
-        "t_wall_gray_end_piece_s",
-        "t_wall_gray_end_piece_e"
-      ]
+      "fg": [ "t_wall_gray_end_piece_n", "t_wall_gray_end_piece_e", "t_wall_gray_end_piece_s", "t_wall_gray_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_gray_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_gray_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_log/t_wall_log.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_log/t_wall_log.json
@@ -5,49 +5,21 @@
     "bg": "t_grass",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_wall_log_center"
-      },
+      { "id": "center", "fg": "t_wall_log_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_wall_log_corner_nw",
-          "t_wall_log_corner_sw",
-          "t_wall_log_corner_se",
-          "t_wall_log_corner_ne"
-        ]
+        "fg": [ "t_wall_log_corner_nw", "t_wall_log_corner_ne", "t_wall_log_corner_se", "t_wall_log_corner_sw" ]
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_wall_log_t_connection_n",
-          "t_wall_log_t_connection_w",
-          "t_wall_log_t_connection_s",
-          "t_wall_log_t_connection_e"
-        ]
+        "fg": [ "t_wall_log_t_connection_n", "t_wall_log_t_connection_e", "t_wall_log_t_connection_s", "t_wall_log_t_connection_w" ]
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_wall_log_edge_ns",
-          "t_wall_log_edge_ew"
-        ]
-      },
+      { "id": "edge", "fg": [ "t_wall_log_edge_ns", "t_wall_log_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [
-          "t_wall_log_end_piece_n",
-          "t_wall_log_end_piece_w",
-          "t_wall_log_end_piece_s",
-          "t_wall_log_end_piece_e"
-        ]
+        "fg": [ "t_wall_log_end_piece_n", "t_wall_log_end_piece_e", "t_wall_log_end_piece_s", "t_wall_log_end_piece_w" ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_wall_log_unconnected",
-        "bg": "t_grass"
-      }
+      { "id": "unconnected", "fg": "t_wall_log_unconnected", "bg": "t_grass" }
     ]
   },
   {
@@ -56,49 +28,21 @@
     "bg": "t_grass_summer",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_wall_log_center"
-      },
+      { "id": "center", "fg": "t_wall_log_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_wall_log_corner_nw",
-          "t_wall_log_corner_sw",
-          "t_wall_log_corner_se",
-          "t_wall_log_corner_ne"
-        ]
+        "fg": [ "t_wall_log_corner_nw", "t_wall_log_corner_ne", "t_wall_log_corner_se", "t_wall_log_corner_sw" ]
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_wall_log_t_connection_n",
-          "t_wall_log_t_connection_w",
-          "t_wall_log_t_connection_s",
-          "t_wall_log_t_connection_e"
-        ]
+        "fg": [ "t_wall_log_t_connection_n", "t_wall_log_t_connection_e", "t_wall_log_t_connection_s", "t_wall_log_t_connection_w" ]
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_wall_log_edge_ns",
-          "t_wall_log_edge_ew"
-        ]
-      },
+      { "id": "edge", "fg": [ "t_wall_log_edge_ns", "t_wall_log_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [
-          "t_wall_log_end_piece_n",
-          "t_wall_log_end_piece_w",
-          "t_wall_log_end_piece_s",
-          "t_wall_log_end_piece_e"
-        ]
+        "fg": [ "t_wall_log_end_piece_n", "t_wall_log_end_piece_e", "t_wall_log_end_piece_s", "t_wall_log_end_piece_w" ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_wall_log_unconnected",
-        "bg": "t_grass_summer"
-      }
+      { "id": "unconnected", "fg": "t_wall_log_unconnected", "bg": "t_grass_summer" }
     ]
   },
   {
@@ -107,49 +51,21 @@
     "bg": "t_grass_autumn",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_wall_log_center"
-      },
+      { "id": "center", "fg": "t_wall_log_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_wall_log_corner_nw",
-          "t_wall_log_corner_sw",
-          "t_wall_log_corner_se",
-          "t_wall_log_corner_ne"
-        ]
+        "fg": [ "t_wall_log_corner_nw", "t_wall_log_corner_ne", "t_wall_log_corner_se", "t_wall_log_corner_sw" ]
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_wall_log_t_connection_n",
-          "t_wall_log_t_connection_w",
-          "t_wall_log_t_connection_s",
-          "t_wall_log_t_connection_e"
-        ]
+        "fg": [ "t_wall_log_t_connection_n", "t_wall_log_t_connection_e", "t_wall_log_t_connection_s", "t_wall_log_t_connection_w" ]
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_wall_log_edge_ns",
-          "t_wall_log_edge_ew"
-        ]
-      },
+      { "id": "edge", "fg": [ "t_wall_log_edge_ns", "t_wall_log_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [
-          "t_wall_log_end_piece_n",
-          "t_wall_log_end_piece_w",
-          "t_wall_log_end_piece_s",
-          "t_wall_log_end_piece_e"
-        ]
+        "fg": [ "t_wall_log_end_piece_n", "t_wall_log_end_piece_e", "t_wall_log_end_piece_s", "t_wall_log_end_piece_w" ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_wall_log_unconnected",
-        "bg": "t_grass_autumn"
-      }
+      { "id": "unconnected", "fg": "t_wall_log_unconnected", "bg": "t_grass_autumn" }
     ]
   },
   {
@@ -158,49 +74,21 @@
     "bg": "snow_shallow_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_wall_log_center"
-      },
+      { "id": "center", "fg": "t_wall_log_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_wall_log_corner_nw",
-          "t_wall_log_corner_sw",
-          "t_wall_log_corner_se",
-          "t_wall_log_corner_ne"
-        ]
+        "fg": [ "t_wall_log_corner_nw", "t_wall_log_corner_ne", "t_wall_log_corner_se", "t_wall_log_corner_sw" ]
       },
       {
         "id": "t_connection",
-        "fg": [
-          "t_wall_log_t_connection_n",
-          "t_wall_log_t_connection_w",
-          "t_wall_log_t_connection_s",
-          "t_wall_log_t_connection_e"
-        ]
+        "fg": [ "t_wall_log_t_connection_n", "t_wall_log_t_connection_e", "t_wall_log_t_connection_s", "t_wall_log_t_connection_w" ]
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_wall_log_edge_ns",
-          "t_wall_log_edge_ew"
-        ]
-      },
+      { "id": "edge", "fg": [ "t_wall_log_edge_ns", "t_wall_log_edge_ew" ] },
       {
         "id": "end_piece",
-        "fg": [
-          "t_wall_log_end_piece_n",
-          "t_wall_log_end_piece_w",
-          "t_wall_log_end_piece_s",
-          "t_wall_log_end_piece_e"
-        ]
+        "fg": [ "t_wall_log_end_piece_n", "t_wall_log_end_piece_e", "t_wall_log_end_piece_s", "t_wall_log_end_piece_w" ]
       },
-      {
-        "id": "unconnected",
-        "fg": "t_wall_log_unconnected",
-        "bg": "snow_shallow_center"
-      }
+      { "id": "unconnected", "fg": "t_wall_log_unconnected", "bg": "snow_shallow_center" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_metal/t_wall_metal.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_metal/t_wall_metal.json
@@ -3,50 +3,25 @@
   "fg": "t_wall_metal_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_metal_center"
-    },
+    { "id": "center", "fg": "t_wall_metal_center" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_metal_corner_nw",
-        "t_wall_metal_corner_sw",
-        "t_wall_metal_corner_se",
-        "t_wall_metal_corner_ne"
-      ]
+      "fg": [ "t_wall_metal_corner_nw", "t_wall_metal_corner_ne", "t_wall_metal_corner_se", "t_wall_metal_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_metal_t_connection_n",
-        "t_wall_metal_t_connection_w",
+        "t_wall_metal_t_connection_e",
         "t_wall_metal_t_connection_s",
-        "t_wall_metal_t_connection_e"
+        "t_wall_metal_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_metal_edge_ns",
-        "t_wall_metal_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_metal_edge_ns", "t_wall_metal_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_metal_end_piece_n",
-        "t_wall_metal_end_piece_w",
-        "t_wall_metal_end_piece_s",
-        "t_wall_metal_end_piece_e"
-      ]
+      "fg": [ "t_wall_metal_end_piece_n", "t_wall_metal_end_piece_e", "t_wall_metal_end_piece_s", "t_wall_metal_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_metal_unconnected",
-        "t_wall_metal_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_metal_unconnected", "t_wall_metal_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_metal_corrugated/t_wall_metal_corrugated.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_metal_corrugated/t_wall_metal_corrugated.json
@@ -3,47 +3,35 @@
   "fg": "t_wall_metal_corrugated_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_metal_corrugated_center"
-    },
+    { "id": "center", "fg": "t_wall_metal_corrugated_center" },
     {
       "id": "corner",
       "fg": [
         "t_wall_metal_corrugated_corner_nw",
-        "t_wall_metal_corrugated_corner_sw",
+        "t_wall_metal_corrugated_corner_ne",
         "t_wall_metal_corrugated_corner_se",
-        "t_wall_metal_corrugated_corner_ne"
+        "t_wall_metal_corrugated_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_metal_corrugated_t_connection_n",
-        "t_wall_metal_corrugated_t_connection_w",
+        "t_wall_metal_corrugated_t_connection_e",
         "t_wall_metal_corrugated_t_connection_s",
-        "t_wall_metal_corrugated_t_connection_e"
+        "t_wall_metal_corrugated_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_metal_corrugated_edge_ns",
-        "t_wall_metal_corrugated_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_metal_corrugated_edge_ns", "t_wall_metal_corrugated_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wall_metal_corrugated_end_piece_n",
-        "t_wall_metal_corrugated_end_piece_w",
+        "t_wall_metal_corrugated_end_piece_e",
         "t_wall_metal_corrugated_end_piece_s",
-        "t_wall_metal_corrugated_end_piece_e"
+        "t_wall_metal_corrugated_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_metal_corrugated_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_metal_corrugated_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_orange/t_wall_orange.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_orange/t_wall_orange.json
@@ -3,47 +3,25 @@
   "fg": "t_wall_orange_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_orange_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wall_orange_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_orange_corner_nw",
-        "t_wall_orange_corner_sw",
-        "t_wall_orange_corner_se",
-        "t_wall_orange_corner_ne"
-      ]
+      "fg": [ "t_wall_orange_corner_nw", "t_wall_orange_corner_ne", "t_wall_orange_corner_se", "t_wall_orange_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_orange_t_connection_n",
-        "t_wall_orange_t_connection_w",
+        "t_wall_orange_t_connection_e",
         "t_wall_orange_t_connection_s",
-        "t_wall_orange_t_connection_e"
+        "t_wall_orange_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_orange_edge_ns",
-        "t_wall_orange_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_orange_edge_ns", "t_wall_orange_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_orange_end_piece_n",
-        "t_wall_orange_end_piece_w",
-        "t_wall_orange_end_piece_s",
-        "t_wall_orange_end_piece_e"
-      ]
+      "fg": [ "t_wall_orange_end_piece_n", "t_wall_orange_end_piece_e", "t_wall_orange_end_piece_s", "t_wall_orange_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_orange_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_orange_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_p/t_wall_p.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_p/t_wall_p.json
@@ -3,47 +3,20 @@
   "fg": "t_wall_p_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_p_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wall_p_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_p_corner_nw",
-        "t_wall_p_corner_sw",
-        "t_wall_p_corner_se",
-        "t_wall_p_corner_ne"
-      ]
+      "fg": [ "t_wall_p_corner_nw", "t_wall_p_corner_ne", "t_wall_p_corner_se", "t_wall_p_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_p_t_connection_n",
-        "t_wall_p_t_connection_w",
-        "t_wall_p_t_connection_s",
-        "t_wall_p_t_connection_e"
-      ]
+      "fg": [ "t_wall_p_t_connection_n", "t_wall_p_t_connection_e", "t_wall_p_t_connection_s", "t_wall_p_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_p_edge_ns",
-        "t_wall_p_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_p_edge_ns", "t_wall_p_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_p_end_piece_n",
-        "t_wall_p_end_piece_w",
-        "t_wall_p_end_piece_s",
-        "t_wall_p_end_piece_e"
-      ]
+      "fg": [ "t_wall_p_end_piece_n", "t_wall_p_end_piece_e", "t_wall_p_end_piece_s", "t_wall_p_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_p_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_p_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_r/t_wall_r.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_r/t_wall_r.json
@@ -3,47 +3,20 @@
   "fg": "t_wall_r_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_r_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wall_r_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_r_corner_nw",
-        "t_wall_r_corner_sw",
-        "t_wall_r_corner_se",
-        "t_wall_r_corner_ne"
-      ]
+      "fg": [ "t_wall_r_corner_nw", "t_wall_r_corner_ne", "t_wall_r_corner_se", "t_wall_r_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_r_t_connection_n",
-        "t_wall_r_t_connection_w",
-        "t_wall_r_t_connection_s",
-        "t_wall_r_t_connection_e"
-      ]
+      "fg": [ "t_wall_r_t_connection_n", "t_wall_r_t_connection_e", "t_wall_r_t_connection_s", "t_wall_r_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_r_edge_ns",
-        "t_wall_r_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_r_edge_ns", "t_wall_r_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_r_end_piece_n",
-        "t_wall_r_end_piece_w",
-        "t_wall_r_end_piece_s",
-        "t_wall_r_end_piece_e"
-      ]
+      "fg": [ "t_wall_r_end_piece_n", "t_wall_r_end_piece_e", "t_wall_r_end_piece_s", "t_wall_r_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_r_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_r_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_rammed_earth/t_wall_rammed_earth.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_rammed_earth/t_wall_rammed_earth.json
@@ -3,50 +3,35 @@
   "fg": "t_wall_rammed_earth_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_rammed_earth_center"
-    },
+    { "id": "center", "fg": "t_wall_rammed_earth_center" },
     {
       "id": "corner",
       "fg": [
         "t_wall_rammed_earth_corner_nw",
-        "t_wall_rammed_earth_corner_sw",
+        "t_wall_rammed_earth_corner_ne",
         "t_wall_rammed_earth_corner_se",
-        "t_wall_rammed_earth_corner_ne"
+        "t_wall_rammed_earth_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wall_rammed_earth_t_connection_n",
-        "t_wall_rammed_earth_t_connection_w",
+        "t_wall_rammed_earth_t_connection_e",
         "t_wall_rammed_earth_t_connection_s",
-        "t_wall_rammed_earth_t_connection_e"
+        "t_wall_rammed_earth_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_rammed_earth_edge_ns",
-        "t_wall_rammed_earth_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_rammed_earth_edge_ns", "t_wall_rammed_earth_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wall_rammed_earth_end_piece_n",
-        "t_wall_rammed_earth_end_piece_w",
+        "t_wall_rammed_earth_end_piece_e",
         "t_wall_rammed_earth_end_piece_s",
-        "t_wall_rammed_earth_end_piece_e"
+        "t_wall_rammed_earth_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_wall_rammed_earth_unconnected",
-        "t_wall_rammed_earth_unconnected"
-      ]
-    }
+    { "id": "unconnected", "fg": [ "t_wall_rammed_earth_unconnected", "t_wall_rammed_earth_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_resin/migo_resin.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_resin/migo_resin.json
@@ -5,54 +5,29 @@
     "fg": "t_wall_resin_unconnected",
     "bg": "",
     "additional_tiles": [
-      {
-        "id": "center",
-        "bg": "",
-        "fg": "t_wall_resin_center"
-      },
+      { "id": "center", "bg": "", "fg": "t_wall_resin_center" },
       {
         "id": "corner",
         "bg": "",
-        "fg": [
-          "t_wall_resin_corner_nw",
-          "t_wall_resin_corner_sw",
-          "t_wall_resin_corner_se",
-          "t_wall_resin_corner_ne"
-        ]
+        "fg": [ "t_wall_resin_corner_nw", "t_wall_resin_corner_ne", "t_wall_resin_corner_se", "t_wall_resin_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "",
         "fg": [
           "t_wall_resin_t_connection_n",
-          "t_wall_resin_t_connection_w",
+          "t_wall_resin_t_connection_e",
           "t_wall_resin_t_connection_s",
-          "t_wall_resin_t_connection_e"
+          "t_wall_resin_t_connection_w"
         ]
       },
-      {
-        "id": "edge",
-        "bg": "",
-        "fg": [
-          "t_wall_resin_edge_ns",
-          "t_wall_resin_edge_ew"
-        ]
-      },
+      { "id": "edge", "bg": "", "fg": [ "t_wall_resin_edge_ns", "t_wall_resin_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "",
-        "fg": [
-          "t_wall_resin_end_piece_n",
-          "t_wall_resin_end_piece_w",
-          "t_wall_resin_end_piece_s",
-          "t_wall_resin_end_piece_e"
-        ]
+        "fg": [ "t_wall_resin_end_piece_n", "t_wall_resin_end_piece_e", "t_wall_resin_end_piece_s", "t_wall_resin_end_piece_w" ]
       },
-      {
-        "bg": "",
-        "id": "unconnected",
-        "fg": "t_wall_resin_unconnected"
-      }
+      { "bg": "", "id": "unconnected", "fg": "t_wall_resin_unconnected" }
     ]
   },
   {

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_w/t_wall_w.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_w/t_wall_w.json
@@ -3,47 +3,20 @@
   "fg": "t_wall_w_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_w_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wall_w_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_w_corner_nw",
-        "t_wall_w_corner_sw",
-        "t_wall_w_corner_se",
-        "t_wall_w_corner_ne"
-      ]
+      "fg": [ "t_wall_w_corner_nw", "t_wall_w_corner_ne", "t_wall_w_corner_se", "t_wall_w_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_w_t_connection_n",
-        "t_wall_w_t_connection_w",
-        "t_wall_w_t_connection_s",
-        "t_wall_w_t_connection_e"
-      ]
+      "fg": [ "t_wall_w_t_connection_n", "t_wall_w_t_connection_e", "t_wall_w_t_connection_s", "t_wall_w_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_w_edge_ns",
-        "t_wall_w_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_w_edge_ns", "t_wall_w_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_w_end_piece_n",
-        "t_wall_w_end_piece_w",
-        "t_wall_w_end_piece_s",
-        "t_wall_w_end_piece_e"
-      ]
+      "fg": [ "t_wall_w_end_piece_n", "t_wall_w_end_piece_e", "t_wall_w_end_piece_s", "t_wall_w_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_w_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_w_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_wood/t_wall_wood.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_wood/t_wall_wood.json
@@ -1,51 +1,29 @@
 [
-{
-  "id": [ "t_wall_wood", "t_wall_wood_chipped", "t_wall_wood_broken" ],
-  "fg": "t_wall_wood_unconnected",
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_wood_t_connection_n"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_wall_wood_corner_nw",
-        "t_wall_wood_corner_sw",
-        "t_wall_wood_corner_se",
-        "t_wall_wood_corner_ne"
-      ]
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "t_wall_wood_t_connection_n",
-        "t_wall_wood_t_connection_w",
-        "t_wall_wood_t_connection_s",
-        "t_wall_wood_t_connection_e"
-      ]
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_wood_edge_ns",
-        "t_wall_wood_edge_ew"
-      ]
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "t_wall_wood_end_piece_n",
-        "t_wall_wood_end_piece_w",
-        "t_wall_wood_end_piece_s",
-        "t_wall_wood_end_piece_e"
-      ]
-    },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_wood_unconnected"
-    }
-  ]
-}
+  {
+    "id": [ "t_wall_wood", "t_wall_wood_chipped", "t_wall_wood_broken" ],
+    "fg": "t_wall_wood_unconnected",
+    "multitile": true,
+    "additional_tiles": [
+      { "id": "center", "fg": "t_wall_wood_t_connection_n" },
+      {
+        "id": "corner",
+        "fg": [ "t_wall_wood_corner_nw", "t_wall_wood_corner_ne", "t_wall_wood_corner_se", "t_wall_wood_corner_sw" ]
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_wall_wood_t_connection_n",
+          "t_wall_wood_t_connection_e",
+          "t_wall_wood_t_connection_s",
+          "t_wall_wood_t_connection_w"
+        ]
+      },
+      { "id": "edge", "fg": [ "t_wall_wood_edge_ns", "t_wall_wood_edge_ew" ] },
+      {
+        "id": "end_piece",
+        "fg": [ "t_wall_wood_end_piece_n", "t_wall_wood_end_piece_e", "t_wall_wood_end_piece_s", "t_wall_wood_end_piece_w" ]
+      },
+      { "id": "unconnected", "fg": "t_wall_wood_unconnected" }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_y/t_wall_y.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wall_y/t_wall_y.json
@@ -3,47 +3,20 @@
   "fg": "t_wall_y_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wall_y_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wall_y_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wall_y_corner_nw",
-        "t_wall_y_corner_sw",
-        "t_wall_y_corner_se",
-        "t_wall_y_corner_ne"
-      ]
+      "fg": [ "t_wall_y_corner_nw", "t_wall_y_corner_ne", "t_wall_y_corner_se", "t_wall_y_corner_sw" ]
     },
     {
       "id": "t_connection",
-      "fg": [
-        "t_wall_y_t_connection_n",
-        "t_wall_y_t_connection_w",
-        "t_wall_y_t_connection_s",
-        "t_wall_y_t_connection_e"
-      ]
+      "fg": [ "t_wall_y_t_connection_n", "t_wall_y_t_connection_e", "t_wall_y_t_connection_s", "t_wall_y_t_connection_w" ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wall_y_edge_ns",
-        "t_wall_y_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wall_y_edge_ns", "t_wall_y_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wall_y_end_piece_n",
-        "t_wall_y_end_piece_w",
-        "t_wall_y_end_piece_s",
-        "t_wall_y_end_piece_e"
-      ]
+      "fg": [ "t_wall_y_end_piece_n", "t_wall_y_end_piece_e", "t_wall_y_end_piece_s", "t_wall_y_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wall_y_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wall_y_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_water_dp/t_water_dp.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_water_dp/t_water_dp.json
@@ -18,18 +18,18 @@
       {
         "id": "corner",
         "bg": "t_grass",
-        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_sw", "t_water_dp_corner_se", "t_water_dp_corner_ne" ]
+        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_ne", "t_water_dp_corner_se", "t_water_dp_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass",
-        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_w", "t_water_dp_t_connection_s", "t_water_dp_t_connection_e" ]
+        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_e", "t_water_dp_t_connection_s", "t_water_dp_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_grass", "fg": [ "t_water_dp_edge_ns", "t_water_dp_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass",
-        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_w", "t_water_dp_end_piece_s", "t_water_dp_end_piece_e" ]
+        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_e", "t_water_dp_end_piece_s", "t_water_dp_end_piece_w" ]
       },
       { "bg": "t_grass", "id": "unconnected", "fg": "t_water_dp_unconnected" }
     ]
@@ -52,18 +52,18 @@
       {
         "id": "corner",
         "bg": "t_grass_summer",
-        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_sw", "t_water_dp_corner_se", "t_water_dp_corner_ne" ]
+        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_ne", "t_water_dp_corner_se", "t_water_dp_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_summer",
-        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_w", "t_water_dp_t_connection_s", "t_water_dp_t_connection_e" ]
+        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_e", "t_water_dp_t_connection_s", "t_water_dp_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_grass_summer", "fg": [ "t_water_dp_edge_ns", "t_water_dp_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_summer",
-        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_w", "t_water_dp_end_piece_s", "t_water_dp_end_piece_e" ]
+        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_e", "t_water_dp_end_piece_s", "t_water_dp_end_piece_w" ]
       },
       { "bg": "t_grass_summer", "id": "unconnected", "fg": "t_water_dp_unconnected" }
     ]
@@ -86,18 +86,18 @@
       {
         "id": "corner",
         "bg": "t_grass_autumn",
-        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_sw", "t_water_dp_corner_se", "t_water_dp_corner_ne" ]
+        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_ne", "t_water_dp_corner_se", "t_water_dp_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_autumn",
-        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_w", "t_water_dp_t_connection_s", "t_water_dp_t_connection_e" ]
+        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_e", "t_water_dp_t_connection_s", "t_water_dp_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_grass_autumn", "fg": [ "t_water_dp_edge_ns", "t_water_dp_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_autumn",
-        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_w", "t_water_dp_end_piece_s", "t_water_dp_end_piece_e" ]
+        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_e", "t_water_dp_end_piece_s", "t_water_dp_end_piece_w" ]
       },
       { "bg": "t_grass_autumn", "id": "unconnected", "fg": "t_water_dp_unconnected" }
     ]
@@ -120,23 +120,23 @@
       {
         "id": "corner",
         "bg": "snow_shallow_center",
-        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_sw", "t_water_dp_corner_se", "t_water_dp_corner_ne" ]
+        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_ne", "t_water_dp_corner_se", "t_water_dp_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "snow_shallow_center",
-        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_w", "t_water_dp_t_connection_s", "t_water_dp_t_connection_e" ]
+        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_e", "t_water_dp_t_connection_s", "t_water_dp_t_connection_w" ]
       },
       { "id": "edge", "bg": "snow_shallow_center", "fg": [ "t_water_dp_edge_ns", "t_water_dp_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "snow_shallow_center",
-        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_w", "t_water_dp_end_piece_s", "t_water_dp_end_piece_e" ]
+        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_e", "t_water_dp_end_piece_s", "t_water_dp_end_piece_w" ]
       },
       { "bg": "snow_shallow_center", "id": "unconnected", "fg": "t_water_dp_unconnected" }
     ]
   },
-   {
+  {
     "id": [ "t_water_dp_underground", "t_swater_dp_underground" ],
     "multitile": true,
     "fg": "t_water_dp_unconnected",
@@ -155,18 +155,18 @@
       {
         "id": "corner",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_sw", "t_water_dp_corner_se", "t_water_dp_corner_ne" ]
+        "fg": [ "t_water_dp_corner_nw", "t_water_dp_corner_ne", "t_water_dp_corner_se", "t_water_dp_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_w", "t_water_dp_t_connection_s", "t_water_dp_t_connection_e" ]
+        "fg": [ "t_water_dp_t_connection_n", "t_water_dp_t_connection_e", "t_water_dp_t_connection_s", "t_water_dp_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_rock_floor_center", "fg": [ "t_water_dp_edge_ns", "t_water_dp_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_w", "t_water_dp_end_piece_s", "t_water_dp_end_piece_e" ]
+        "fg": [ "t_water_dp_end_piece_n", "t_water_dp_end_piece_e", "t_water_dp_end_piece_s", "t_water_dp_end_piece_w" ]
       },
       { "bg": "t_rock_floor_center", "id": "unconnected", "fg": "t_water_dp_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_water_hot/t_water_hot.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_water_hot/t_water_hot.json
@@ -1,235 +1,130 @@
 [
-{
-  "id": "t_water_hot",
-  "fg": "t_water_hot_unconnected",
-  "bg": "t_grass",
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_water_hot_center",
-      "bg": "t_grass"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_water_hot_corner_nw",
-        "t_water_hot_corner_sw",
-        "t_water_hot_corner_se",
-        "t_water_hot_corner_ne"
-      ],
-      "bg": "t_grass"
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "t_water_hot_t_connection_n",
-        "t_water_hot_t_connection_w",
-        "t_water_hot_t_connection_s",
-        "t_water_hot_t_connection_e"
-      ],
-      "bg": "t_grass"
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "t_water_hot_edge_ns",
-        "t_water_hot_edge_ew"
-      ],
-      "bg": "t_grass"
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "t_water_hot_end_piece_n",
-        "t_water_hot_end_piece_w",
-        "t_water_hot_end_piece_s",
-        "t_water_hot_end_piece_e"
-      ],
-      "bg": "t_grass"
-    },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_water_hot_unconnected",
-        "t_water_hot_unconnected"
-      ],
-      "bg": "t_grass"
-    }
-  ]
-}, {
-  "id": "t_water_hot_season_summer",
-  "fg": "t_water_hot_unconnected",
-  "bg": "t_grass_summer",
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_water_hot_center",
-      "bg": "t_grass_summer"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_water_hot_corner_nw",
-        "t_water_hot_corner_sw",
-        "t_water_hot_corner_se",
-        "t_water_hot_corner_ne"
-      ],
-      "bg": "t_grass_summer"
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "t_water_hot_t_connection_n",
-        "t_water_hot_t_connection_w",
-        "t_water_hot_t_connection_s",
-        "t_water_hot_t_connection_e"
-      ],
-      "bg": "t_grass_summer"
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "t_water_hot_edge_ns",
-        "t_water_hot_edge_ew"
-      ],
-      "bg": "t_grass_summer"
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "t_water_hot_end_piece_n",
-        "t_water_hot_end_piece_w",
-        "t_water_hot_end_piece_s",
-        "t_water_hot_end_piece_e"
-      ],
-      "bg": "t_grass_summer"
-    },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_water_hot_unconnected",
-        "t_water_hot_unconnected"
-      ],
-      "bg": "t_grass_summer"
-    }
-  ]
-}, {
-  "id": "t_water_hot_season_autumn",
-  "fg": "t_water_hot_unconnected",
-  "bg": "t_grass_autumn",
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_water_hot_center",
-      "bg": "t_grass_autumn"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_water_hot_corner_nw",
-        "t_water_hot_corner_sw",
-        "t_water_hot_corner_se",
-        "t_water_hot_corner_ne"
-      ],
-      "bg": "t_grass_autumn"
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "t_water_hot_t_connection_n",
-        "t_water_hot_t_connection_w",
-        "t_water_hot_t_connection_s",
-        "t_water_hot_t_connection_e"
-      ],
-      "bg": "t_grass_autumn"
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "t_water_hot_edge_ns",
-        "t_water_hot_edge_ew"
-      ],
-      "bg": "t_grass_autumn"
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "t_water_hot_end_piece_n",
-        "t_water_hot_end_piece_w",
-        "t_water_hot_end_piece_s",
-        "t_water_hot_end_piece_e"
-      ],
-      "bg": "t_grass_autumn"
-    },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_water_hot_unconnected",
-        "t_water_hot_unconnected"
-      ],
-      "bg": "t_grass_autumn"
-    }
-  ]
-}, {
-  "id": "t_water_hot_season_winter",
-  "fg": "t_water_hot_unconnected",
-  "bg": "snow_shallow_center",
-  "multitile": true,
-  "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_water_hot_center",
-      "bg": "snow_shallow_center"
-    },
-    {
-      "id": "corner",
-      "fg": [
-        "t_water_hot_corner_nw",
-        "t_water_hot_corner_sw",
-        "t_water_hot_corner_se",
-        "t_water_hot_corner_ne"
-      ],
-      "bg": "snow_shallow_center"
-    },
-    {
-      "id": "t_connection",
-      "fg": [
-        "t_water_hot_t_connection_n",
-        "t_water_hot_t_connection_w",
-        "t_water_hot_t_connection_s",
-        "t_water_hot_t_connection_e"
-      ],
-      "bg": "snow_shallow_center"
-    },
-    {
-      "id": "edge",
-      "fg": [
-        "t_water_hot_edge_ns",
-        "t_water_hot_edge_ew"
-      ],
-      "bg": "snow_shallow_center"
-    },
-    {
-      "id": "end_piece",
-      "fg": [
-        "t_water_hot_end_piece_n",
-        "t_water_hot_end_piece_w",
-        "t_water_hot_end_piece_s",
-        "t_water_hot_end_piece_e"
-      ],
-      "bg": "snow_shallow_center"
-    },
-    {
-      "id": "unconnected",
-      "fg": [
-        "t_water_hot_unconnected",
-        "t_water_hot_unconnected"
-      ],
-      "bg": "snow_shallow_center"
-    }
-  ]
-}
+  {
+    "id": "t_water_hot",
+    "fg": "t_water_hot_unconnected",
+    "bg": "t_grass",
+    "multitile": true,
+    "additional_tiles": [
+      { "id": "center", "fg": "t_water_hot_center", "bg": "t_grass" },
+      {
+        "id": "corner",
+        "fg": [ "t_water_hot_corner_nw", "t_water_hot_corner_ne", "t_water_hot_corner_se", "t_water_hot_corner_sw" ],
+        "bg": "t_grass"
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_water_hot_t_connection_n",
+          "t_water_hot_t_connection_e",
+          "t_water_hot_t_connection_s",
+          "t_water_hot_t_connection_w"
+        ],
+        "bg": "t_grass"
+      },
+      { "id": "edge", "fg": [ "t_water_hot_edge_ns", "t_water_hot_edge_ew" ], "bg": "t_grass" },
+      {
+        "id": "end_piece",
+        "fg": [ "t_water_hot_end_piece_n", "t_water_hot_end_piece_e", "t_water_hot_end_piece_s", "t_water_hot_end_piece_w" ],
+        "bg": "t_grass"
+      },
+      { "id": "unconnected", "fg": [ "t_water_hot_unconnected", "t_water_hot_unconnected" ], "bg": "t_grass" }
+    ]
+  },
+  {
+    "id": "t_water_hot_season_summer",
+    "fg": "t_water_hot_unconnected",
+    "bg": "t_grass_summer",
+    "multitile": true,
+    "additional_tiles": [
+      { "id": "center", "fg": "t_water_hot_center", "bg": "t_grass_summer" },
+      {
+        "id": "corner",
+        "fg": [ "t_water_hot_corner_nw", "t_water_hot_corner_ne", "t_water_hot_corner_se", "t_water_hot_corner_sw" ],
+        "bg": "t_grass_summer"
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_water_hot_t_connection_n",
+          "t_water_hot_t_connection_e",
+          "t_water_hot_t_connection_s",
+          "t_water_hot_t_connection_w"
+        ],
+        "bg": "t_grass_summer"
+      },
+      { "id": "edge", "fg": [ "t_water_hot_edge_ns", "t_water_hot_edge_ew" ], "bg": "t_grass_summer" },
+      {
+        "id": "end_piece",
+        "fg": [ "t_water_hot_end_piece_n", "t_water_hot_end_piece_e", "t_water_hot_end_piece_s", "t_water_hot_end_piece_w" ],
+        "bg": "t_grass_summer"
+      },
+      { "id": "unconnected", "fg": [ "t_water_hot_unconnected", "t_water_hot_unconnected" ], "bg": "t_grass_summer" }
+    ]
+  },
+  {
+    "id": "t_water_hot_season_autumn",
+    "fg": "t_water_hot_unconnected",
+    "bg": "t_grass_autumn",
+    "multitile": true,
+    "additional_tiles": [
+      { "id": "center", "fg": "t_water_hot_center", "bg": "t_grass_autumn" },
+      {
+        "id": "corner",
+        "fg": [ "t_water_hot_corner_nw", "t_water_hot_corner_ne", "t_water_hot_corner_se", "t_water_hot_corner_sw" ],
+        "bg": "t_grass_autumn"
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_water_hot_t_connection_n",
+          "t_water_hot_t_connection_e",
+          "t_water_hot_t_connection_s",
+          "t_water_hot_t_connection_w"
+        ],
+        "bg": "t_grass_autumn"
+      },
+      { "id": "edge", "fg": [ "t_water_hot_edge_ns", "t_water_hot_edge_ew" ], "bg": "t_grass_autumn" },
+      {
+        "id": "end_piece",
+        "fg": [ "t_water_hot_end_piece_n", "t_water_hot_end_piece_e", "t_water_hot_end_piece_s", "t_water_hot_end_piece_w" ],
+        "bg": "t_grass_autumn"
+      },
+      { "id": "unconnected", "fg": [ "t_water_hot_unconnected", "t_water_hot_unconnected" ], "bg": "t_grass_autumn" }
+    ]
+  },
+  {
+    "id": "t_water_hot_season_winter",
+    "fg": "t_water_hot_unconnected",
+    "bg": "snow_shallow_center",
+    "multitile": true,
+    "additional_tiles": [
+      { "id": "center", "fg": "t_water_hot_center", "bg": "snow_shallow_center" },
+      {
+        "id": "corner",
+        "fg": [ "t_water_hot_corner_nw", "t_water_hot_corner_ne", "t_water_hot_corner_se", "t_water_hot_corner_sw" ],
+        "bg": "snow_shallow_center"
+      },
+      {
+        "id": "t_connection",
+        "fg": [
+          "t_water_hot_t_connection_n",
+          "t_water_hot_t_connection_e",
+          "t_water_hot_t_connection_s",
+          "t_water_hot_t_connection_w"
+        ],
+        "bg": "snow_shallow_center"
+      },
+      { "id": "edge", "fg": [ "t_water_hot_edge_ns", "t_water_hot_edge_ew" ], "bg": "snow_shallow_center" },
+      {
+        "id": "end_piece",
+        "fg": [ "t_water_hot_end_piece_n", "t_water_hot_end_piece_e", "t_water_hot_end_piece_s", "t_water_hot_end_piece_w" ],
+        "bg": "snow_shallow_center"
+      },
+      {
+        "id": "unconnected",
+        "fg": [ "t_water_hot_unconnected", "t_water_hot_unconnected" ],
+        "bg": "snow_shallow_center"
+      }
+    ]
+  }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_water_moving_dp/t_water_moving_dp.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_water_moving_dp/t_water_moving_dp.json
@@ -8,26 +8,38 @@
       {
         "id": "center",
         "bg": "t_grass",
-        "fg": [
-          { "weight": 1, "sprite": "t_water_moving_dp_center" },
-          { "weight": 1, "sprite": "t_water_moving_dp_center2" }
-        ]
+        "fg": [ { "weight": 1, "sprite": "t_water_moving_dp_center" }, { "weight": 1, "sprite": "t_water_moving_dp_center2" } ]
       },
       {
         "id": "corner",
         "bg": "t_grass",
-        "fg": [ "t_water_moving_dp_corner_nw", "t_water_moving_dp_corner_sw", "t_water_moving_dp_corner_se", "t_water_moving_dp_corner_ne" ]
+        "fg": [
+          "t_water_moving_dp_corner_nw",
+          "t_water_moving_dp_corner_ne",
+          "t_water_moving_dp_corner_se",
+          "t_water_moving_dp_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass",
-        "fg": [ "t_water_moving_dp_t_connection_n", "t_water_moving_dp_t_connection_w", "t_water_moving_dp_t_connection_s", "t_water_moving_dp_t_connection_e" ]
+        "fg": [
+          "t_water_moving_dp_t_connection_n",
+          "t_water_moving_dp_t_connection_e",
+          "t_water_moving_dp_t_connection_s",
+          "t_water_moving_dp_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "t_grass", "fg": [ "t_water_moving_dp_edge_ns", "t_water_moving_dp_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass",
-        "fg": [ "t_water_moving_dp_end_piece_n", "t_water_moving_dp_end_piece_w", "t_water_moving_dp_end_piece_s", "t_water_moving_dp_end_piece_e" ]
+        "fg": [
+          "t_water_moving_dp_end_piece_n",
+          "t_water_moving_dp_end_piece_e",
+          "t_water_moving_dp_end_piece_s",
+          "t_water_moving_dp_end_piece_w"
+        ]
       },
       { "bg": "t_grass", "id": "unconnected", "fg": "t_water_moving_dp_unconnected" }
     ]
@@ -41,26 +53,38 @@
       {
         "id": "center",
         "bg": "t_grass_summer",
-        "fg": [
-          { "weight": 1, "sprite": "t_water_moving_dp_center" },
-          { "weight": 1, "sprite": "t_water_moving_dp_center2" }
-        ]
+        "fg": [ { "weight": 1, "sprite": "t_water_moving_dp_center" }, { "weight": 1, "sprite": "t_water_moving_dp_center2" } ]
       },
       {
         "id": "corner",
         "bg": "t_grass_summer",
-        "fg": [ "t_water_moving_dp_corner_nw", "t_water_moving_dp_corner_sw", "t_water_moving_dp_corner_se", "t_water_moving_dp_corner_ne" ]
+        "fg": [
+          "t_water_moving_dp_corner_nw",
+          "t_water_moving_dp_corner_ne",
+          "t_water_moving_dp_corner_se",
+          "t_water_moving_dp_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_summer",
-        "fg": [ "t_water_moving_dp_t_connection_n", "t_water_moving_dp_t_connection_w", "t_water_moving_dp_t_connection_s", "t_water_moving_dp_t_connection_e" ]
+        "fg": [
+          "t_water_moving_dp_t_connection_n",
+          "t_water_moving_dp_t_connection_e",
+          "t_water_moving_dp_t_connection_s",
+          "t_water_moving_dp_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "t_grass_summer", "fg": [ "t_water_moving_dp_edge_ns", "t_water_moving_dp_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_summer",
-        "fg": [ "t_water_moving_dp_end_piece_n", "t_water_moving_dp_end_piece_w", "t_water_moving_dp_end_piece_s", "t_water_moving_dp_end_piece_e" ]
+        "fg": [
+          "t_water_moving_dp_end_piece_n",
+          "t_water_moving_dp_end_piece_e",
+          "t_water_moving_dp_end_piece_s",
+          "t_water_moving_dp_end_piece_w"
+        ]
       },
       { "bg": "t_grass_summer", "id": "unconnected", "fg": "t_water_moving_dp_unconnected" }
     ]
@@ -74,26 +98,38 @@
       {
         "id": "center",
         "bg": "t_grass_autumn",
-        "fg": [
-          { "weight": 1, "sprite": "t_water_moving_dp_center" },
-          { "weight": 1, "sprite": "t_water_moving_dp_center2" }
-        ]
+        "fg": [ { "weight": 1, "sprite": "t_water_moving_dp_center" }, { "weight": 1, "sprite": "t_water_moving_dp_center2" } ]
       },
       {
         "id": "corner",
         "bg": "t_grass_autumn",
-        "fg": [ "t_water_moving_dp_corner_nw", "t_water_moving_dp_corner_sw", "t_water_moving_dp_corner_se", "t_water_moving_dp_corner_ne" ]
+        "fg": [
+          "t_water_moving_dp_corner_nw",
+          "t_water_moving_dp_corner_ne",
+          "t_water_moving_dp_corner_se",
+          "t_water_moving_dp_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_autumn",
-        "fg": [ "t_water_moving_dp_t_connection_n", "t_water_moving_dp_t_connection_w", "t_water_moving_dp_t_connection_s", "t_water_moving_dp_t_connection_e" ]
+        "fg": [
+          "t_water_moving_dp_t_connection_n",
+          "t_water_moving_dp_t_connection_e",
+          "t_water_moving_dp_t_connection_s",
+          "t_water_moving_dp_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "t_grass_autumn", "fg": [ "t_water_moving_dp_edge_ns", "t_water_moving_dp_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_autumn",
-        "fg": [ "t_water_moving_dp_end_piece_n", "t_water_moving_dp_end_piece_w", "t_water_moving_dp_end_piece_s", "t_water_moving_dp_end_piece_e" ]
+        "fg": [
+          "t_water_moving_dp_end_piece_n",
+          "t_water_moving_dp_end_piece_e",
+          "t_water_moving_dp_end_piece_s",
+          "t_water_moving_dp_end_piece_w"
+        ]
       },
       { "bg": "t_grass_autumn", "id": "unconnected", "fg": "t_water_moving_dp_unconnected" }
     ]
@@ -107,26 +143,42 @@
       {
         "id": "center",
         "bg": "snow_shallow_center",
-        "fg": [
-          { "weight": 1, "sprite": "t_water_moving_dp_center" },
-          { "weight": 1, "sprite": "t_water_moving_dp_center2" }
-        ]
+        "fg": [ { "weight": 1, "sprite": "t_water_moving_dp_center" }, { "weight": 1, "sprite": "t_water_moving_dp_center2" } ]
       },
       {
         "id": "corner",
         "bg": "snow_shallow_center",
-        "fg": [ "t_water_moving_dp_corner_nw", "t_water_moving_dp_corner_sw", "t_water_moving_dp_corner_se", "t_water_moving_dp_corner_ne" ]
+        "fg": [
+          "t_water_moving_dp_corner_nw",
+          "t_water_moving_dp_corner_ne",
+          "t_water_moving_dp_corner_se",
+          "t_water_moving_dp_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "snow_shallow_center",
-        "fg": [ "t_water_moving_dp_t_connection_n", "t_water_moving_dp_t_connection_w", "t_water_moving_dp_t_connection_s", "t_water_moving_dp_t_connection_e" ]
+        "fg": [
+          "t_water_moving_dp_t_connection_n",
+          "t_water_moving_dp_t_connection_e",
+          "t_water_moving_dp_t_connection_s",
+          "t_water_moving_dp_t_connection_w"
+        ]
       },
-      { "id": "edge", "bg": "snow_shallow_center", "fg": [ "t_water_moving_dp_edge_ns", "t_water_moving_dp_edge_ew" ] },
+      {
+        "id": "edge",
+        "bg": "snow_shallow_center",
+        "fg": [ "t_water_moving_dp_edge_ns", "t_water_moving_dp_edge_ew" ]
+      },
       {
         "id": "end_piece",
         "bg": "snow_shallow_center",
-        "fg": [ "t_water_moving_dp_end_piece_n", "t_water_moving_dp_end_piece_w", "t_water_moving_dp_end_piece_s", "t_water_moving_dp_end_piece_e" ]
+        "fg": [
+          "t_water_moving_dp_end_piece_n",
+          "t_water_moving_dp_end_piece_e",
+          "t_water_moving_dp_end_piece_s",
+          "t_water_moving_dp_end_piece_w"
+        ]
       },
       { "bg": "snow_shallow_center", "id": "unconnected", "fg": "t_water_moving_dp_unconnected" }
     ]
@@ -140,26 +192,42 @@
       {
         "id": "center",
         "bg": "t_rock_floor_center",
-        "fg": [
-          { "weight": 1, "sprite": "t_water_moving_dp_center" },
-          { "weight": 1, "sprite": "t_water_moving_dp_center2" }
-        ]
+        "fg": [ { "weight": 1, "sprite": "t_water_moving_dp_center" }, { "weight": 1, "sprite": "t_water_moving_dp_center2" } ]
       },
       {
         "id": "corner",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_water_moving_dp_corner_nw", "t_water_moving_dp_corner_sw", "t_water_moving_dp_corner_se", "t_water_moving_dp_corner_ne" ]
+        "fg": [
+          "t_water_moving_dp_corner_nw",
+          "t_water_moving_dp_corner_ne",
+          "t_water_moving_dp_corner_se",
+          "t_water_moving_dp_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_water_moving_dp_t_connection_n", "t_water_moving_dp_t_connection_w", "t_water_moving_dp_t_connection_s", "t_water_moving_dp_t_connection_e" ]
+        "fg": [
+          "t_water_moving_dp_t_connection_n",
+          "t_water_moving_dp_t_connection_e",
+          "t_water_moving_dp_t_connection_s",
+          "t_water_moving_dp_t_connection_w"
+        ]
       },
-      { "id": "edge", "bg": "t_rock_floor_center", "fg": [ "t_water_moving_dp_edge_ns", "t_water_moving_dp_edge_ew" ] },
+      {
+        "id": "edge",
+        "bg": "t_rock_floor_center",
+        "fg": [ "t_water_moving_dp_edge_ns", "t_water_moving_dp_edge_ew" ]
+      },
       {
         "id": "end_piece",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_water_moving_dp_end_piece_n", "t_water_moving_dp_end_piece_w", "t_water_moving_dp_end_piece_s", "t_water_moving_dp_end_piece_e" ]
+        "fg": [
+          "t_water_moving_dp_end_piece_n",
+          "t_water_moving_dp_end_piece_e",
+          "t_water_moving_dp_end_piece_s",
+          "t_water_moving_dp_end_piece_w"
+        ]
       },
       { "bg": "t_rock_floor_center", "id": "unconnected", "fg": "t_water_moving_dp_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_water_moving_sh/t_water_moving_sh.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_water_moving_sh/t_water_moving_sh.json
@@ -9,27 +9,42 @@
         "id": "center",
         "bg": "t_grass",
         "fg": [
-            { "weight": 1, "sprite": "t_water_moving_sh_center" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center2" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center3" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center4" }
+          { "weight": 1, "sprite": "t_water_moving_sh_center" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center2" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center3" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center4" }
         ]
       },
       {
         "id": "corner",
         "bg": "t_grass",
-        "fg": [ "t_water_moving_sh_corner_nw", "t_water_moving_sh_corner_sw", "t_water_moving_sh_corner_se", "t_water_moving_sh_corner_ne" ]
+        "fg": [
+          "t_water_moving_sh_corner_nw",
+          "t_water_moving_sh_corner_ne",
+          "t_water_moving_sh_corner_se",
+          "t_water_moving_sh_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass",
-        "fg": [ "t_water_moving_sh_t_connection_n", "t_water_moving_sh_t_connection_w", "t_water_moving_sh_t_connection_s", "t_water_moving_sh_t_connection_e" ]
+        "fg": [
+          "t_water_moving_sh_t_connection_n",
+          "t_water_moving_sh_t_connection_e",
+          "t_water_moving_sh_t_connection_s",
+          "t_water_moving_sh_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "t_grass", "fg": [ "t_water_moving_sh_edge_ns", "t_water_moving_sh_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass",
-        "fg": [ "t_water_moving_sh_end_piece_n", "t_water_moving_sh_end_piece_w", "t_water_moving_sh_end_piece_s", "t_water_moving_sh_end_piece_e" ]
+        "fg": [
+          "t_water_moving_sh_end_piece_n",
+          "t_water_moving_sh_end_piece_e",
+          "t_water_moving_sh_end_piece_s",
+          "t_water_moving_sh_end_piece_w"
+        ]
       },
       { "bg": "t_grass", "id": "unconnected", "fg": "t_water_moving_sh_unconnected" }
     ]
@@ -44,27 +59,42 @@
         "id": "center",
         "bg": "t_grass_summer",
         "fg": [
-            { "weight": 1, "sprite": "t_water_moving_sh_center" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center2" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center3" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center4" }
+          { "weight": 1, "sprite": "t_water_moving_sh_center" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center2" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center3" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center4" }
         ]
       },
       {
         "id": "corner",
         "bg": "t_grass_summer",
-        "fg": [ "t_water_moving_sh_corner_nw", "t_water_moving_sh_corner_sw", "t_water_moving_sh_corner_se", "t_water_moving_sh_corner_ne" ]
+        "fg": [
+          "t_water_moving_sh_corner_nw",
+          "t_water_moving_sh_corner_ne",
+          "t_water_moving_sh_corner_se",
+          "t_water_moving_sh_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_summer",
-        "fg": [ "t_water_moving_sh_t_connection_n", "t_water_moving_sh_t_connection_w", "t_water_moving_sh_t_connection_s", "t_water_moving_sh_t_connection_e" ]
+        "fg": [
+          "t_water_moving_sh_t_connection_n",
+          "t_water_moving_sh_t_connection_e",
+          "t_water_moving_sh_t_connection_s",
+          "t_water_moving_sh_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "t_grass_summer", "fg": [ "t_water_moving_sh_edge_ns", "t_water_moving_sh_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_summer",
-        "fg": [ "t_water_moving_sh_end_piece_n", "t_water_moving_sh_end_piece_w", "t_water_moving_sh_end_piece_s", "t_water_moving_sh_end_piece_e" ]
+        "fg": [
+          "t_water_moving_sh_end_piece_n",
+          "t_water_moving_sh_end_piece_e",
+          "t_water_moving_sh_end_piece_s",
+          "t_water_moving_sh_end_piece_w"
+        ]
       },
       { "bg": "t_grass_summer", "id": "unconnected", "fg": "t_water_moving_sh_unconnected" }
     ]
@@ -79,27 +109,42 @@
         "id": "center",
         "bg": "t_grass_autumn",
         "fg": [
-            { "weight": 1, "sprite": "t_water_moving_sh_center" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center2" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center3" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center4" }
+          { "weight": 1, "sprite": "t_water_moving_sh_center" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center2" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center3" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center4" }
         ]
       },
       {
         "id": "corner",
         "bg": "t_grass_autumn",
-        "fg": [ "t_water_moving_sh_corner_nw", "t_water_moving_sh_corner_sw", "t_water_moving_sh_corner_se", "t_water_moving_sh_corner_ne" ]
+        "fg": [
+          "t_water_moving_sh_corner_nw",
+          "t_water_moving_sh_corner_ne",
+          "t_water_moving_sh_corner_se",
+          "t_water_moving_sh_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_autumn",
-        "fg": [ "t_water_moving_sh_t_connection_n", "t_water_moving_sh_t_connection_w", "t_water_moving_sh_t_connection_s", "t_water_moving_sh_t_connection_e" ]
+        "fg": [
+          "t_water_moving_sh_t_connection_n",
+          "t_water_moving_sh_t_connection_e",
+          "t_water_moving_sh_t_connection_s",
+          "t_water_moving_sh_t_connection_w"
+        ]
       },
       { "id": "edge", "bg": "t_grass_autumn", "fg": [ "t_water_moving_sh_edge_ns", "t_water_moving_sh_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_autumn",
-        "fg": [ "t_water_moving_sh_end_piece_n", "t_water_moving_sh_end_piece_w", "t_water_moving_sh_end_piece_s", "t_water_moving_sh_end_piece_e" ]
+        "fg": [
+          "t_water_moving_sh_end_piece_n",
+          "t_water_moving_sh_end_piece_e",
+          "t_water_moving_sh_end_piece_s",
+          "t_water_moving_sh_end_piece_w"
+        ]
       },
       { "bg": "t_grass_autumn", "id": "unconnected", "fg": "t_water_moving_sh_unconnected" }
     ]
@@ -114,32 +159,51 @@
         "id": "center",
         "bg": "snow_shallow_center",
         "fg": [
-            { "weight": 1, "sprite": "t_water_moving_sh_center" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center2" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center3" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center4" }
+          { "weight": 1, "sprite": "t_water_moving_sh_center" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center2" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center3" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center4" }
         ]
       },
       {
         "id": "corner",
         "bg": "snow_shallow_center",
-        "fg": [ "t_water_moving_sh_corner_nw", "t_water_moving_sh_corner_sw", "t_water_moving_sh_corner_se", "t_water_moving_sh_corner_ne" ]
+        "fg": [
+          "t_water_moving_sh_corner_nw",
+          "t_water_moving_sh_corner_ne",
+          "t_water_moving_sh_corner_se",
+          "t_water_moving_sh_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "snow_shallow_center",
-        "fg": [ "t_water_moving_sh_t_connection_n", "t_water_moving_sh_t_connection_w", "t_water_moving_sh_t_connection_s", "t_water_moving_sh_t_connection_e" ]
+        "fg": [
+          "t_water_moving_sh_t_connection_n",
+          "t_water_moving_sh_t_connection_e",
+          "t_water_moving_sh_t_connection_s",
+          "t_water_moving_sh_t_connection_w"
+        ]
       },
-      { "id": "edge", "bg": "snow_shallow_center", "fg": [ "t_water_moving_sh_edge_ns", "t_water_moving_sh_edge_ew" ] },
+      {
+        "id": "edge",
+        "bg": "snow_shallow_center",
+        "fg": [ "t_water_moving_sh_edge_ns", "t_water_moving_sh_edge_ew" ]
+      },
       {
         "id": "end_piece",
         "bg": "snow_shallow_center",
-        "fg": [ "t_water_moving_sh_end_piece_n", "t_water_moving_sh_end_piece_w", "t_water_moving_sh_end_piece_s", "t_water_moving_sh_end_piece_e" ]
+        "fg": [
+          "t_water_moving_sh_end_piece_n",
+          "t_water_moving_sh_end_piece_e",
+          "t_water_moving_sh_end_piece_s",
+          "t_water_moving_sh_end_piece_w"
+        ]
       },
       { "bg": "snow_shallow_center", "id": "unconnected", "fg": "t_water_moving_sh_unconnected" }
     ]
   },
-   {
+  {
     "id": "t_water_moving_sh_underground",
     "multitile": true,
     "fg": "t_water_moving_sh_unconnected",
@@ -149,27 +213,46 @@
         "id": "center",
         "bg": "t_rock_floor_center",
         "fg": [
-            { "weight": 1, "sprite": "t_water_moving_sh_center" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center2" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center3" },
-            { "weight": 1, "sprite": "t_water_moving_sh_center4" }
+          { "weight": 1, "sprite": "t_water_moving_sh_center" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center2" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center3" },
+          { "weight": 1, "sprite": "t_water_moving_sh_center4" }
         ]
       },
       {
         "id": "corner",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_water_moving_sh_corner_nw", "t_water_moving_sh_corner_sw", "t_water_moving_sh_corner_se", "t_water_moving_sh_corner_ne" ]
+        "fg": [
+          "t_water_moving_sh_corner_nw",
+          "t_water_moving_sh_corner_ne",
+          "t_water_moving_sh_corner_se",
+          "t_water_moving_sh_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_water_moving_sh_t_connection_n", "t_water_moving_sh_t_connection_w", "t_water_moving_sh_t_connection_s", "t_water_moving_sh_t_connection_e" ]
+        "fg": [
+          "t_water_moving_sh_t_connection_n",
+          "t_water_moving_sh_t_connection_e",
+          "t_water_moving_sh_t_connection_s",
+          "t_water_moving_sh_t_connection_w"
+        ]
       },
-      { "id": "edge", "bg": "t_rock_floor_center", "fg": [ "t_water_moving_sh_edge_ns", "t_water_moving_sh_edge_ew" ] },
+      {
+        "id": "edge",
+        "bg": "t_rock_floor_center",
+        "fg": [ "t_water_moving_sh_edge_ns", "t_water_moving_sh_edge_ew" ]
+      },
       {
         "id": "end_piece",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_water_moving_sh_end_piece_n", "t_water_moving_sh_end_piece_w", "t_water_moving_sh_end_piece_s", "t_water_moving_sh_end_piece_e" ]
+        "fg": [
+          "t_water_moving_sh_end_piece_n",
+          "t_water_moving_sh_end_piece_e",
+          "t_water_moving_sh_end_piece_s",
+          "t_water_moving_sh_end_piece_w"
+        ]
       },
       { "bg": "t_rock_floor_center", "id": "unconnected", "fg": "t_water_moving_sh_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_water_pool/t_water_pool.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_water_pool/t_water_pool.json
@@ -19,48 +19,24 @@
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "t_water_pool_corner_nw",
-        "t_water_pool_corner_sw",
-        "t_water_pool_corner_se",
-        "t_water_pool_corner_ne"
-      ]
+      "fg": [ "t_water_pool_corner_nw", "t_water_pool_corner_ne", "t_water_pool_corner_se", "t_water_pool_corner_sw" ]
     },
     {
       "id": "t_connection",
       "bg": "",
       "fg": [
         "t_water_pool_t_connection_n",
-        "t_water_pool_t_connection_w",
+        "t_water_pool_t_connection_e",
         "t_water_pool_t_connection_s",
-        "t_water_pool_t_connection_e"
+        "t_water_pool_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "t_water_pool_edge_ns",
-        "t_water_pool_edge_ew"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "t_water_pool_edge_ns", "t_water_pool_edge_ew" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "t_water_pool_end_piece_n",
-        "t_water_pool_end_piece_w",
-        "t_water_pool_end_piece_s",
-        "t_water_pool_end_piece_e"
-      ]
+      "fg": [ "t_water_pool_end_piece_n", "t_water_pool_end_piece_e", "t_water_pool_end_piece_s", "t_water_pool_end_piece_w" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [
-        "t_water_pool_unconnected",
-        "t_water_pool_unconnected"
-      ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "t_water_pool_unconnected", "t_water_pool_unconnected" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_water_sh/t_water_sh.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_water_sh/t_water_sh.json
@@ -18,18 +18,18 @@
       {
         "id": "corner",
         "bg": "t_grass",
-        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_sw", "t_water_sh_corner_se", "t_water_sh_corner_ne" ]
+        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_ne", "t_water_sh_corner_se", "t_water_sh_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass",
-        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_w", "t_water_sh_t_connection_s", "t_water_sh_t_connection_e" ]
+        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_e", "t_water_sh_t_connection_s", "t_water_sh_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_grass", "fg": [ "t_water_sh_edge_ns", "t_water_sh_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass",
-        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_w", "t_water_sh_end_piece_s", "t_water_sh_end_piece_e" ]
+        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_e", "t_water_sh_end_piece_s", "t_water_sh_end_piece_w" ]
       },
       { "bg": "t_grass", "id": "unconnected", "fg": "t_water_sh_unconnected" }
     ]
@@ -52,18 +52,18 @@
       {
         "id": "corner",
         "bg": "t_grass_summer",
-        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_sw", "t_water_sh_corner_se", "t_water_sh_corner_ne" ]
+        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_ne", "t_water_sh_corner_se", "t_water_sh_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_summer",
-        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_w", "t_water_sh_t_connection_s", "t_water_sh_t_connection_e" ]
+        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_e", "t_water_sh_t_connection_s", "t_water_sh_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_grass_summer", "fg": [ "t_water_sh_edge_ns", "t_water_sh_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_summer",
-        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_w", "t_water_sh_end_piece_s", "t_water_sh_end_piece_e" ]
+        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_e", "t_water_sh_end_piece_s", "t_water_sh_end_piece_w" ]
       },
       { "bg": "t_grass_summer", "id": "unconnected", "fg": "t_water_sh_unconnected" }
     ]
@@ -86,18 +86,18 @@
       {
         "id": "corner",
         "bg": "t_grass_autumn",
-        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_sw", "t_water_sh_corner_se", "t_water_sh_corner_ne" ]
+        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_ne", "t_water_sh_corner_se", "t_water_sh_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_autumn",
-        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_w", "t_water_sh_t_connection_s", "t_water_sh_t_connection_e" ]
+        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_e", "t_water_sh_t_connection_s", "t_water_sh_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_grass_autumn", "fg": [ "t_water_sh_edge_ns", "t_water_sh_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_autumn",
-        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_w", "t_water_sh_end_piece_s", "t_water_sh_end_piece_e" ]
+        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_e", "t_water_sh_end_piece_s", "t_water_sh_end_piece_w" ]
       },
       { "bg": "t_grass_autumn", "id": "unconnected", "fg": "t_water_sh_unconnected" }
     ]
@@ -120,18 +120,18 @@
       {
         "id": "corner",
         "bg": "snow_shallow_center",
-        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_sw", "t_water_sh_corner_se", "t_water_sh_corner_ne" ]
+        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_ne", "t_water_sh_corner_se", "t_water_sh_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "snow_shallow_center",
-        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_w", "t_water_sh_t_connection_s", "t_water_sh_t_connection_e" ]
+        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_e", "t_water_sh_t_connection_s", "t_water_sh_t_connection_w" ]
       },
       { "id": "edge", "bg": "snow_shallow_center", "fg": [ "t_water_sh_edge_ns", "t_water_sh_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "snow_shallow_center",
-        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_w", "t_water_sh_end_piece_s", "t_water_sh_end_piece_e" ]
+        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_e", "t_water_sh_end_piece_s", "t_water_sh_end_piece_w" ]
       },
       { "bg": "snow_shallow_center", "id": "unconnected", "fg": "t_water_sh_unconnected" }
     ]
@@ -155,18 +155,18 @@
       {
         "id": "corner",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_sw", "t_water_sh_corner_se", "t_water_sh_corner_ne" ]
+        "fg": [ "t_water_sh_corner_nw", "t_water_sh_corner_ne", "t_water_sh_corner_se", "t_water_sh_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_w", "t_water_sh_t_connection_s", "t_water_sh_t_connection_e" ]
+        "fg": [ "t_water_sh_t_connection_n", "t_water_sh_t_connection_e", "t_water_sh_t_connection_s", "t_water_sh_t_connection_w" ]
       },
       { "id": "edge", "bg": "t_rock_floor_center", "fg": [ "t_water_sh_edge_ns", "t_water_sh_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_rock_floor_center",
-        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_w", "t_water_sh_end_piece_s", "t_water_sh_end_piece_e" ]
+        "fg": [ "t_water_sh_end_piece_n", "t_water_sh_end_piece_e", "t_water_sh_end_piece_s", "t_water_sh_end_piece_w" ]
       },
       { "bg": "t_rock_floor_center", "id": "unconnected", "fg": "t_water_sh_unconnected" }
     ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wattle_fence/t_wattle_fence.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wattle_fence/t_wattle_fence.json
@@ -5,54 +5,34 @@
     "bg": "t_grass",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_wattle_fence_center",
-        "bg": "t_grass"
-      },
+      { "id": "center", "fg": "t_wattle_fence_center", "bg": "t_grass" },
       {
         "id": "corner",
-        "fg": [
-          "t_wattle_fence_corner_nw",
-          "t_wattle_fence_corner_sw",
-          "t_wattle_fence_corner_se",
-          "t_wattle_fence_corner_ne"
-        ],
+        "fg": [ "t_wattle_fence_corner_nw", "t_wattle_fence_corner_ne", "t_wattle_fence_corner_se", "t_wattle_fence_corner_sw" ],
         "bg": "t_grass"
       },
       {
         "id": "t_connection",
         "fg": [
           "t_wattle_fence_t_connection_n",
-          "t_wattle_fence_t_connection_w",
+          "t_wattle_fence_t_connection_e",
           "t_wattle_fence_t_connection_s",
-          "t_wattle_fence_t_connection_e"
+          "t_wattle_fence_t_connection_w"
         ],
         "bg": "t_grass"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_wattle_fence_edge_ns",
-          "t_wattle_fence_edge_ew"
-        ],
-        "bg": "t_grass"
-      },
+      { "id": "edge", "fg": [ "t_wattle_fence_edge_ns", "t_wattle_fence_edge_ew" ], "bg": "t_grass" },
       {
         "id": "end_piece",
         "fg": [
           "t_wattle_fence_end_piece_n",
-          "t_wattle_fence_end_piece_w",
+          "t_wattle_fence_end_piece_e",
           "t_wattle_fence_end_piece_s",
-          "t_wattle_fence_end_piece_e"
+          "t_wattle_fence_end_piece_w"
         ],
         "bg": "t_grass"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_wattle_fence_unconnected",
-        "bg": "t_grass"
-      }
+      { "id": "unconnected", "fg": "t_wattle_fence_unconnected", "bg": "t_grass" }
     ]
   },
   {
@@ -61,54 +41,34 @@
     "bg": "t_grass_summer",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_wattle_fence_center",
-        "bg": "t_grass_summer"
-      },
+      { "id": "center", "fg": "t_wattle_fence_center", "bg": "t_grass_summer" },
       {
         "id": "corner",
-        "fg": [
-          "t_wattle_fence_corner_nw",
-          "t_wattle_fence_corner_sw",
-          "t_wattle_fence_corner_se",
-          "t_wattle_fence_corner_ne"
-        ],
+        "fg": [ "t_wattle_fence_corner_nw", "t_wattle_fence_corner_ne", "t_wattle_fence_corner_se", "t_wattle_fence_corner_sw" ],
         "bg": "t_grass_summer"
       },
       {
         "id": "t_connection",
         "fg": [
           "t_wattle_fence_t_connection_n",
-          "t_wattle_fence_t_connection_w",
+          "t_wattle_fence_t_connection_e",
           "t_wattle_fence_t_connection_s",
-          "t_wattle_fence_t_connection_e"
+          "t_wattle_fence_t_connection_w"
         ],
         "bg": "t_grass_summer"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_wattle_fence_edge_ns",
-          "t_wattle_fence_edge_ew"
-        ],
-        "bg": "t_grass_summer"
-      },
+      { "id": "edge", "fg": [ "t_wattle_fence_edge_ns", "t_wattle_fence_edge_ew" ], "bg": "t_grass_summer" },
       {
         "id": "end_piece",
         "fg": [
           "t_wattle_fence_end_piece_n",
-          "t_wattle_fence_end_piece_w",
+          "t_wattle_fence_end_piece_e",
           "t_wattle_fence_end_piece_s",
-          "t_wattle_fence_end_piece_e"
+          "t_wattle_fence_end_piece_w"
         ],
         "bg": "t_grass_summer"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_wattle_fence_unconnected",
-        "bg": "t_grass_summer"
-      }
+      { "id": "unconnected", "fg": "t_wattle_fence_unconnected", "bg": "t_grass_summer" }
     ]
   },
   {
@@ -117,54 +77,34 @@
     "bg": "t_grass_autumn",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_wattle_fence_center",
-        "bg": "t_grass_autumn"
-      },
+      { "id": "center", "fg": "t_wattle_fence_center", "bg": "t_grass_autumn" },
       {
         "id": "corner",
-        "fg": [
-          "t_wattle_fence_corner_nw",
-          "t_wattle_fence_corner_sw",
-          "t_wattle_fence_corner_se",
-          "t_wattle_fence_corner_ne"
-        ],
+        "fg": [ "t_wattle_fence_corner_nw", "t_wattle_fence_corner_ne", "t_wattle_fence_corner_se", "t_wattle_fence_corner_sw" ],
         "bg": "t_grass_autumn"
       },
       {
         "id": "t_connection",
         "fg": [
           "t_wattle_fence_t_connection_n",
-          "t_wattle_fence_t_connection_w",
+          "t_wattle_fence_t_connection_e",
           "t_wattle_fence_t_connection_s",
-          "t_wattle_fence_t_connection_e"
+          "t_wattle_fence_t_connection_w"
         ],
         "bg": "t_grass_autumn"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_wattle_fence_edge_ns",
-          "t_wattle_fence_edge_ew"
-        ],
-        "bg": "t_grass_autumn"
-      },
+      { "id": "edge", "fg": [ "t_wattle_fence_edge_ns", "t_wattle_fence_edge_ew" ], "bg": "t_grass_autumn" },
       {
         "id": "end_piece",
         "fg": [
           "t_wattle_fence_end_piece_n",
-          "t_wattle_fence_end_piece_w",
+          "t_wattle_fence_end_piece_e",
           "t_wattle_fence_end_piece_s",
-          "t_wattle_fence_end_piece_e"
+          "t_wattle_fence_end_piece_w"
         ],
         "bg": "t_grass_autumn"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_wattle_fence_unconnected",
-        "bg": "t_grass_autumn"
-      }
+      { "id": "unconnected", "fg": "t_wattle_fence_unconnected", "bg": "t_grass_autumn" }
     ]
   },
   {
@@ -173,54 +113,34 @@
     "bg": "snow_shallow_center",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_wattle_fence_center",
-        "bg": "snow_shallow_center"
-      },
+      { "id": "center", "fg": "t_wattle_fence_center", "bg": "snow_shallow_center" },
       {
         "id": "corner",
-        "fg": [
-          "t_wattle_fence_corner_nw",
-          "t_wattle_fence_corner_sw",
-          "t_wattle_fence_corner_se",
-          "t_wattle_fence_corner_ne"
-        ],
+        "fg": [ "t_wattle_fence_corner_nw", "t_wattle_fence_corner_ne", "t_wattle_fence_corner_se", "t_wattle_fence_corner_sw" ],
         "bg": "snow_shallow_center"
       },
       {
         "id": "t_connection",
         "fg": [
           "t_wattle_fence_t_connection_n",
-          "t_wattle_fence_t_connection_w",
+          "t_wattle_fence_t_connection_e",
           "t_wattle_fence_t_connection_s",
-          "t_wattle_fence_t_connection_e"
+          "t_wattle_fence_t_connection_w"
         ],
         "bg": "snow_shallow_center"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_wattle_fence_edge_ns",
-          "t_wattle_fence_edge_ew"
-        ],
-        "bg": "snow_shallow_center"
-      },
+      { "id": "edge", "fg": [ "t_wattle_fence_edge_ns", "t_wattle_fence_edge_ew" ], "bg": "snow_shallow_center" },
       {
         "id": "end_piece",
         "fg": [
           "t_wattle_fence_end_piece_n",
-          "t_wattle_fence_end_piece_w",
+          "t_wattle_fence_end_piece_e",
           "t_wattle_fence_end_piece_s",
-          "t_wattle_fence_end_piece_e"
+          "t_wattle_fence_end_piece_w"
         ],
         "bg": "snow_shallow_center"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_wattle_fence_unconnected",
-        "bg": "snow_shallow_center"
-      }
+      { "id": "unconnected", "fg": "t_wattle_fence_unconnected", "bg": "snow_shallow_center" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_Pi/t_wood_wall_Pi.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_Pi/t_wood_wall_Pi.json
@@ -3,47 +3,30 @@
   "fg": "t_wood_wall_Pi_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wood_wall_Pi_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wood_wall_Pi_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wood_wall_Pi_corner_nw",
-        "t_wood_wall_Pi_corner_sw",
-        "t_wood_wall_Pi_corner_se",
-        "t_wood_wall_Pi_corner_ne"
-      ]
+      "fg": [ "t_wood_wall_Pi_corner_nw", "t_wood_wall_Pi_corner_ne", "t_wood_wall_Pi_corner_se", "t_wood_wall_Pi_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wood_wall_Pi_t_connection_n",
-        "t_wood_wall_Pi_t_connection_w",
+        "t_wood_wall_Pi_t_connection_e",
         "t_wood_wall_Pi_t_connection_s",
-        "t_wood_wall_Pi_t_connection_e"
+        "t_wood_wall_Pi_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wood_wall_Pi_edge_ns",
-        "t_wood_wall_Pi_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wood_wall_Pi_edge_ns", "t_wood_wall_Pi_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wood_wall_Pi_end_piece_n",
-        "t_wood_wall_Pi_end_piece_w",
+        "t_wood_wall_Pi_end_piece_e",
         "t_wood_wall_Pi_end_piece_s",
-        "t_wood_wall_Pi_end_piece_e"
+        "t_wood_wall_Pi_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wood_wall_Pi_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wood_wall_Pi_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_b/t_wood_wall_b.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_b/t_wood_wall_b.json
@@ -3,47 +3,25 @@
   "fg": "t_wood_wall_b_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wood_wall_b_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wood_wall_b_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wood_wall_b_corner_nw",
-        "t_wood_wall_b_corner_sw",
-        "t_wood_wall_b_corner_se",
-        "t_wood_wall_b_corner_ne"
-      ]
+      "fg": [ "t_wood_wall_b_corner_nw", "t_wood_wall_b_corner_ne", "t_wood_wall_b_corner_se", "t_wood_wall_b_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wood_wall_b_t_connection_n",
-        "t_wood_wall_b_t_connection_w",
+        "t_wood_wall_b_t_connection_e",
         "t_wood_wall_b_t_connection_s",
-        "t_wood_wall_b_t_connection_e"
+        "t_wood_wall_b_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wood_wall_b_edge_ns",
-        "t_wood_wall_b_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wood_wall_b_edge_ns", "t_wood_wall_b_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wood_wall_b_end_piece_n",
-        "t_wood_wall_b_end_piece_w",
-        "t_wood_wall_b_end_piece_s",
-        "t_wood_wall_b_end_piece_e"
-      ]
+      "fg": [ "t_wood_wall_b_end_piece_n", "t_wood_wall_b_end_piece_e", "t_wood_wall_b_end_piece_s", "t_wood_wall_b_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wood_wall_b_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wood_wall_b_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_black/t_wood_wall_black.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_black/t_wood_wall_black.json
@@ -3,47 +3,35 @@
   "fg": "t_wood_wall_black_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wood_wall_black_center"
-    },
+    { "id": "center", "fg": "t_wood_wall_black_center" },
     {
       "id": "corner",
       "fg": [
         "t_wood_wall_black_corner_nw",
-        "t_wood_wall_black_corner_sw",
+        "t_wood_wall_black_corner_ne",
         "t_wood_wall_black_corner_se",
-        "t_wood_wall_black_corner_ne"
+        "t_wood_wall_black_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wood_wall_black_t_connection_n",
-        "t_wood_wall_black_t_connection_w",
+        "t_wood_wall_black_t_connection_e",
         "t_wood_wall_black_t_connection_s",
-        "t_wood_wall_black_t_connection_e"
+        "t_wood_wall_black_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wood_wall_black_edge_ns",
-        "t_wood_wall_black_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wood_wall_black_edge_ns", "t_wood_wall_black_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wood_wall_black_end_piece_n",
-        "t_wood_wall_black_end_piece_w",
+        "t_wood_wall_black_end_piece_e",
         "t_wood_wall_black_end_piece_s",
         "t_wood_wall_black_end_piece_e"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wood_wall_black_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wood_wall_black_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_brown/t_wood_wall_brown.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_brown/t_wood_wall_brown.json
@@ -3,47 +3,35 @@
   "fg": "t_wood_wall_brown_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wood_wall_brown_center"
-    },
+    { "id": "center", "fg": "t_wood_wall_brown_center" },
     {
       "id": "corner",
       "fg": [
         "t_wood_wall_brown_corner_nw",
-        "t_wood_wall_brown_corner_sw",
+        "t_wood_wall_brown_corner_ne",
         "t_wood_wall_brown_corner_se",
-        "t_wood_wall_brown_corner_ne"
+        "t_wood_wall_brown_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wood_wall_brown_t_connection_n",
-        "t_wood_wall_brown_t_connection_w",
+        "t_wood_wall_brown_t_connection_e",
         "t_wood_wall_brown_t_connection_s",
-        "t_wood_wall_brown_t_connection_e"
+        "t_wood_wall_brown_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wood_wall_brown_edge_ns",
-        "t_wood_wall_brown_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wood_wall_brown_edge_ns", "t_wood_wall_brown_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wood_wall_brown_end_piece_n",
-        "t_wood_wall_brown_end_piece_w",
+        "t_wood_wall_brown_end_piece_e",
         "t_wood_wall_brown_end_piece_s",
-        "t_wood_wall_brown_end_piece_e"
+        "t_wood_wall_brown_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wood_wall_brown_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wood_wall_brown_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_cyan/t_wood_wall_cyan.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_cyan/t_wood_wall_cyan.json
@@ -3,47 +3,35 @@
   "fg": "t_wood_wall_cyan_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wood_wall_cyan_center"
-    },
+    { "id": "center", "fg": "t_wood_wall_cyan_center" },
     {
       "id": "corner",
       "fg": [
         "t_wood_wall_cyan_corner_nw",
-        "t_wood_wall_cyan_corner_sw",
+        "t_wood_wall_cyan_corner_ne",
         "t_wood_wall_cyan_corner_se",
-        "t_wood_wall_cyan_corner_ne"
+        "t_wood_wall_cyan_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wood_wall_cyan_t_connection_n",
-        "t_wood_wall_cyan_t_connection_w",
+        "t_wood_wall_cyan_t_connection_e",
         "t_wood_wall_cyan_t_connection_s",
-        "t_wood_wall_cyan_t_connection_e"
+        "t_wood_wall_cyan_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wood_wall_cyan_edge_ns",
-        "t_wood_wall_cyan_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wood_wall_cyan_edge_ns", "t_wood_wall_cyan_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wood_wall_cyan_end_piece_n",
-        "t_wood_wall_cyan_end_piece_w",
+        "t_wood_wall_cyan_end_piece_e",
         "t_wood_wall_cyan_end_piece_s",
-        "t_wood_wall_cyan_end_piece_e"
+        "t_wood_wall_cyan_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wood_wall_cyan_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wood_wall_cyan_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_g/t_wood_wall_g.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_g/t_wood_wall_g.json
@@ -3,47 +3,25 @@
   "fg": "t_wood_wall_g_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wood_wall_g_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wood_wall_g_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wood_wall_g_corner_nw",
-        "t_wood_wall_g_corner_sw",
-        "t_wood_wall_g_corner_se",
-        "t_wood_wall_g_corner_ne"
-      ]
+      "fg": [ "t_wood_wall_g_corner_nw", "t_wood_wall_g_corner_ne", "t_wood_wall_g_corner_se", "t_wood_wall_g_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wood_wall_g_t_connection_n",
-        "t_wood_wall_g_t_connection_w",
+        "t_wood_wall_g_t_connection_e",
         "t_wood_wall_g_t_connection_s",
-        "t_wood_wall_g_t_connection_e"
+        "t_wood_wall_g_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wood_wall_g_edge_ns",
-        "t_wood_wall_g_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wood_wall_g_edge_ns", "t_wood_wall_g_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wood_wall_g_end_piece_n",
-        "t_wood_wall_g_end_piece_w",
-        "t_wood_wall_g_end_piece_s",
-        "t_wood_wall_g_end_piece_e"
-      ]
+      "fg": [ "t_wood_wall_g_end_piece_n", "t_wood_wall_g_end_piece_e", "t_wood_wall_g_end_piece_s", "t_wood_wall_g_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wood_wall_g_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wood_wall_g_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_gray/t_wood_wall_gray.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_gray/t_wood_wall_gray.json
@@ -3,47 +3,35 @@
   "fg": "t_wood_wall_gray_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wood_wall_gray_center"
-    },
+    { "id": "center", "fg": "t_wood_wall_gray_center" },
     {
       "id": "corner",
       "fg": [
         "t_wood_wall_gray_corner_nw",
-        "t_wood_wall_gray_corner_sw",
+        "t_wood_wall_gray_corner_ne",
         "t_wood_wall_gray_corner_se",
-        "t_wood_wall_gray_corner_ne"
+        "t_wood_wall_gray_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wood_wall_gray_t_connection_n",
-        "t_wood_wall_gray_t_connection_w",
+        "t_wood_wall_gray_t_connection_e",
         "t_wood_wall_gray_t_connection_s",
-        "t_wood_wall_gray_t_connection_e"
+        "t_wood_wall_gray_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wood_wall_gray_edge_ns",
-        "t_wood_wall_gray_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wood_wall_gray_edge_ns", "t_wood_wall_gray_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wood_wall_gray_end_piece_n",
-        "t_wood_wall_gray_end_piece_w",
+        "t_wood_wall_gray_end_piece_e",
         "t_wood_wall_gray_end_piece_s",
-        "t_wood_wall_gray_end_piece_e"
+        "t_wood_wall_gray_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wood_wall_gray_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wood_wall_gray_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_orange/t_wood_wall_orange.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_orange/t_wood_wall_orange.json
@@ -3,47 +3,35 @@
   "fg": "t_wood_wall_orange_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wood_wall_orange_center"
-    },
+    { "id": "center", "fg": "t_wood_wall_orange_center" },
     {
       "id": "corner",
       "fg": [
         "t_wood_wall_orange_corner_nw",
-        "t_wood_wall_orange_corner_sw",
+        "t_wood_wall_orange_corner_ne",
         "t_wood_wall_orange_corner_se",
-        "t_wood_wall_orange_corner_ne"
+        "t_wood_wall_orange_corner_sw"
       ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wood_wall_orange_t_connection_n",
-        "t_wood_wall_orange_t_connection_w",
+        "t_wood_wall_orange_t_connection_e",
         "t_wood_wall_orange_t_connection_s",
-        "t_wood_wall_orange_t_connection_e"
+        "t_wood_wall_orange_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wood_wall_orange_edge_ns",
-        "t_wood_wall_orange_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wood_wall_orange_edge_ns", "t_wood_wall_orange_edge_ew" ] },
     {
       "id": "end_piece",
       "fg": [
         "t_wood_wall_orange_end_piece_n",
-        "t_wood_wall_orange_end_piece_w",
+        "t_wood_wall_orange_end_piece_e",
         "t_wood_wall_orange_end_piece_s",
-        "t_wood_wall_orange_end_piece_e"
+        "t_wood_wall_orange_end_piece_w"
       ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wood_wall_orange_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wood_wall_orange_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_p/t_wood_wall_p.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_p/t_wood_wall_p.json
@@ -3,47 +3,25 @@
   "fg": "t_wood_wall_p_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wood_wall_p_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wood_wall_p_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wood_wall_p_corner_nw",
-        "t_wood_wall_p_corner_sw",
-        "t_wood_wall_p_corner_se",
-        "t_wood_wall_p_corner_ne"
-      ]
+      "fg": [ "t_wood_wall_p_corner_nw", "t_wood_wall_p_corner_ne", "t_wood_wall_p_corner_se", "t_wood_wall_p_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wood_wall_p_t_connection_n",
-        "t_wood_wall_p_t_connection_w",
+        "t_wood_wall_p_t_connection_e",
         "t_wood_wall_p_t_connection_s",
-        "t_wood_wall_p_t_connection_e"
+        "t_wood_wall_p_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wood_wall_p_edge_ns",
-        "t_wood_wall_p_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wood_wall_p_edge_ns", "t_wood_wall_p_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wood_wall_p_end_piece_n",
-        "t_wood_wall_p_end_piece_w",
-        "t_wood_wall_p_end_piece_s",
-        "t_wood_wall_p_end_piece_e"
-      ]
+      "fg": [ "t_wood_wall_p_end_piece_n", "t_wood_wall_p_end_piece_e", "t_wood_wall_p_end_piece_s", "t_wood_wall_p_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wood_wall_p_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wood_wall_p_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_r/t_wood_wall_r.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_r/t_wood_wall_r.json
@@ -3,47 +3,25 @@
   "fg": "t_wood_wall_r_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wood_wall_r_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wood_wall_r_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wood_wall_r_corner_nw",
-        "t_wood_wall_r_corner_sw",
-        "t_wood_wall_r_corner_se",
-        "t_wood_wall_r_corner_ne"
-      ]
+      "fg": [ "t_wood_wall_r_corner_nw", "t_wood_wall_r_corner_ne", "t_wood_wall_r_corner_se", "t_wood_wall_r_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wood_wall_r_t_connection_n",
-        "t_wood_wall_r_t_connection_w",
+        "t_wood_wall_r_t_connection_e",
         "t_wood_wall_r_t_connection_s",
-        "t_wood_wall_r_t_connection_e"
+        "t_wood_wall_r_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wood_wall_r_edge_ns",
-        "t_wood_wall_r_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wood_wall_r_edge_ns", "t_wood_wall_r_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wood_wall_r_end_piece_n",
-        "t_wood_wall_r_end_piece_w",
-        "t_wood_wall_r_end_piece_s",
-        "t_wood_wall_r_end_piece_e"
-      ]
+      "fg": [ "t_wood_wall_r_end_piece_n", "t_wood_wall_r_end_piece_e", "t_wood_wall_r_end_piece_s", "t_wood_wall_r_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wood_wall_r_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wood_wall_r_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_w/t_wood_wall_w.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_w/t_wood_wall_w.json
@@ -3,47 +3,25 @@
   "fg": "t_wood_wall_w_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wood_wall_w_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wood_wall_w_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wood_wall_w_corner_nw",
-        "t_wood_wall_w_corner_sw",
-        "t_wood_wall_w_corner_se",
-        "t_wood_wall_w_corner_ne"
-      ]
+      "fg": [ "t_wood_wall_w_corner_nw", "t_wood_wall_w_corner_ne", "t_wood_wall_w_corner_se", "t_wood_wall_w_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wood_wall_w_t_connection_n",
-        "t_wood_wall_w_t_connection_w",
+        "t_wood_wall_w_t_connection_e",
         "t_wood_wall_w_t_connection_s",
-        "t_wood_wall_w_t_connection_e"
+        "t_wood_wall_w_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wood_wall_w_edge_ns",
-        "t_wood_wall_w_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wood_wall_w_edge_ns", "t_wood_wall_w_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wood_wall_w_end_piece_n",
-        "t_wood_wall_w_end_piece_w",
-        "t_wood_wall_w_end_piece_s",
-        "t_wood_wall_w_end_piece_e"
-      ]
+      "fg": [ "t_wood_wall_w_end_piece_n", "t_wood_wall_w_end_piece_e", "t_wood_wall_w_end_piece_s", "t_wood_wall_w_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wood_wall_w_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wood_wall_w_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_y/t_wood_wall_y.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/terrain/t_wood_wall_y/t_wood_wall_y.json
@@ -3,47 +3,25 @@
   "fg": "t_wood_wall_y_unconnected",
   "multitile": true,
   "additional_tiles": [
-    {
-      "id": "center",
-      "fg": "t_wood_wall_y_t_connection_n"
-    },
+    { "id": "center", "fg": "t_wood_wall_y_t_connection_n" },
     {
       "id": "corner",
-      "fg": [
-        "t_wood_wall_y_corner_nw",
-        "t_wood_wall_y_corner_sw",
-        "t_wood_wall_y_corner_se",
-        "t_wood_wall_y_corner_ne"
-      ]
+      "fg": [ "t_wood_wall_y_corner_nw", "t_wood_wall_y_corner_ne", "t_wood_wall_y_corner_se", "t_wood_wall_y_corner_sw" ]
     },
     {
       "id": "t_connection",
       "fg": [
         "t_wood_wall_y_t_connection_n",
-        "t_wood_wall_y_t_connection_w",
+        "t_wood_wall_y_t_connection_e",
         "t_wood_wall_y_t_connection_s",
-        "t_wood_wall_y_t_connection_e"
+        "t_wood_wall_y_t_connection_w"
       ]
     },
-    {
-      "id": "edge",
-      "fg": [
-        "t_wood_wall_y_edge_ns",
-        "t_wood_wall_y_edge_ew"
-      ]
-    },
+    { "id": "edge", "fg": [ "t_wood_wall_y_edge_ns", "t_wood_wall_y_edge_ew" ] },
     {
       "id": "end_piece",
-      "fg": [
-        "t_wood_wall_y_end_piece_n",
-        "t_wood_wall_y_end_piece_w",
-        "t_wood_wall_y_end_piece_s",
-        "t_wood_wall_y_end_piece_e"
-      ]
+      "fg": [ "t_wood_wall_y_end_piece_n", "t_wood_wall_y_end_piece_e", "t_wood_wall_y_end_piece_s", "t_wood_wall_y_end_piece_w" ]
     },
-    {
-      "id": "unconnected",
-      "fg": "t_wood_wall_y_unconnected"
-    }
+    { "id": "unconnected", "fg": "t_wood_wall_y_unconnected" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/vehicle/motorcycle/motorcycle_saddle.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/vehicle/motorcycle/motorcycle_saddle.json
@@ -1,13 +1,13 @@
 [
   {
     "id": "vp_saddle_motor",
-    "fg": [ "saddle_motor_rotN", "saddle_motor_rotW", "saddle_motor_rotS", "saddle_motor_rotE" ],
+    "fg": [ "saddle_motor_rotN", "saddle_motor_rotE", "saddle_motor_rotS", "saddle_motor_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "saddle_motor_rotN", "saddle_motor_rotW", "saddle_motor_rotS", "saddle_motor_rotE" ]
+        "bg": [ "saddle_motor_rotN", "saddle_motor_rotE", "saddle_motor_rotS", "saddle_motor_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/vehicle/motorcycle/motorcycle_wheels.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/vehicle/motorcycle/motorcycle_wheels.json
@@ -1,25 +1,25 @@
 [
   {
     "id": [ "vp_wheel_motorbike_front", "vp_wheel_motorbike_or_front" ],
-    "fg": [ "vp_wheel_motor_rotN", "vp_wheel_motor_rotW", "vp_wheel_motor_rotS", "vp_wheel_motor_rotE" ],
+    "fg": [ "vp_wheel_motor_rotN", "vp_wheel_motor_rotE", "vp_wheel_motor_rotS", "vp_wheel_motor_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_wheel_motor_rotN", "vp_wheel_motor_rotW", "vp_wheel_motor_rotS", "vp_wheel_motor_rotE" ]
+        "bg": [ "vp_wheel_motor_rotN", "vp_wheel_motor_rotE", "vp_wheel_motor_rotS", "vp_wheel_motor_rotW" ]
       }
     ]
   },
   {
     "id": [ "vp_wheel_motorbike_rear", "vp_wheel_motorbike_or_rear" ],
-    "fg": [ "vp_wheel_motor_rear_rotN", "vp_wheel_motor_rear_rotW", "vp_wheel_motor_rear_rotS", "vp_wheel_motor_rear_rotE" ],
+    "fg": [ "vp_wheel_motor_rear_rotN", "vp_wheel_motor_rear_rotE", "vp_wheel_motor_rear_rotS", "vp_wheel_motor_rear_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_wheel_motor_rear_rotN", "vp_wheel_motor_rear_rotW", "vp_wheel_motor_rear_rotS", "vp_wheel_motor_rear_rotE" ]
+        "bg": [ "vp_wheel_motor_rear_rotN", "vp_wheel_motor_rear_rotE", "vp_wheel_motor_rear_rotS", "vp_wheel_motor_rear_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/vehicle/scooter/scooter_wheels.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/vehicle/scooter/scooter_wheels.json
@@ -1,12 +1,17 @@
 [
   {
     "id": "vp_wheel_small_scooter",
-    "fg": [ "vp_wheel_scooter_rotN", "vp_wheel_scooter_rotW", "vp_wheel_scooter_rotS", "vp_wheel_scooter_rotE" ],
+    "fg": [ "vp_wheel_scooter_rotN", "vp_wheel_scooter_rotE", "vp_wheel_scooter_rotS", "vp_wheel_scooter_rotW" ],
     "rotates": true
   },
   {
     "id": "vp_wheel_small_scooter_rear",
-    "fg": [ "vp_wheel_scooter_rear_rotN", "vp_wheel_scooter_rear_rotW", "vp_wheel_scooter_rear_rotS", "vp_wheel_scooter_rear_rotE" ],
+    "fg": [
+      "vp_wheel_scooter_rear_rotN",
+      "vp_wheel_scooter_rear_rotE",
+      "vp_wheel_scooter_rear_rotS",
+      "vp_wheel_scooter_rear_rotW"
+    ],
     "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/vehicle/vp_crane_medium/vp_crane_medium.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/vehicle/vp_crane_medium/vp_crane_medium.json
@@ -1,13 +1,13 @@
 [
   {
     "id": [ "vp_crane_medium" ],
-    "fg": [ "vp_crane_medium_rotN", "vp_crane_medium_rotW", "vp_crane_medium_rotS", "vp_crane_medium_rotE" ],
+    "fg": [ "vp_crane_medium_rotN", "vp_crane_medium_rotE", "vp_crane_medium_rotS", "vp_crane_medium_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_crane_medium_rotN", "vp_crane_medium_rotW", "vp_crane_medium_rotS", "vp_crane_medium_rotE" ]
+        "bg": [ "vp_crane_medium_rotN", "vp_crane_medium_rotE", "vp_crane_medium_rotS", "vp_crane_medium_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/vehicle/vp_rockwheel/vp_rockwheel.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/vehicle/vp_rockwheel/vp_rockwheel.json
@@ -1,7 +1,7 @@
 [
   {
-    "id": [ "vp_rockwheel"],
-    "fg": [ "vp_rockwheel_rotN", "vp_rockwheel_rotW", "vp_rockwheel_rotS", "vp_rockwheel_rotE" ],
+    "id": [ "vp_rockwheel" ],
+    "fg": [ "vp_rockwheel_rotN", "vp_rockwheel_rotE", "vp_rockwheel_rotS", "vp_rockwheel_rotW" ],
     "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/vehicle/vp_scoop/vp_vehicle_scoop.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/vehicle/vp_scoop/vp_vehicle_scoop.json
@@ -1,7 +1,7 @@
 [
   {
-    "id": [ "vp_vehicle_scoop"],
-    "fg": [ "vp_vehicle_scoop_rotN", "vp_vehicle_scoop_rotW", "vp_vehicle_scoop_rotS", "vp_vehicle_scoop_rotE" ],
+    "id": [ "vp_vehicle_scoop" ],
+    "fg": [ "vp_vehicle_scoop_rotN", "vp_vehicle_scoop_rotE", "vp_vehicle_scoop_rotS", "vp_vehicle_scoop_rotW" ],
     "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_bookcase/f_bookcase.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_bookcase/f_bookcase.json
@@ -5,56 +5,23 @@
   "fg": "f_bookcase",
   "bg": "",
   "additional_tiles": [
-    {
-      "id": "center",
-      "bg": "",
-      "fg": "f_bookcase"
-    },
+    { "id": "center", "bg": "", "fg": "f_bookcase" },
     {
       "id": "corner",
       "bg": "",
-      "fg": [
-        "f_bookcase_end_piece_n",
-        "f_bookcase_end_piece_s",
-        "f_bookcase_end_piece_s",
-        "f_bookcase_end_piece_n"
-      ]
+      "fg": [ "f_bookcase_end_piece_n", "f_bookcase_end_piece_n", "f_bookcase_end_piece_s", "f_bookcase_end_piece_s" ]
     },
     {
       "id": "t_connection",
       "bg": "",
-      "fg": [
-        "f_bookcase",
-        "f_bookcase_edge_ns",
-        "f_bookcase",
-        "f_bookcase_edge_ns"
-      ]
+      "fg": [ "f_bookcase", "f_bookcase_edge_ns", "f_bookcase", "f_bookcase_edge_ns" ]
     },
-    {
-      "id": "edge",
-      "bg": "",
-      "fg": [
-        "f_bookcase_edge_ns",
-        "f_bookcase"
-      ]
-    },
+    { "id": "edge", "bg": "", "fg": [ "f_bookcase_edge_ns", "f_bookcase" ] },
     {
       "id": "end_piece",
       "bg": "",
-      "fg": [
-        "f_bookcase_end_piece_n",
-        "f_bookcase",
-        "f_bookcase_end_piece_s",
-        "f_bookcase"
-      ]
+      "fg": [ "f_bookcase_end_piece_n", "f_bookcase", "f_bookcase_end_piece_s", "f_bookcase" ]
     },
-    {
-      "bg": "",
-      "id": "unconnected",
-      "fg": [
-        "f_bookcase",
-		"f_bookcase"
-      ]
-    }
+    { "bg": "", "id": "unconnected", "fg": [ "f_bookcase", "f_bookcase" ] }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_console/f_console.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_console/f_console.json
@@ -9,20 +9,24 @@
       {
         "id": "corner",
         "bg": "",
-        "fg": [ "f_console_corner_nw", "f_console_corner_sw", "f_console_corner_se", "f_console_corner_ne" ]
+        "fg": [ "f_console_corner_nw", "f_console_corner_ne", "f_console_corner_se", "f_console_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "",
-        "fg": [ "f_console_t_connection_n", "f_console_t_connection_w", "f_console_t_connection_s", "f_console_t_connection_e" ]
+        "fg": [ "f_console_t_connection_n", "f_console_t_connection_e", "f_console_t_connection_s", "f_console_t_connection_w" ]
       },
       { "id": "edge", "bg": "", "fg": [ "f_console_edge_ns", "f_console_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "",
-        "fg": [ "f_console_end_piece_n", "f_console_end_piece_w", "f_console_end_piece_s", "f_console_end_piece_e" ]
+        "fg": [ "f_console_end_piece_n", "f_console_end_piece_e", "f_console_end_piece_s", "f_console_end_piece_w" ]
       },
-      { "bg": "", "id": "unconnected", "fg": [ "f_console_unconnected", "f_console_unconnected_faceW", "f_console_unconnected", "f_console_unconnected_faceE" ] }
+      {
+        "bg": "",
+        "id": "unconnected",
+        "fg": [ "f_console_unconnected", "f_console_unconnected_faceE", "f_console_unconnected", "f_console_unconnected_faceW" ]
+      }
     ]
   },
   {
@@ -37,9 +41,9 @@
         "bg": "",
         "fg": [
           "f_console_broken_corner_nw",
-          "f_console_broken_corner_sw",
+          "f_console_broken_corner_ne",
           "f_console_broken_corner_se",
-          "f_console_broken_corner_ne"
+          "f_console_broken_corner_sw"
         ]
       },
       {
@@ -47,9 +51,9 @@
         "bg": "",
         "fg": [
           "f_console_broken_t_connection_n",
-          "f_console_broken_t_connection_w",
+          "f_console_broken_t_connection_e",
           "f_console_broken_t_connection_s",
-          "f_console_broken_t_connection_e"
+          "f_console_broken_t_connection_w"
         ]
       },
       { "id": "edge", "bg": "", "fg": [ "f_console_broken_edge_ns", "f_console_broken_edge_ew" ] },
@@ -58,12 +62,21 @@
         "bg": "",
         "fg": [
           "f_console_broken_end_piece_n",
-          "f_console_broken_end_piece_w",
+          "f_console_broken_end_piece_e",
           "f_console_broken_end_piece_s",
-          "f_console_broken_end_piece_e"
+          "f_console_broken_end_piece_w"
         ]
       },
-      { "bg": "", "id": "unconnected", "fg": [ "f_console_broken_unconnected_faceS", "f_console_broken_unconnected_faceW", "f_console_broken_unconnected_faceS", "f_console_broken_unconnected_faceE" ] }
+      {
+        "bg": "",
+        "id": "unconnected",
+        "fg": [
+          "f_console_broken_unconnected_faceS",
+          "f_console_broken_unconnected_faceE",
+          "f_console_broken_unconnected_faceS",
+          "f_console_broken_unconnected_faceW"
+        ]
+      }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_dresser/f_dresser.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_dresser/f_dresser.json
@@ -1,6 +1,11 @@
 {
   "id": "f_dresser",
   "rotates": true,
-  "fg": [ "f_dresser_faceS", "f_dresser_faceW", "f_dresser_faceN", "f_dresser_faceE" ],
+  "fg": [
+    "f_dresser_faceS",
+    "f_dresser_faceE",
+    "f_dresser_faceN",
+    "f_dresser_faceW"
+  ],
   "bg": ""
 }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_dumpster/f_dumpster.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_dumpster/f_dumpster.json
@@ -4,51 +4,23 @@
   "bg": "",
   "multitile": true,
   "additional_tiles": [
+    { "id": "center", "fg": "f_dumpster_edge_ew", "bg": "" },
     {
-      "id": "center",
-      "fg": "f_dumpster_edge_ew",
-      "bg": ""
-    }, {
       "id": "corner",
-      "fg": [
-        "f_dumpster_end_w",
-        "f_dumpster_end_w",
-        "f_dumpster_end_e",
-        "f_dumpster_end_e"
-      ],
+      "fg": [ "f_dumpster_end_w", "f_dumpster_end_e", "f_dumpster_end_e", "f_dumpster_end_w" ],
       "bg": ""
-    }, {
+    },
+    {
       "id": "t_connection",
-      "fg": [
-        "f_dumpster_edge_ew",
-        "f_dumpster_end_w",
-        "f_dumpster_edge_ew",
-        "f_dumpster_end_e"
-      ],
+      "fg": [ "f_dumpster_edge_ew", "f_dumpster_end_e", "f_dumpster_edge_ew", "f_dumpster_end_w" ],
       "bg": ""
-    }, {
-      "id": "edge",
-      "fg": [
-        "f_dumpster_edge_ns",
-        "f_dumpster_edge_ew"
-      ],
-      "bg": ""
-    }, {
+    },
+    { "id": "edge", "fg": [ "f_dumpster_edge_ns", "f_dumpster_edge_ew" ], "bg": "" },
+    {
       "id": "end_piece",
-      "fg": [
-        "f_dumpster_end_n",
-        "f_dumpster_end_w",
-        "f_dumpster_end_s",
-        "f_dumpster_end_e"
-      ],
+      "fg": [ "f_dumpster_end_n", "f_dumpster_end_e", "f_dumpster_end_s", "f_dumpster_end_w" ],
       "bg": ""
-    }, {
-      "id": "unconnected",
-      "fg": [
-        "f_dumpster_unconnected",
-        "f_dumpster_unconnected"
-      ],
-      "bg": ""
-    }
+    },
+    { "id": "unconnected", "fg": [ "f_dumpster_unconnected", "f_dumpster_unconnected" ], "bg": "" }
   ]
 }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_fridge/f_fridge.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_fridge/f_fridge.json
@@ -1,6 +1,11 @@
 {
   "id": "f_fridge",
   "rotates": true,
-  "fg": [ "f_fridge_faceS", "f_fridge_faceW", "f_fridge_faceN", "f_fridge_faceE" ],
+  "fg": [
+    "f_fridge_faceS",
+    "f_fridge_faceE",
+    "f_fridge_faceN",
+    "f_fridge_faceW"
+  ],
   "bg": ""
 }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_ground_cable/f_ground_cable.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_ground_cable/f_ground_cable.json
@@ -15,11 +15,11 @@
       "fg": [
         {
           "weight": 1,
-          "sprite": [ "f_ground_cable_corner_nw", "f_ground_cable_corner_sw", "f_ground_cable_corner_se", "f_ground_cable_corner_ne" ]
+          "sprite": [ "f_ground_cable_corner_nw", "f_ground_cable_corner_ne", "f_ground_cable_corner_se", "f_ground_cable_corner_sw" ]
         },
         {
           "weight": 1,
-          "sprite": [ "f_ground_cable_corner_nw", "f_ground_cable_corner_sw", "f_ground_cable_corner_se_2", "f_ground_cable_corner_ne" ]
+          "sprite": [ "f_ground_cable_corner_nw", "f_ground_cable_corner_ne", "f_ground_cable_corner_se_2", "f_ground_cable_corner_sw" ]
         }
       ]
     },
@@ -31,18 +31,18 @@
           "weight": 1,
           "sprite": [
             "f_ground_cable_t_connection_n",
-            "f_ground_cable_t_connection_w",
+            "f_ground_cable_t_connection_e",
             "f_ground_cable_t_connection_s",
-            "f_ground_cable_t_connection_e"
+            "f_ground_cable_t_connection_w"
           ]
         },
         {
           "weight": 1,
           "sprite": [
             "f_ground_cable_t_connection_n",
-            "f_ground_cable_t_connection_w",
+            "f_ground_cable_t_connection_e",
             "f_ground_cable_t_connection_s",
-            "f_ground_cable_t_connection_e"
+            "f_ground_cable_t_connection_w"
           ]
         }
       ]
@@ -63,18 +63,18 @@
           "weight": 1,
           "sprite": [
             "f_ground_cable_end_piece_n",
-            "f_ground_cable_end_piece_w",
+            "f_ground_cable_end_piece_e",
             "f_ground_cable_end_piece_s",
-            "f_ground_cable_end_piece_e"
+            "f_ground_cable_end_piece_w"
           ]
         },
         {
           "weight": 1,
           "sprite": [
             "f_ground_cable_end_piece_n",
-            "f_ground_cable_end_piece_w",
+            "f_ground_cable_end_piece_e",
             "f_ground_cable_end_piece_s",
-            "f_ground_cable_end_piece_e"
+            "f_ground_cable_end_piece_w"
           ]
         }
       ]

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_oven/f_oven.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_oven/f_oven.json
@@ -1,6 +1,11 @@
 {
   "id": "f_oven",
   "rotates": true,
-  "fg": ["oven_faceS", "oven_faceW", "oven_faceN", "oven_faceE"],
+  "fg": [
+    "oven_faceS",
+    "oven_faceE",
+    "oven_faceN",
+    "oven_faceW"
+  ],
   "bg": ""
 }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/apartments_con_tower/apartments_con_tower.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/apartments_con_tower/apartments_con_tower.json
@@ -3,9 +3,9 @@
     "id": [ "apartments_con_tower_000", "apartments_mod_tower_000" ],
     "fg": [
       "apartments_con_tower_4x4_bot_right",
-      "apartments_con_tower_4x4_top_right",
+      "apartments_con_tower_4x4_bot_left",
       "apartments_con_tower_4x4_top_left",
-      "apartments_con_tower_4x4_bot_left"
+      "apartments_con_tower_4x4_top_right"
     ],
     "bg": "field_tall",
     "rotates": true
@@ -14,9 +14,9 @@
     "id": [ "apartments_con_tower_100", "apartments_mod_tower_100" ],
     "fg": [
       "apartments_con_tower_4x4_bot_left",
-      "apartments_con_tower_4x4_bot_right",
+      "apartments_con_tower_4x4_top_left",
       "apartments_con_tower_4x4_top_right",
-      "apartments_con_tower_4x4_top_left"
+      "apartments_con_tower_4x4_bot_right"
     ],
     "bg": "field_tall",
     "rotates": true
@@ -25,9 +25,9 @@
     "id": [ "apartments_con_tower_010", "apartments_mod_tower_010" ],
     "fg": [
       "apartments_con_tower_4x4_top_right",
-      "apartments_con_tower_4x4_top_left",
+      "apartments_con_tower_4x4_bot_right",
       "apartments_con_tower_4x4_bot_left",
-      "apartments_con_tower_4x4_bot_right"
+      "apartments_con_tower_4x4_top_left"
     ],
     "bg": "field_tall",
     "rotates": true
@@ -36,41 +36,31 @@
     "id": [ "apartments_con_tower_110", "apartments_mod_tower_110" ],
     "fg": [
       "apartments_con_tower_4x4_top_left",
-      "apartments_con_tower_4x4_bot_left",
+      "apartments_con_tower_4x4_top_right",
       "apartments_con_tower_4x4_bot_right",
-      "apartments_con_tower_4x4_top_right"
+      "apartments_con_tower_4x4_bot_left"
     ],
     "bg": "field_tall",
     "rotates": true
   },
   {
-    "id": [
-      "apartments_con_tower_002",
-      "apartments_con_tower_004",
-      "apartments_mod_tower_001",
-      "apartments_mod_tower_003"
-    ],
+    "id": [ "apartments_con_tower_002", "apartments_con_tower_004", "apartments_mod_tower_001", "apartments_mod_tower_003" ],
     "fg": [
       "apartments_con_tower_4x4_bot_right",
-      "apartments_con_tower_4x4_top_right",
+      "apartments_con_tower_4x4_bot_left",
       "apartments_con_tower_4x4_top_left",
-      "apartments_con_tower_4x4_bot_left"
+      "apartments_con_tower_4x4_top_right"
     ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
-    "id": [
-      "apartments_con_tower_102",
-      "apartments_con_tower_104",
-      "apartments_mod_tower_101",
-      "apartments_mod_tower_103"
-    ],
+    "id": [ "apartments_con_tower_102", "apartments_con_tower_104", "apartments_mod_tower_101", "apartments_mod_tower_103" ],
     "fg": [
       "apartments_con_tower_4x4_bot_left",
-      "apartments_con_tower_4x4_bot_right",
+      "apartments_con_tower_4x4_top_left",
       "apartments_con_tower_4x4_top_right",
-      "apartments_con_tower_4x4_top_left"
+      "apartments_con_tower_4x4_bot_right"
     ],
     "bg": "open_air_tall",
     "rotates": true
@@ -88,9 +78,9 @@
     ],
     "fg": [
       "apartments_con_tower_4x4_top_right",
-      "apartments_con_tower_4x4_top_left",
+      "apartments_con_tower_4x4_bot_right",
       "apartments_con_tower_4x4_bot_left",
-      "apartments_con_tower_4x4_bot_right"
+      "apartments_con_tower_4x4_top_left"
     ],
     "bg": "open_air_tall",
     "rotates": true
@@ -108,9 +98,9 @@
     ],
     "fg": [
       "apartments_con_tower_4x4_top_left",
-      "apartments_con_tower_4x4_bot_left",
+      "apartments_con_tower_4x4_top_right",
       "apartments_con_tower_4x4_bot_right",
-      "apartments_con_tower_4x4_top_right"
+      "apartments_con_tower_4x4_bot_left"
     ],
     "bg": "open_air_tall",
     "rotates": true

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/hospital/hospital.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/hospital/hospital.json
@@ -1,188 +1,77 @@
 [
   {
     "id": [ "hospital_1", "hospital_1_roof" ],
-    "fg": [
-      "hospital_9",
-      "hospital_7",
-      "hospital_1",
-      "hospital_3"
-    ],
+    "fg": [ "hospital_9", "hospital_3", "hospital_1", "hospital_7" ],
     "rotates": true
   },
   {
     "id": [ "hospital_2", "hospital_2_roof" ],
-    "fg": [
-      "hospital_8",
-      "hospital_4",
-      "hospital_2",
-      "hospital_6"
-    ],
+    "fg": [ "hospital_8", "hospital_6", "hospital_2", "hospital_4" ],
     "rotates": true
   },
   {
     "id": [ "hospital_3", "hospital_3_roof" ],
-    "fg": [
-      "hospital_7",
-      "hospital_1",
-      "hospital_3",
-      "hospital_9"
-    ],
+    "fg": [ "hospital_7", "hospital_9", "hospital_3", "hospital_1" ],
     "rotates": true
   },
   {
     "id": [ "hospital_4", "hospital_4_roof" ],
-    "fg": [
-      "hospital_6",
-      "hospital_8",
-      "hospital_4",
-      "hospital_2"
-    ],
+    "fg": [ "hospital_6", "hospital_2", "hospital_4", "hospital_8" ],
     "rotates": true
   },
   {
     "id": [ "hospital_5", "hospital_5_roof" ],
-    "fg": [
-      "hospital_5",
-      "hospital_5",
-      "hospital_5",
-      "hospital_5"
-    ],
+    "fg": [ "hospital_5", "hospital_5", "hospital_5", "hospital_5" ],
     "rotates": true
   },
   {
     "id": [ "hospital_6", "hospital_6_roof" ],
-    "fg": [
-      "hospital_4",
-      "hospital_2",
-      "hospital_6",
-      "hospital_8"
-    ],
+    "fg": [ "hospital_4", "hospital_8", "hospital_6", "hospital_2" ],
     "rotates": true
   },
   {
     "id": [ "hospital_7", "hospital_7_roof" ],
-    "fg": [
-      "hospital_3",
-      "hospital_9",
-      "hospital_7",
-      "hospital_1"
-    ],
+    "fg": [ "hospital_3", "hospital_1", "hospital_7", "hospital_9" ],
     "rotates": true
   },
   {
     "id": [ "hospital_8", "hospital_8_roof" ],
-    "fg": [
-      "hospital_2",
-      "hospital_6",
-      "hospital_8",
-      "hospital_4"
-    ],
+    "fg": [ "hospital_2", "hospital_4", "hospital_8", "hospital_6" ],
     "rotates": true
   },
   {
     "id": [ "hospital_9", "hospital_9_roof" ],
-    "fg": [
-      "hospital_1",
-      "hospital_3",
-      "hospital_9",
-      "hospital_7"
-    ],
+    "fg": [ "hospital_1", "hospital_7", "hospital_9", "hospital_3" ],
     "rotates": true
   },
   {
-    "id": [
-      "urban_35_1",
-      "urban_35_5",
-      "urban_35_9",
-      "urban_35_13",
-      "urban_35_17",
-      "urban_35_21",
-      "urban_35_25",
-      "urban_35_29"
-    ],
-    "fg": [
-      "hospital_7",
-      "hospital_1",
-      "hospital_3",
-      "hospital_9"
-    ],
+    "id": [ "urban_35_1", "urban_35_5", "urban_35_9", "urban_35_13", "urban_35_17", "urban_35_21", "urban_35_25", "urban_35_29" ],
+    "fg": [ "hospital_7", "hospital_9", "hospital_3", "hospital_1" ],
     "rotates": true
   },
   {
-    "id": [
-      "urban_35_2",
-      "urban_35_6",
-      "urban_35_10",
-      "urban_35_14",
-      "urban_35_18",
-      "urban_35_22",
-      "urban_35_26",
-      "urban_35_30"
-    ],
-    "fg": [
-      "hospital_8",
-      "hospital_4",
-      "hospital_2",
-      "hospital_6"
-    ],
+    "id": [ "urban_35_2", "urban_35_6", "urban_35_10", "urban_35_14", "urban_35_18", "urban_35_22", "urban_35_26", "urban_35_30" ],
+    "fg": [ "hospital_8", "hospital_6", "hospital_2", "hospital_4" ],
     "rotates": true
   },
   {
-    "id": [
-      "urban_35_3",
-      "urban_35_7",
-      "urban_35_11",
-      "urban_35_15",
-      "urban_35_19",
-      "urban_35_23",
-      "urban_35_27",
-      "urban_35_31"
-    ],
-    "fg": [
-      "hospital_1",
-      "hospital_3",
-      "hospital_9",
-      "hospital_7"
-    ],
+    "id": [ "urban_35_3", "urban_35_7", "urban_35_11", "urban_35_15", "urban_35_19", "urban_35_23", "urban_35_27", "urban_35_31" ],
+    "fg": [ "hospital_1", "hospital_7", "hospital_9", "hospital_3" ],
     "rotates": true
   },
   {
-    "id": [
-      "urban_35_4",
-      "urban_35_8",
-      "urban_35_12",
-      "urban_35_16",
-      "urban_35_20",
-      "urban_35_24",
-      "urban_35_28",
-      "urban_35_32"
-    ],
-    "fg": [
-      "hospital_2",
-      "hospital_6",
-      "hospital_8",
-      "hospital_4"
-    ],
+    "id": [ "urban_35_4", "urban_35_8", "urban_35_12", "urban_35_16", "urban_35_20", "urban_35_24", "urban_35_28", "urban_35_32" ],
+    "fg": [ "hospital_2", "hospital_4", "hospital_8", "hospital_6" ],
     "rotates": true
   },
   {
     "id": "urban_35_34",
-    "fg": [
-      "hospital_9",
-      "hospital_7",
-      "hospital_1",
-      "hospital_3"
-    ],
+    "fg": [ "hospital_9", "hospital_3", "hospital_1", "hospital_7" ],
     "rotates": true
   },
   {
     "id": "urban_35_35",
-    "fg": [
-      "hospital_3",
-      "hospital_9",
-      "hospital_7",
-      "hospital_1"
-    ],
+    "fg": [ "hospital_3", "hospital_1", "hospital_7", "hospital_9" ],
     "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/mansion/mansion.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/mansion/mansion.json
@@ -16,19 +16,13 @@
       "mansion_c4d",
       "mansion_c5d"
     ],
-    "fg": [ "mansion_NW", "mansion_SW", "mansion_SE", "mansion_NE" ],
+    "fg": [ "mansion_NW", "mansion_NE", "mansion_SE", "mansion_SW" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
-    "id": [
-      "mansion_e1",
-      "mansion_e2",
-      "mansion_boarded_e1",
-      "mansion_e1d",
-      "mansion_e2d"
-    ],
-    "fg": [ "mansion_N", "mansion_W", "mansion_S", "mansion_E" ],
+    "id": [ "mansion_e1", "mansion_e2", "mansion_boarded_e1", "mansion_e1d", "mansion_e2d" ],
+    "fg": [ "mansion_N", "mansion_E", "mansion_S", "mansion_W" ],
     "bg": "field_tall",
     "rotates": true
   },
@@ -52,20 +46,12 @@
       "mansion_boarded_t2d_start",
       "mansion_boarded_t2d"
     ],
-    "fg": [ "mansion_S", "mansion_E", "mansion_N", "mansion_W" ],
+    "fg": [ "mansion_S", "mansion_W", "mansion_N", "mansion_E" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
-    "id": [
-      "mansion_+1",
-      "mansion_+2",
-      "mansion_+3",
-      "mansion_+4",
-      "mansion_+1d",
-      "mansion_+2d",
-      "mansion_+4d"
-    ],
+    "id": [ "mansion_+1", "mansion_+2", "mansion_+3", "mansion_+4", "mansion_+1d", "mansion_+2d", "mansion_+4d" ],
     "fg": "mansion_CENTER",
     "bg": "field_tall"
   },
@@ -86,19 +72,13 @@
       "mansion_c4_roof",
       "mansion_c5_roof"
     ],
-    "fg": [ "mansion_NW", "mansion_SW", "mansion_SE", "mansion_NE" ],
+    "fg": [ "mansion_NW", "mansion_NE", "mansion_SE", "mansion_SW" ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
-    "id": [
-      "mansion_e1u",
-      "mansion_e2u",
-      "mansion_boarded_e1u",
-      "mansion_e1_roof",
-      "mansion_e2_roof"
-    ],
-    "fg": [ "mansion_N", "mansion_W", "mansion_S", "mansion_E" ],
+    "id": [ "mansion_e1u", "mansion_e2u", "mansion_boarded_e1u", "mansion_e1_roof", "mansion_e2_roof" ],
+    "fg": [ "mansion_N", "mansion_E", "mansion_S", "mansion_W" ],
     "bg": "open_air_tall",
     "rotates": true
   },
@@ -119,7 +99,7 @@
       "mansion_t6_roof",
       "mansion_t7_roof"
     ],
-    "fg": [ "mansion_S", "mansion_E", "mansion_N", "mansion_W" ],
+    "fg": [ "mansion_S", "mansion_W", "mansion_N", "mansion_E" ],
     "bg": "open_air_tall",
     "rotates": true
   },

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/mine32x64/mine32x64.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/mine32x64/mine32x64.json
@@ -1,45 +1,25 @@
 [
   {
     "id": "mine_entrance",
-    "fg": [
-      "mine_N_1",
-      "mine_W_1",
-      "mine_S_1",
-      "mine_E_1"
-    ],
+    "fg": [ "mine_N_1", "mine_E_1", "mine_S_1", "mine_W_1" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
     "id": "mine_entrance_roof",
-    "fg": [
-      "mine_N_1",
-      "mine_W_1",
-      "mine_S_1",
-      "mine_E_1"
-    ],
+    "fg": [ "mine_N_1", "mine_E_1", "mine_S_1", "mine_W_1" ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
     "id": "mine_shaft_middle",
-    "fg": [
-      "mine_N_1",
-      "mine_W_1",
-      "mine_S_1",
-      "mine_E_1"
-    ],
+    "fg": [ "mine_N_1", "mine_E_1", "mine_S_1", "mine_W_1" ],
     "bg": "t_dirt_center3_tall",
     "rotates": true
   },
   {
     "id": "mine_shaft_lower",
-    "fg": [
-      "mine_N_1",
-      "mine_W_1",
-      "mine_S_1",
-      "mine_E_1"
-    ],
+    "fg": [ "mine_N_1", "mine_E_1", "mine_S_1", "mine_W_1" ],
     "bg": "t_rock_floor_center_tall",
     "rotates": true
   }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/office_tower/office_tower.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/office_tower/office_tower.json
@@ -1,153 +1,73 @@
 [
   {
     "id": [ "office_tower_nw", "office_tower_underground_nw" ],
-    "fg": [
-      "office_tower_ground_nw",
-      "office_tower_ground_sw",
-      "office_tower_ground_se",
-      "office_tower_ground_ne"
-    ],
+    "fg": [ "office_tower_ground_nw", "office_tower_ground_ne", "office_tower_ground_se", "office_tower_ground_sw" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
     "id": [ "office_tower_ne", "office_tower_underground_ne" ],
-    "fg": [
-      "office_tower_ground_ne",
-      "office_tower_ground_nw",
-      "office_tower_ground_sw",
-      "office_tower_ground_se"
-    ],
+    "fg": [ "office_tower_ground_ne", "office_tower_ground_se", "office_tower_ground_sw", "office_tower_ground_nw" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
     "id": [ "office_tower_sw", "office_tower_underground_sw" ],
-    "fg": [
-      "office_tower_ground_sw",
-      "office_tower_ground_se",
-      "office_tower_ground_ne",
-      "office_tower_ground_nw"
-    ],
+    "fg": [ "office_tower_ground_sw", "office_tower_ground_nw", "office_tower_ground_ne", "office_tower_ground_se" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
     "id": [ "office_tower_se", "office_tower_underground_se" ],
-    "fg": [
-      "office_tower_ground_se",
-      "office_tower_ground_ne",
-      "office_tower_ground_nw",
-      "office_tower_ground_sw"
-    ],
+    "fg": [ "office_tower_ground_se", "office_tower_ground_sw", "office_tower_ground_nw", "office_tower_ground_ne" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
     "id": "office_tower_roof_nw",
-    "fg": [
-      "office_tower_roof_nw",
-      "office_tower_roof_sw",
-      "office_tower_roof_se",
-      "office_tower_roof_ne"
-    ],
+    "fg": [ "office_tower_roof_nw", "office_tower_roof_nw", "office_tower_roof_se", "office_tower_roof_sw" ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
     "id": "office_tower_roof_ne",
-    "fg": [
-      "office_tower_roof_ne",
-      "office_tower_roof_nw",
-      "office_tower_roof_sw",
-      "office_tower_roof_se"
-    ],
+    "fg": [ "office_tower_roof_ne", "office_tower_roof_se", "office_tower_roof_sw", "office_tower_roof_nw" ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
     "id": "office_tower_roof_sw",
-    "fg": [
-      "office_tower_roof_sw",
-      "office_tower_roof_se",
-      "office_tower_roof_ne",
-      "office_tower_roof_nw"
-    ],
+    "fg": [ "office_tower_roof_sw", "office_tower_roof_nw", "office_tower_roof_ne", "office_tower_roof_se" ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
     "id": "office_tower_roof_se",
-    "fg": [
-      "office_tower_roof_se",
-      "office_tower_roof_ne",
-      "office_tower_roof_nw",
-      "office_tower_roof_sw"
-    ],
+    "fg": [ "office_tower_roof_se", "office_tower_roof_sw", "office_tower_roof_nw", "office_tower_roof_ne" ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
-    "id": [
-      "loffice_tower_4",
-      "loffice_tower_8",
-      "office_skyscraper_4",
-      "office_skyscraper_8"
-    ],
-    "fg": [
-      "office_tower_ground_se",
-      "office_tower_ground_ne",
-      "office_tower_ground_nw",
-      "office_tower_ground_sw"
-    ],
+    "id": [ "loffice_tower_4", "loffice_tower_8", "office_skyscraper_4", "office_skyscraper_8" ],
+    "fg": [ "office_tower_ground_se", "office_tower_ground_sw", "office_tower_ground_nw", "office_tower_ground_ne" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
-    "id": [
-      "loffice_tower_3",
-      "loffice_tower_7",
-      "office_skyscraper_3",
-      "office_skyscraper_7"
-    ],
-    "fg": [
-      "office_tower_ground_sw",
-      "office_tower_ground_se",
-      "office_tower_ground_ne",
-      "office_tower_ground_nw"
-    ],
+    "id": [ "loffice_tower_3", "loffice_tower_7", "office_skyscraper_3", "office_skyscraper_7" ],
+    "fg": [ "office_tower_ground_sw", "office_tower_ground_nw", "office_tower_ground_ne", "office_tower_ground_se" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
-    "id": [
-      "loffice_tower_2",
-      "loffice_tower_6",
-      "office_skyscraper_2",
-      "office_skyscraper_6"
-    ],
-    "fg": [
-      "office_tower_ground_ne",
-      "office_tower_ground_nw",
-      "office_tower_ground_sw",
-      "office_tower_ground_se"
-    ],
+    "id": [ "loffice_tower_2", "loffice_tower_6", "office_skyscraper_2", "office_skyscraper_6" ],
+    "fg": [ "office_tower_ground_ne", "office_tower_ground_se", "office_tower_ground_sw", "office_tower_ground_nw" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
-    "id": [
-      "loffice_tower_1",
-      "loffice_tower_5",
-      "office_skyscraper_1",
-      "office_skyscraper_5"
-    ],
-    "fg": [
-      "office_tower_ground_nw",
-      "office_tower_ground_sw",
-      "office_tower_ground_se",
-      "office_tower_ground_ne"
-    ],
+    "id": [ "loffice_tower_1", "loffice_tower_5", "office_skyscraper_1", "office_skyscraper_5" ],
+    "fg": [ "office_tower_ground_nw", "office_tower_ground_ne", "office_tower_ground_se", "office_tower_ground_sw" ],
     "bg": "field_tall",
     "rotates": true
   },
@@ -160,12 +80,7 @@
       "office_skyscraper_12",
       "office_skyscraper_16"
     ],
-    "fg": [
-      "office_tower_mid_se",
-      "office_tower_mid_ne",
-      "office_tower_mid_nw",
-      "office_tower_mid_sw"
-    ],
+    "fg": [ "office_tower_mid_se", "office_tower_mid_sw", "office_tower_mid_nw", "office_tower_mid_ne" ],
     "bg": "open_air_tall",
     "rotates": true
   },
@@ -178,12 +93,7 @@
       "office_skyscraper_11",
       "office_skyscraper_15"
     ],
-    "fg": [
-      "office_tower_mid_sw",
-      "office_tower_mid_se",
-      "office_tower_mid_ne",
-      "office_tower_mid_nw"
-    ],
+    "fg": [ "office_tower_mid_sw", "office_tower_mid_nw", "office_tower_mid_ne", "office_tower_mid_se" ],
     "bg": "open_air_tall",
     "rotates": true
   },
@@ -198,12 +108,7 @@
       "office_skyscraper_10b",
       "office_skyscraper_14"
     ],
-    "fg": [
-      "office_tower_mid_ne",
-      "office_tower_mid_nw",
-      "office_tower_mid_sw",
-      "office_tower_mid_se"
-    ],
+    "fg": [ "office_tower_mid_ne", "office_tower_mid_se", "office_tower_mid_sw", "office_tower_mid_nw" ],
     "bg": "open_air_tall",
     "rotates": true
   },
@@ -218,68 +123,31 @@
       "office_skyscraper_9b",
       "office_skyscraper_13"
     ],
-    "fg": [
-      "office_tower_mid_nw",
-      "office_tower_mid_sw",
-      "office_tower_mid_se",
-      "office_tower_mid_ne"
-    ],
+    "fg": [ "office_tower_mid_nw", "office_tower_mid_ne", "office_tower_mid_se", "office_tower_mid_sw" ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
-    "id": [
-      "loffice_tower_20",
-      "office_skyscraper_20"
-    ],
-    "fg": [
-      "office_tower_roof_se",
-      "office_tower_roof_ne",
-      "office_tower_roof_nw",
-      "office_tower_roof_sw"
-    ],
+    "id": [ "loffice_tower_20", "office_skyscraper_20" ],
+    "fg": [ "office_tower_roof_se", "office_tower_roof_sw", "office_tower_roof_nw", "office_tower_roof_ne" ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
-    "id": [
-      "loffice_tower_19",
-      "office_skyscraper_19"
-    ],
-    "fg": [
-      "office_tower_roof_sw",
-      "office_tower_roof_se",
-      "office_tower_roof_ne",
-      "office_tower_roof_nw"
-    ],
+    "id": [ "loffice_tower_19", "office_skyscraper_19" ],
+    "fg": [ "office_tower_roof_sw", "office_tower_roof_nw", "office_tower_roof_ne", "office_tower_roof_se" ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
-    "id": [
-      "loffice_tower_18",
-      "office_skyscraper_18"
-    ],
-    "fg": [
-      "office_tower_roof_ne",
-      "office_tower_roof_nw",
-      "office_tower_roof_sw",
-      "office_tower_roof_se"
-    ],
+    "id": [ "loffice_tower_18", "office_skyscraper_18" ],
+    "fg": [ "office_tower_roof_ne", "office_tower_roof_se", "office_tower_roof_sw", "office_tower_roof_nw" ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
-    "id": [
-      "loffice_tower_17",
-      "office_skyscraper_17"
-    ],
-    "fg": [
-      "office_tower_roof_nw",
-      "office_tower_roof_sw",
-      "office_tower_roof_se",
-      "office_tower_roof_ne"
-    ],
+    "id": [ "loffice_tower_17", "office_skyscraper_17" ],
+    "fg": [ "office_tower_roof_nw", "office_tower_roof_ne", "office_tower_roof_se", "office_tower_roof_sw" ],
     "bg": "open_air_tall",
     "rotates": true
   }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/office_tower_2/office_tower_2.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/office_tower_2/office_tower_2.json
@@ -9,12 +9,7 @@
       "office_tower_collapse_b_a0",
       "office_tower_2_a1_tower_lab"
     ],
-    "fg": [
-      "office_tower_2_a1_faceN",
-      "office_tower_2_a1_faceW",
-      "office_tower_2_a1_faceS",
-      "office_tower_2_a1_faceE"
-    ],
+    "fg": [ "office_tower_2_a1_faceN", "office_tower_2_a1_faceE", "office_tower_2_a1_faceS", "office_tower_2_a1_faceW" ],
     "rotates": true
   },
   {
@@ -26,26 +21,12 @@
       "office_tower_collapse_a1",
       "office_tower_collapse_b_a1"
     ],
-    "fg": [
-      "office_tower_2_a2_faceN",
-      "office_tower_2_a2_faceW",
-      "office_tower_2_a2_faceS",
-      "office_tower_2_a2_faceE"
-    ],
+    "fg": [ "office_tower_2_a2_faceN", "office_tower_2_a2_faceE", "office_tower_2_a2_faceS", "office_tower_2_a2_faceW" ],
     "rotates": true
   },
   {
-    "id": [
-      "office_tower_2_a3",
-      "office_tower_collapse_a2",
-      "office_tower_collapse_b_a2"
-      ],
-    "fg": [
-      "office_tower_2_a3_faceN",
-      "office_tower_2_a3_faceW",
-      "office_tower_2_a3_faceS",
-      "office_tower_2_a3_faceE"
-    ],
+    "id": [ "office_tower_2_a3", "office_tower_collapse_a2", "office_tower_collapse_b_a2" ],
+    "fg": [ "office_tower_2_a3_faceN", "office_tower_2_a3_faceE", "office_tower_2_a3_faceS", "office_tower_2_a3_faceW" ],
     "rotates": true
   },
   {
@@ -57,12 +38,7 @@
       "office_tower_collapse_b0",
       "office_tower_collapse_b_b0"
     ],
-    "fg": [
-      "office_tower_2_b1_faceN",
-      "office_tower_2_b1_faceW",
-      "office_tower_2_b1_faceS",
-      "office_tower_2_b1_faceE"
-    ],
+    "fg": [ "office_tower_2_b1_faceN", "office_tower_2_b1_faceE", "office_tower_2_b1_faceS", "office_tower_2_b1_faceW" ],
     "rotates": true
   },
   {
@@ -74,12 +50,7 @@
       "office_tower_collapse_b1",
       "office_tower_collapse_b_b1"
     ],
-    "fg": [
-      "office_tower_2_b2_faceN",
-      "office_tower_2_b2_faceW",
-      "office_tower_2_b2_faceS",
-      "office_tower_2_b2_faceE"
-    ],
+    "fg": [ "office_tower_2_b2_faceN", "office_tower_2_b2_faceE", "office_tower_2_b2_faceS", "office_tower_2_b2_faceW" ],
     "rotates": true
   },
   {
@@ -91,20 +62,11 @@
       "office_tower_collapse_b2",
       "office_tower_collapse_b_b2"
     ],
-    "fg": [
-      "office_tower_2_b3_faceN",
-      "office_tower_2_b3_faceW",
-      "office_tower_2_b3_faceS",
-      "office_tower_2_b3_faceE"
-    ],
+    "fg": [ "office_tower_2_b3_faceN", "office_tower_2_b3_faceE", "office_tower_2_b3_faceS", "office_tower_2_b3_faceW" ],
     "rotates": true
   },
   {
-    "id": [
-      "tower_lab",
-      "tower_lab_stairs",
-      "tower_lab_finale"
-    ],
+    "id": [ "tower_lab", "tower_lab_stairs", "tower_lab_finale" ],
     "fg": "office_tower_2_a3_faceW"
   },
   {

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/police_dept/police_dept.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/police_dept/police_dept.json
@@ -1,128 +1,47 @@
 [
   {
-    "id": [
-      "police_dept_u010",
-      "police_dept_u011",
-      "police_dept_u012"
-    ],
-    "fg": [
-      "police_dept01",
-      "police_dept02",
-      "police_dept04",
-      "police_dept03"
-    ],
+    "id": [ "police_dept_u010", "police_dept_u011", "police_dept_u012" ],
+    "fg": [ "police_dept01", "police_dept03", "police_dept04", "police_dept02" ],
     "rotates": true
   },
   {
-    "id": [
-      "police_dept_u110",
-      "police_dept_u111",
-      "police_dept_u112"
-    ],
-    "fg": [
-      "police_dept02",
-      "police_dept04",
-      "police_dept03",
-      "police_dept01"
-    ],
+    "id": [ "police_dept_u110", "police_dept_u111", "police_dept_u112" ],
+    "fg": [ "police_dept02", "police_dept01", "police_dept03", "police_dept04" ],
     "rotates": true
   },
   {
-    "id": [
-      "police_dept_u000",
-      "police_dept_u001",
-      "police_dept_u002"
-    ],
-    "fg": [
-      "police_dept03",
-      "police_dept01",
-      "police_dept02",
-      "police_dept04"
-    ],
+    "id": [ "police_dept_u000", "police_dept_u001", "police_dept_u002" ],
+    "fg": [ "police_dept03", "police_dept04", "police_dept02", "police_dept01" ],
     "rotates": true
   },
   {
-    "id": [
-      "police_dept_u100",
-      "police_dept_u101",
-      "police_dept_u102"
-    ],
-    "fg": [
-      "police_dept04",
-      "police_dept03",
-      "police_dept01",
-      "police_dept02_bridge"
-    ],
+    "id": [ "police_dept_u100", "police_dept_u101", "police_dept_u102" ],
+    "fg": [ "police_dept04", "police_dept02_bridge", "police_dept01", "police_dept03" ],
     "rotates": true
   },
   {
-    "id": [
-      "police_dept_d010",
-      "police_dept_d011",
-      "police_dept_d012",
-      "police_dept_b01"
-    ],
-    "fg": [
-      "police_dept02",
-      "police_dept04",
-      "police_dept03",
-      "police_dept01"
-    ],
+    "id": [ "police_dept_d010", "police_dept_d011", "police_dept_d012", "police_dept_b01" ],
+    "fg": [ "police_dept02", "police_dept01", "police_dept03", "police_dept04" ],
     "rotates": true
   },
   {
-    "id": [
-      "police_dept_d110",
-      "police_dept_d111",
-      "police_dept_d112",
-      "police_dept_b11"
-    ],
-    "fg": [
-      "police_dept01",
-      "police_dept02",
-      "police_dept04",
-      "police_dept03"
-    ],
+    "id": [ "police_dept_d110", "police_dept_d111", "police_dept_d112", "police_dept_b11" ],
+    "fg": [ "police_dept01", "police_dept03", "police_dept04", "police_dept02" ],
     "rotates": true
   },
   {
-    "id": [
-      "police_dept_d000",
-      "police_dept_d001",
-      "police_dept_d002",
-      "police_dept_b00"
-    ],
-    "fg": [
-      "police_dept04",
-      "police_dept03",
-      "police_dept01",
-      "police_dept02"
-    ],
+    "id": [ "police_dept_d000", "police_dept_d001", "police_dept_d002", "police_dept_b00" ],
+    "fg": [ "police_dept04", "police_dept02", "police_dept01", "police_dept03" ],
     "rotates": true
   },
   {
-    "id": [
-      "police_dept_d100",
-      "police_dept_d101",
-      "police_dept_d102",
-      "police_dept_b10"
-    ],
-    "fg": [
-      "police_dept03",
-      "police_dept01",
-      "police_dept02",
-      "police_dept04_bridge"
-    ],
+    "id": [ "police_dept_d100", "police_dept_d101", "police_dept_d102", "police_dept_b10" ],
+    "fg": [ "police_dept03", "police_dept04_bridge", "police_dept02", "police_dept01" ],
     "rotates": true
   },
   {
     "id": [ "police_dept_skyway", "police_dept_skyway_roof" ],
-    "fg": [
-      "police_dept_bridge_2",
-      "police_dept_bridge",
-      "police_dept_bridge_2",
-      "police_dept_bridge"
-    ],
+    "fg": [ "police_dept_bridge_2", "police_dept_bridge", "police_dept_bridge_2", "police_dept_bridge" ],
     "bg": "open_air_tall",
     "rotates": true
   }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/rural_house_big/rural_house_big.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/rural_house_big/rural_house_big.json
@@ -1,25 +1,23 @@
-[{
-  "id": [
-    "horse_farm_isherwood_13",
-	  "horse_farm_13",
-	  "farm_dairy_twd_4",
-	  "farm_stills_3"
-	],
-  "fg": [ "rural_house_big_faceN", "rural_house_big_faceE", "rural_house_big_faceS", "rural_house_big_faceW" ], 
-  "bg": "field_tall",
-  "rotates": true
-},{
-  "id": [
-    "horse_farm_isherwood_13_2ndfloor",
-	  "horse_farm_isherwood_13_roof",
-	  "horse_farm_13_2ndfloor",
-	  "horse_farm_13_roof",
-	  "farm_dairy_twd_second_floor_4",
-	  "farm_dairy_twd_4_roof",
-	  "farm_stills_3_2nd",
-	  "farm_stills_3_roof"
-	],
-  "fg": [ "rural_house_big_faceN", "rural_house_big_faceE", "rural_house_big_faceS", "rural_house_big_faceW" ],
-  "bg": "open_air_tall",
-  "rotates": true
-}]
+[
+  {
+    "id": [ "horse_farm_isherwood_13", "horse_farm_13", "farm_dairy_twd_4", "farm_stills_3" ],
+    "fg": [ "rural_house_big_faceN", "rural_house_big_faceW", "rural_house_big_faceS", "rural_house_big_faceE" ],
+    "bg": "field_tall",
+    "rotates": true
+  },
+  {
+    "id": [
+      "horse_farm_isherwood_13_2ndfloor",
+      "horse_farm_isherwood_13_roof",
+      "horse_farm_13_2ndfloor",
+      "horse_farm_13_roof",
+      "farm_dairy_twd_second_floor_4",
+      "farm_dairy_twd_4_roof",
+      "farm_stills_3_2nd",
+      "farm_stills_3_roof"
+    ],
+    "fg": [ "rural_house_big_faceN", "rural_house_big_faceW", "rural_house_big_faceS", "rural_house_big_faceE" ],
+    "bg": "open_air_tall",
+    "rotates": true
+  }
+]

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/s_lightindustry32x64/s_lightindustry32x64.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/s_lightindustry32x64/s_lightindustry32x64.json
@@ -1,89 +1,49 @@
 [
   {
     "id": [ "s_lightindustry_00", "s_lightindustry_scen_00" ],
-    "fg": [
-      "industry_light_EW_1",
-      "industry_light_NS_2",
-      "industry_light_EW_4",
-      "industry_light_NS_3"
-    ],
+    "fg": [ "industry_light_EW_1", "industry_light_NS_3", "industry_light_EW_4", "industry_light_NS_2" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
     "id": [ "s_lightindustry_01", "s_lightindustry_scen_01" ],
-    "fg": [
-      "industry_light_EW_2",
-      "industry_light_NS_4",
-      "industry_light_EW_3",
-      "industry_light_NS_1"
-    ],
+    "fg": [ "industry_light_EW_2", "industry_light_NS_1", "industry_light_EW_3", "industry_light_NS_4" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
     "id": [ "s_lightindustry_10", "s_lightindustry_scen_10" ],
-    "fg": [
-      "industry_light_EW_3",
-      "industry_light_NS_1",
-      "industry_light_EW_2",
-      "industry_light_NS_4"
-    ],
+    "fg": [ "industry_light_EW_3", "industry_light_NS_4", "industry_light_EW_2", "industry_light_NS_1" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
     "id": [ "s_lightindustry_11", "s_lightindustry_scen_11" ],
-    "fg": [
-      "industry_light_EW_4",
-      "industry_light_NS_3",
-      "industry_light_EW_1",
-      "industry_light_NS_2"
-    ],
+    "fg": [ "industry_light_EW_4", "industry_light_NS_2", "industry_light_EW_1", "industry_light_NS_3" ],
     "bg": "field_tall",
     "rotates": true
   },
   {
     "id": [ "s_lightindustry_00_roof", "s_lightindustry_scen_00_roof" ],
-    "fg": [
-      "industry_light_EW_1",
-      "industry_light_NS_2",
-      "industry_light_EW_4",
-      "industry_light_NS_3"
-    ],
+    "fg": [ "industry_light_EW_1", "industry_light_NS_3", "industry_light_EW_4", "industry_light_NS_2" ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
     "id": [ "s_lightindustry_01_roof", "s_lightindustry_scen_01_roof" ],
-    "fg": [
-      "industry_light_EW_2",
-      "industry_light_NS_4",
-      "industry_light_EW_3",
-      "industry_light_NS_1"
-    ],
+    "fg": [ "industry_light_EW_2", "industry_light_NS_1", "industry_light_EW_3", "industry_light_NS_4" ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
     "id": [ "s_lightindustry_10_roof", "s_lightindustry_scen_10_roof" ],
-    "fg": [
-      "industry_light_EW_3",
-      "industry_light_NS_1",
-      "industry_light_EW_2",
-      "industry_light_NS_4"
-    ],
+    "fg": [ "industry_light_EW_3", "industry_light_NS_3", "industry_light_EW_2", "industry_light_NS_1" ],
     "bg": "open_air_tall",
     "rotates": true
   },
   {
     "id": [ "s_lightindustry_11_roof", "s_lightindustry_scen_11_roof" ],
-    "fg": [
-      "industry_light_EW_4",
-      "industry_light_NS_3",
-      "industry_light_EW_1",
-      "industry_light_NS_2"
-    ],
+    "fg": [ "industry_light_EW_4", "industry_light_NS_2", "industry_light_EW_1", "industry_light_NS_3" ],
     "bg": "open_air_tall",
     "rotates": true
   }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/wind_turbine/wind_turbine.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/overmap/wind_turbine/wind_turbine.json
@@ -1,19 +1,14 @@
 [
   {
-	"id": [
-	  "wind_turbine_pillar",
-	  "wind_turbine_pillar_platform",
-	  "wind_turbine_nacelle",
-	  "wind_turbine_roof"
-	],
-	"fg": [ "wind_turbine_rot_N", "wind_turbine_rot_W", "wind_turbine_rot_S", "wind_turbine_rot_E" ],
-	"bg": "open_air_tall",
-	"rotates": true
+    "id": [ "wind_turbine_pillar", "wind_turbine_pillar_platform", "wind_turbine_nacelle", "wind_turbine_roof" ],
+    "fg": [ "wind_turbine_rot_N", "wind_turbine_rot_E", "wind_turbine_rot_S", "wind_turbine_rot_W" ],
+    "bg": "open_air_tall",
+    "rotates": true
   },
   {
-	"id": "wind_turbine_ground",
-	"fg": [ "wind_turbine_rot_N", "wind_turbine_rot_W", "wind_turbine_rot_S", "wind_turbine_rot_E" ],
-	"bg": "field_tall",
-	"rotates": true
+    "id": "wind_turbine_ground",
+    "fg": [ "wind_turbine_rot_N", "wind_turbine_rot_E", "wind_turbine_rot_S", "wind_turbine_rot_W" ],
+    "bg": "field_tall",
+    "rotates": true
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/terrain/t_grass_long/t_grass_long.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/terrain/t_grass_long/t_grass_long.json
@@ -5,40 +5,46 @@
     "fg": "t_grass_long_unconnected",
     "bg": "t_grass_tall",
     "additional_tiles": [
-      { "id": "center", "bg": "t_grass_tall", "fg": [
-        { "weight": 100, "sprite": "t_grass_long_center" },
-        { "weight": 100, "sprite": "t_grass_long_center2" },
-        { "weight": 100, "sprite": "t_grass_long_center3" },
-        { "weight": 100, "sprite": "t_grass_long_center4" }
-      ]
+      {
+        "id": "center",
+        "bg": "t_grass_tall",
+        "fg": [
+          { "weight": 100, "sprite": "t_grass_long_center" },
+          { "weight": 100, "sprite": "t_grass_long_center2" },
+          { "weight": 100, "sprite": "t_grass_long_center3" },
+          { "weight": 100, "sprite": "t_grass_long_center4" }
+        ]
       },
       {
         "id": "corner",
         "bg": "t_grass_tall",
-        "fg": [ "t_grass_long_corner_nw", "t_grass_long_corner_sw", "t_grass_long_corner_se", "t_grass_long_corner_ne" ]
+        "fg": [ "t_grass_long_corner_nw", "t_grass_long_corner_ne", "t_grass_long_corner_se", "t_grass_long_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_tall",
         "fg": [
           "t_grass_long_t_connection_n",
-          "t_grass_long_t_connection_w",
+          "t_grass_long_t_connection_e",
           "t_grass_long_t_connection_s",
-          "t_grass_long_t_connection_e"
+          "t_grass_long_t_connection_w"
         ]
       },
       { "id": "edge", "bg": "t_grass_tall", "fg": [ "t_grass_long_edge_ns", "t_grass_long_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_tall",
-        "fg": [ "t_grass_long_end_piece_n", "t_grass_long_end_piece_w", "t_grass_long_end_piece_s", "t_grass_long_end_piece_e" ]
+        "fg": [ "t_grass_long_end_piece_n", "t_grass_long_end_piece_e", "t_grass_long_end_piece_s", "t_grass_long_end_piece_w" ]
       },
-      { "id": "unconnected", "bg": "t_grass_tall", "fg": [
-        { "weight": 100, "sprite": "t_grass_long_unconnected" },
-        { "weight": 100, "sprite": "t_grass_long_unconnected2" },
-        { "weight": 100, "sprite": "t_grass_long_unconnected3" },
-        { "weight": 100, "sprite": "t_grass_long_unconnected4" }
-      ]
+      {
+        "id": "unconnected",
+        "bg": "t_grass_tall",
+        "fg": [
+          { "weight": 100, "sprite": "t_grass_long_unconnected" },
+          { "weight": 100, "sprite": "t_grass_long_unconnected2" },
+          { "weight": 100, "sprite": "t_grass_long_unconnected3" },
+          { "weight": 100, "sprite": "t_grass_long_unconnected4" }
+        ]
       }
     ]
   },
@@ -48,40 +54,60 @@
     "fg": "t_grass_long_summer_unconnected",
     "bg": "t_grass_summer_tall",
     "additional_tiles": [
-      { "id": "center", "bg": "t_grass_summer_tall", "fg": [
-        { "weight": 100, "sprite": "t_grass_long_summer_center" },
-        { "weight": 100, "sprite": "t_grass_long_summer_center2" },
-        { "weight": 100, "sprite": "t_grass_long_summer_center3" },
-        { "weight": 100, "sprite": "t_grass_long_summer_center4" }
-      ]
+      {
+        "id": "center",
+        "bg": "t_grass_summer_tall",
+        "fg": [
+          { "weight": 100, "sprite": "t_grass_long_summer_center" },
+          { "weight": 100, "sprite": "t_grass_long_summer_center2" },
+          { "weight": 100, "sprite": "t_grass_long_summer_center3" },
+          { "weight": 100, "sprite": "t_grass_long_summer_center4" }
+        ]
       },
       {
         "id": "corner",
         "bg": "t_grass_summer_tall",
-        "fg": [ "t_grass_long_summer_corner_nw", "t_grass_long_summer_corner_sw", "t_grass_long_summer_corner_se", "t_grass_long_summer_corner_ne" ]
+        "fg": [
+          "t_grass_long_summer_corner_nw",
+          "t_grass_long_summer_corner_ne",
+          "t_grass_long_summer_corner_se",
+          "t_grass_long_summer_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_summer_tall",
         "fg": [
           "t_grass_long_summer_t_connection_n",
-          "t_grass_long_summer_t_connection_w",
+          "t_grass_long_summer_t_connection_e",
           "t_grass_long_summer_t_connection_s",
-          "t_grass_long_summer_t_connection_e"
+          "t_grass_long_summer_t_connection_w"
         ]
       },
-      { "id": "edge", "bg": "t_grass_summer_tall", "fg": [ "t_grass_long_summer_edge_ns", "t_grass_long_summer_edge_ew" ] },
+      {
+        "id": "edge",
+        "bg": "t_grass_summer_tall",
+        "fg": [ "t_grass_long_summer_edge_ns", "t_grass_long_summer_edge_ew" ]
+      },
       {
         "id": "end_piece",
         "bg": "t_grass_summer_tall",
-        "fg": [ "t_grass_long_summer_end_piece_n", "t_grass_long_summer_end_piece_w", "t_grass_long_summer_end_piece_s", "t_grass_long_summer_end_piece_e" ]
+        "fg": [
+          "t_grass_long_summer_end_piece_n",
+          "t_grass_long_summer_end_piece_e",
+          "t_grass_long_summer_end_piece_s",
+          "t_grass_long_summer_end_piece_w"
+        ]
       },
-      { "id": "unconnected", "bg": "t_grass_summer_tall", "fg": [
-        { "weight": 100, "sprite": "t_grass_long_summer_unconnected" },
-        { "weight": 100, "sprite": "t_grass_long_summer_unconnected2" },
-        { "weight": 100, "sprite": "t_grass_long_summer_unconnected3" },
-        { "weight": 100, "sprite": "t_grass_long_summer_unconnected4" }
-      ]
+      {
+        "id": "unconnected",
+        "bg": "t_grass_summer_tall",
+        "fg": [
+          { "weight": 100, "sprite": "t_grass_long_summer_unconnected" },
+          { "weight": 100, "sprite": "t_grass_long_summer_unconnected2" },
+          { "weight": 100, "sprite": "t_grass_long_summer_unconnected3" },
+          { "weight": 100, "sprite": "t_grass_long_summer_unconnected4" }
+        ]
       }
     ]
   },
@@ -91,40 +117,60 @@
     "fg": "t_grass_long_autumn_unconnected",
     "bg": "t_grass_autumn_tall",
     "additional_tiles": [
-      { "id": "center", "bg": "t_grass_autumn_tall", "fg": [
-        { "weight": 100, "sprite": "t_grass_long_autumn_center" },
-        { "weight": 100, "sprite": "t_grass_long_autumn_center2" },
-        { "weight": 100, "sprite": "t_grass_long_autumn_center3" },
-        { "weight": 100, "sprite": "t_grass_long_autumn_center4" }
-      ]
+      {
+        "id": "center",
+        "bg": "t_grass_autumn_tall",
+        "fg": [
+          { "weight": 100, "sprite": "t_grass_long_autumn_center" },
+          { "weight": 100, "sprite": "t_grass_long_autumn_center2" },
+          { "weight": 100, "sprite": "t_grass_long_autumn_center3" },
+          { "weight": 100, "sprite": "t_grass_long_autumn_center4" }
+        ]
       },
       {
         "id": "corner",
         "bg": "t_grass_autumn_tall",
-        "fg": [ "t_grass_long_autumn_corner_nw", "t_grass_long_autumn_corner_sw", "t_grass_long_autumn_corner_se", "t_grass_long_autumn_corner_ne" ]
+        "fg": [
+          "t_grass_long_autumn_corner_nw",
+          "t_grass_long_autumn_corner_ne",
+          "t_grass_long_autumn_corner_se",
+          "t_grass_long_autumn_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_autumn_tall",
         "fg": [
           "t_grass_long_autumn_t_connection_n",
-          "t_grass_long_autumn_t_connection_w",
+          "t_grass_long_autumn_t_connection_e",
           "t_grass_long_autumn_t_connection_s",
-          "t_grass_long_autumn_t_connection_e"
+          "t_grass_long_autumn_t_connection_w"
         ]
       },
-      { "id": "edge", "bg": "t_grass_autumn_tall", "fg": [ "t_grass_long_autumn_edge_ns", "t_grass_long_autumn_edge_ew" ] },
+      {
+        "id": "edge",
+        "bg": "t_grass_autumn_tall",
+        "fg": [ "t_grass_long_autumn_edge_ns", "t_grass_long_autumn_edge_ew" ]
+      },
       {
         "id": "end_piece",
         "bg": "t_grass_autumn_tall",
-        "fg": [ "t_grass_long_autumn_end_piece_n", "t_grass_long_autumn_end_piece_w", "t_grass_long_autumn_end_piece_s", "t_grass_long_autumn_end_piece_e" ]
+        "fg": [
+          "t_grass_long_autumn_end_piece_n",
+          "t_grass_long_autumn_end_piece_e",
+          "t_grass_long_autumn_end_piece_s",
+          "t_grass_long_autumn_end_piece_w"
+        ]
       },
-      { "id": "unconnected", "bg": "t_grass_autumn_tall", "fg": [
-        { "weight": 100, "sprite": "t_grass_long_autumn_unconnected" },
-        { "weight": 100, "sprite": "t_grass_long_autumn_unconnected2" },
-        { "weight": 100, "sprite": "t_grass_long_autumn_unconnected3" },
-        { "weight": 100, "sprite": "t_grass_long_autumn_unconnected4" }
-      ]
+      {
+        "id": "unconnected",
+        "bg": "t_grass_autumn_tall",
+        "fg": [
+          { "weight": 100, "sprite": "t_grass_long_autumn_unconnected" },
+          { "weight": 100, "sprite": "t_grass_long_autumn_unconnected2" },
+          { "weight": 100, "sprite": "t_grass_long_autumn_unconnected3" },
+          { "weight": 100, "sprite": "t_grass_long_autumn_unconnected4" }
+        ]
       }
     ]
   },

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/terrain/t_grass_tall/t_grass_tall.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/terrain/t_grass_tall/t_grass_tall.json
@@ -5,40 +5,46 @@
     "fg": "t_grass_tall_unconnected",
     "bg": "t_grass_tall",
     "additional_tiles": [
-      { "id": "center", "bg": "t_grass_tall", "fg": [
-        { "weight": 100, "sprite": "t_grass_tall_center" },
-        { "weight": 100, "sprite": "t_grass_tall_center2" },
-        { "weight": 100, "sprite": "t_grass_tall_center3" },
-        { "weight": 100, "sprite": "t_grass_tall_center4" }
-      ]
+      {
+        "id": "center",
+        "bg": "t_grass_tall",
+        "fg": [
+          { "weight": 100, "sprite": "t_grass_tall_center" },
+          { "weight": 100, "sprite": "t_grass_tall_center2" },
+          { "weight": 100, "sprite": "t_grass_tall_center3" },
+          { "weight": 100, "sprite": "t_grass_tall_center4" }
+        ]
       },
       {
         "id": "corner",
         "bg": "t_grass_tall",
-        "fg": [ "t_grass_tall_corner_nw", "t_grass_tall_corner_sw", "t_grass_tall_corner_se", "t_grass_tall_corner_ne" ]
+        "fg": [ "t_grass_tall_corner_nw", "t_grass_tall_corner_ne", "t_grass_tall_corner_se", "t_grass_tall_corner_sw" ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_tall",
         "fg": [
           "t_grass_tall_t_connection_n",
-          "t_grass_tall_t_connection_w",
+          "t_grass_tall_t_connection_e",
           "t_grass_tall_t_connection_s",
-          "t_grass_tall_t_connection_e"
+          "t_grass_tall_t_connection_w"
         ]
       },
       { "id": "edge", "bg": "t_grass_tall", "fg": [ "t_grass_tall_edge_ns", "t_grass_tall_edge_ew" ] },
       {
         "id": "end_piece",
         "bg": "t_grass_tall",
-        "fg": [ "t_grass_tall_end_piece_n", "t_grass_tall_end_piece_w", "t_grass_tall_end_piece_s", "t_grass_tall_end_piece_e" ]
+        "fg": [ "t_grass_tall_end_piece_n", "t_grass_tall_end_piece_e", "t_grass_tall_end_piece_s", "t_grass_tall_end_piece_w" ]
       },
-      { "id": "unconnected", "bg": "t_grass_tall", "fg": [
-        { "weight": 100, "sprite": "t_grass_tall_unconnected" },
-        { "weight": 100, "sprite": "t_grass_tall_unconnected2" },
-        { "weight": 100, "sprite": "t_grass_tall_unconnected3" },
-        { "weight": 100, "sprite": "t_grass_tall_unconnected4" }
-      ]
+      {
+        "id": "unconnected",
+        "bg": "t_grass_tall",
+        "fg": [
+          { "weight": 100, "sprite": "t_grass_tall_unconnected" },
+          { "weight": 100, "sprite": "t_grass_tall_unconnected2" },
+          { "weight": 100, "sprite": "t_grass_tall_unconnected3" },
+          { "weight": 100, "sprite": "t_grass_tall_unconnected4" }
+        ]
       }
     ]
   },
@@ -48,40 +54,60 @@
     "fg": "t_grass_tall_summer_unconnected",
     "bg": "t_grass_summer_tall",
     "additional_tiles": [
-      { "id": "center", "bg": "t_grass_summer_tall", "fg": [
-        { "weight": 100, "sprite": "t_grass_tall_summer_center" },
-        { "weight": 100, "sprite": "t_grass_tall_summer_center2" },
-        { "weight": 100, "sprite": "t_grass_tall_summer_center3" },
-        { "weight": 100, "sprite": "t_grass_tall_summer_center4" }
-      ]
+      {
+        "id": "center",
+        "bg": "t_grass_summer_tall",
+        "fg": [
+          { "weight": 100, "sprite": "t_grass_tall_summer_center" },
+          { "weight": 100, "sprite": "t_grass_tall_summer_center2" },
+          { "weight": 100, "sprite": "t_grass_tall_summer_center3" },
+          { "weight": 100, "sprite": "t_grass_tall_summer_center4" }
+        ]
       },
       {
         "id": "corner",
         "bg": "t_grass_summer_tall",
-        "fg": [ "t_grass_tall_summer_corner_nw", "t_grass_tall_summer_corner_sw", "t_grass_tall_summer_corner_se", "t_grass_tall_summer_corner_ne" ]
+        "fg": [
+          "t_grass_tall_summer_corner_nw",
+          "t_grass_tall_summer_corner_ne",
+          "t_grass_tall_summer_corner_se",
+          "t_grass_tall_summer_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_summer_tall",
         "fg": [
           "t_grass_tall_summer_t_connection_n",
-          "t_grass_tall_summer_t_connection_w",
+          "t_grass_tall_summer_t_connection_e",
           "t_grass_tall_summer_t_connection_s",
-          "t_grass_tall_summer_t_connection_e"
+          "t_grass_tall_summer_t_connection_w"
         ]
       },
-      { "id": "edge", "bg": "t_grass_summer_tall", "fg": [ "t_grass_tall_summer_edge_ns", "t_grass_tall_summer_edge_ew" ] },
+      {
+        "id": "edge",
+        "bg": "t_grass_summer_tall",
+        "fg": [ "t_grass_tall_summer_edge_ns", "t_grass_tall_summer_edge_ew" ]
+      },
       {
         "id": "end_piece",
         "bg": "t_grass_summer_tall",
-        "fg": [ "t_grass_tall_summer_end_piece_n", "t_grass_tall_summer_end_piece_w", "t_grass_tall_summer_end_piece_s", "t_grass_tall_summer_end_piece_e" ]
+        "fg": [
+          "t_grass_tall_summer_end_piece_n",
+          "t_grass_tall_summer_end_piece_e",
+          "t_grass_tall_summer_end_piece_s",
+          "t_grass_tall_summer_end_piece_w"
+        ]
       },
-      { "id": "unconnected", "bg": "t_grass_summer_tall", "fg": [
-        { "weight": 100, "sprite": "t_grass_tall_summer_unconnected" },
-        { "weight": 100, "sprite": "t_grass_tall_summer_unconnected2" },
-        { "weight": 100, "sprite": "t_grass_tall_summer_unconnected3" },
-        { "weight": 100, "sprite": "t_grass_tall_summer_unconnected4" }
-      ]
+      {
+        "id": "unconnected",
+        "bg": "t_grass_summer_tall",
+        "fg": [
+          { "weight": 100, "sprite": "t_grass_tall_summer_unconnected" },
+          { "weight": 100, "sprite": "t_grass_tall_summer_unconnected2" },
+          { "weight": 100, "sprite": "t_grass_tall_summer_unconnected3" },
+          { "weight": 100, "sprite": "t_grass_tall_summer_unconnected4" }
+        ]
       }
     ]
   },
@@ -91,40 +117,60 @@
     "fg": "t_grass_tall_autumn_unconnected",
     "bg": "t_grass_autumn_tall",
     "additional_tiles": [
-      { "id": "center", "bg": "t_grass_autumn_tall", "fg": [
-        { "weight": 100, "sprite": "t_grass_tall_autumn_center" },
-        { "weight": 100, "sprite": "t_grass_tall_autumn_center2" },
-        { "weight": 100, "sprite": "t_grass_tall_autumn_center3" },
-        { "weight": 100, "sprite": "t_grass_tall_autumn_center4" }
-      ]
+      {
+        "id": "center",
+        "bg": "t_grass_autumn_tall",
+        "fg": [
+          { "weight": 100, "sprite": "t_grass_tall_autumn_center" },
+          { "weight": 100, "sprite": "t_grass_tall_autumn_center2" },
+          { "weight": 100, "sprite": "t_grass_tall_autumn_center3" },
+          { "weight": 100, "sprite": "t_grass_tall_autumn_center4" }
+        ]
       },
       {
         "id": "corner",
         "bg": "t_grass_autumn_tall",
-        "fg": [ "t_grass_tall_autumn_corner_nw", "t_grass_tall_autumn_corner_sw", "t_grass_tall_autumn_corner_se", "t_grass_tall_autumn_corner_ne" ]
+        "fg": [
+          "t_grass_tall_autumn_corner_nw",
+          "t_grass_tall_autumn_corner_ne",
+          "t_grass_tall_autumn_corner_se",
+          "t_grass_tall_autumn_corner_sw"
+        ]
       },
       {
         "id": "t_connection",
         "bg": "t_grass_autumn_tall",
         "fg": [
           "t_grass_tall_autumn_t_connection_n",
-          "t_grass_tall_autumn_t_connection_w",
+          "t_grass_tall_autumn_t_connection_e",
           "t_grass_tall_autumn_t_connection_s",
-          "t_grass_tall_autumn_t_connection_e"
+          "t_grass_tall_autumn_t_connection_w"
         ]
       },
-      { "id": "edge", "bg": "t_grass_autumn_tall", "fg": [ "t_grass_tall_autumn_edge_ns", "t_grass_tall_autumn_edge_ew" ] },
+      {
+        "id": "edge",
+        "bg": "t_grass_autumn_tall",
+        "fg": [ "t_grass_tall_autumn_edge_ns", "t_grass_tall_autumn_edge_ew" ]
+      },
       {
         "id": "end_piece",
         "bg": "t_grass_autumn_tall",
-        "fg": [ "t_grass_tall_autumn_end_piece_n", "t_grass_tall_autumn_end_piece_w", "t_grass_tall_autumn_end_piece_s", "t_grass_tall_autumn_end_piece_e" ]
+        "fg": [
+          "t_grass_tall_autumn_end_piece_n",
+          "t_grass_tall_autumn_end_piece_e",
+          "t_grass_tall_autumn_end_piece_s",
+          "t_grass_tall_autumn_end_piece_w"
+        ]
       },
-      { "id": "unconnected", "bg": "t_grass_autumn_tall", "fg": [
-        { "weight": 100, "sprite": "t_grass_tall_autumn_unconnected" },
-        { "weight": 100, "sprite": "t_grass_tall_autumn_unconnected2" },
-        { "weight": 100, "sprite": "t_grass_tall_autumn_unconnected3" },
-        { "weight": 100, "sprite": "t_grass_tall_autumn_unconnected4" }
-      ]
+      {
+        "id": "unconnected",
+        "bg": "t_grass_autumn_tall",
+        "fg": [
+          { "weight": 100, "sprite": "t_grass_tall_autumn_unconnected" },
+          { "weight": 100, "sprite": "t_grass_tall_autumn_unconnected2" },
+          { "weight": 100, "sprite": "t_grass_tall_autumn_unconnected3" },
+          { "weight": 100, "sprite": "t_grass_tall_autumn_unconnected4" }
+        ]
       }
     ]
   },

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/terrain/t_monkey_bars/t_monkey_bars.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/terrain/t_monkey_bars/t_monkey_bars.json
@@ -5,54 +5,29 @@
     "bg": "t_grass_tall",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_monkey_bars_center",
-        "bg": "t_grass_tall"
-      },
+      { "id": "center", "fg": "t_monkey_bars_center", "bg": "t_grass_tall" },
       {
         "id": "corner",
-        "fg": [
-          "t_monkey_bars_corner_nw",
-          "t_monkey_bars_corner_sw",
-          "t_monkey_bars_corner_se",
-          "t_monkey_bars_corner_ne"
-        ],
+        "fg": [ "t_monkey_bars_corner_nw", "t_monkey_bars_corner_ne", "t_monkey_bars_corner_se", "t_monkey_bars_corner_sw" ],
         "bg": "t_grass_tall"
       },
       {
         "id": "t_connection",
         "fg": [
           "t_monkey_bars_t_connection_n",
-          "t_monkey_bars_t_connection_w",
+          "t_monkey_bars_t_connection_e",
           "t_monkey_bars_t_connection_s",
-          "t_monkey_bars_t_connection_e"
+          "t_monkey_bars_t_connection_w"
         ],
         "bg": "t_grass_tall"
       },
-      {
-        "id": "edge",
-        "fg": [
-        "t_monkey_bars_edge_ns",
-        "t_monkey_bars_edge_ew"
-        ],
-        "bg": "t_grass_tall"
-      },
+      { "id": "edge", "fg": [ "t_monkey_bars_edge_ns", "t_monkey_bars_edge_ew" ], "bg": "t_grass_tall" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_monkey_bars_end_piece_n",
-          "t_monkey_bars_end_piece_w",
-          "t_monkey_bars_end_piece_s",
-          "t_monkey_bars_end_piece_e"
-        ],
+        "fg": [ "t_monkey_bars_end_piece_n", "t_monkey_bars_end_piece_e", "t_monkey_bars_end_piece_s", "t_monkey_bars_end_piece_w" ],
         "bg": "t_grass_tall"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_monkey_bars_unconnected",
-        "bg": "t_grass_tall"
-      }
+      { "id": "unconnected", "fg": "t_monkey_bars_unconnected", "bg": "t_grass_tall" }
     ]
   },
   {
@@ -61,54 +36,29 @@
     "bg": "t_grass_summer_tall",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_monkey_bars_center",
-        "bg": "t_grass_summer_tall"
-      },
+      { "id": "center", "fg": "t_monkey_bars_center", "bg": "t_grass_summer_tall" },
       {
         "id": "corner",
-        "fg": [
-          "t_monkey_bars_corner_nw",
-          "t_monkey_bars_corner_sw",
-          "t_monkey_bars_corner_se",
-          "t_monkey_bars_corner_ne"
-        ],
+        "fg": [ "t_monkey_bars_corner_nw", "t_monkey_bars_corner_ne", "t_monkey_bars_corner_se", "t_monkey_bars_corner_sw" ],
         "bg": "t_grass_summer_tall"
       },
       {
         "id": "t_connection",
         "fg": [
           "t_monkey_bars_t_connection_n",
-          "t_monkey_bars_t_connection_w",
+          "t_monkey_bars_t_connection_e",
           "t_monkey_bars_t_connection_s",
-          "t_monkey_bars_t_connection_e"
+          "t_monkey_bars_t_connection_w"
         ],
         "bg": "t_grass_summer_tall"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_monkey_bars_edge_ns",
-          "t_monkey_bars_edge_ew"
-        ],
-        "bg": "t_grass_summer_tall"
-      },
+      { "id": "edge", "fg": [ "t_monkey_bars_edge_ns", "t_monkey_bars_edge_ew" ], "bg": "t_grass_summer_tall" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_monkey_bars_end_piece_n",
-          "t_monkey_bars_end_piece_w",
-          "t_monkey_bars_end_piece_s",
-          "t_monkey_bars_end_piece_e"
-        ],
+        "fg": [ "t_monkey_bars_end_piece_n", "t_monkey_bars_end_piece_e", "t_monkey_bars_end_piece_s", "t_monkey_bars_end_piece_w" ],
         "bg": "t_grass_summer_tall"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_monkey_bars_unconnected",
-        "bg": "t_grass_summer_tall"
-      }
+      { "id": "unconnected", "fg": "t_monkey_bars_unconnected", "bg": "t_grass_summer_tall" }
     ]
   },
   {
@@ -117,54 +67,29 @@
     "bg": "t_grass_autumn_tall",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_monkey_bars_center",
-        "bg": "t_grass_autumn_tall"
-      },
+      { "id": "center", "fg": "t_monkey_bars_center", "bg": "t_grass_autumn_tall" },
       {
         "id": "corner",
-        "fg": [
-          "t_monkey_bars_corner_nw",
-          "t_monkey_bars_corner_sw",
-          "t_monkey_bars_corner_se",
-          "t_monkey_bars_corner_ne"
-        ],
+        "fg": [ "t_monkey_bars_corner_nw", "t_monkey_bars_corner_ne", "t_monkey_bars_corner_se", "t_monkey_bars_corner_sw" ],
         "bg": "t_grass_autumn_tall"
       },
       {
         "id": "t_connection",
         "fg": [
           "t_monkey_bars_t_connection_n",
-          "t_monkey_bars_t_connection_w",
+          "t_monkey_bars_t_connection_e",
           "t_monkey_bars_t_connection_s",
-          "t_monkey_bars_t_connection_e"
+          "t_monkey_bars_t_connection_w"
         ],
         "bg": "t_grass_autumn_tall"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_monkey_bars_edge_ns",
-          "t_monkey_bars_edge_ew"
-        ],
-        "bg": "t_grass_autumn_tall"
-      },
+      { "id": "edge", "fg": [ "t_monkey_bars_edge_ns", "t_monkey_bars_edge_ew" ], "bg": "t_grass_autumn_tall" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_monkey_bars_end_piece_n",
-          "t_monkey_bars_end_piece_w",
-          "t_monkey_bars_end_piece_s",
-          "t_monkey_bars_end_piece_e"
-        ],
+        "fg": [ "t_monkey_bars_end_piece_n", "t_monkey_bars_end_piece_e", "t_monkey_bars_end_piece_s", "t_monkey_bars_end_piece_w" ],
         "bg": "t_grass_autumn_tall"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_monkey_bars_unconnected",
-        "bg": "t_grass_autumn_tall"
-      }
+      { "id": "unconnected", "fg": "t_monkey_bars_unconnected", "bg": "t_grass_autumn_tall" }
     ]
   },
   {
@@ -173,54 +98,29 @@
     "bg": "snow_shallow_tall",
     "multitile": true,
     "additional_tiles": [
-      {
-        "id": "center",
-        "fg": "t_monkey_bars_center",
-        "bg": "snow_shallow_tall"
-      },
+      { "id": "center", "fg": "t_monkey_bars_center", "bg": "snow_shallow_tall" },
       {
         "id": "corner",
-        "fg": [
-          "t_monkey_bars_corner_nw",
-          "t_monkey_bars_corner_sw",
-          "t_monkey_bars_corner_se",
-          "t_monkey_bars_corner_ne"
-        ],
+        "fg": [ "t_monkey_bars_corner_nw", "t_monkey_bars_corner_ne", "t_monkey_bars_corner_se", "t_monkey_bars_corner_sw" ],
         "bg": "snow_shallow_tall"
       },
       {
         "id": "t_connection",
         "fg": [
           "t_monkey_bars_t_connection_n",
-          "t_monkey_bars_t_connection_w",
+          "t_monkey_bars_t_connection_e",
           "t_monkey_bars_t_connection_s",
-          "t_monkey_bars_t_connection_e"
+          "t_monkey_bars_t_connection_w"
         ],
         "bg": "snow_shallow_tall"
       },
-      {
-        "id": "edge",
-        "fg": [
-          "t_monkey_bars_edge_ns",
-          "t_monkey_bars_edge_ew"
-        ],
-        "bg": "snow_shallow_tall"
-      },
+      { "id": "edge", "fg": [ "t_monkey_bars_edge_ns", "t_monkey_bars_edge_ew" ], "bg": "snow_shallow_tall" },
       {
         "id": "end_piece",
-        "fg": [
-          "t_monkey_bars_end_piece_n",
-          "t_monkey_bars_end_piece_w",
-          "t_monkey_bars_end_piece_s",
-          "t_monkey_bars_end_piece_e"
-        ],
+        "fg": [ "t_monkey_bars_end_piece_n", "t_monkey_bars_end_piece_e", "t_monkey_bars_end_piece_s", "t_monkey_bars_end_piece_w" ],
         "bg": "snow_shallow_tall"
       },
-      {
-        "id": "unconnected",
-        "fg": "t_monkey_bars_unconnected",
-        "bg": "snow_shallow_tall"
-      }
+      { "id": "unconnected", "fg": "t_monkey_bars_unconnected", "bg": "snow_shallow_tall" }
     ]
   }
 ]

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/doors/interior/vp_door_interior.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/doors/interior/vp_door_interior.json
@@ -1,16 +1,16 @@
 [
   {
     "id": [ "vp_door", "vp_door_internal", "vp_door_opaque" ],
-    "fg": [ "vp_door_interior_rotN", "vp_door_interior_rotW", "vp_door_interior_rotS", "vp_door_interior_rotE" ],
+    "fg": [ "vp_door_interior_rotN", "vp_door_interior_rotE", "vp_door_interior_rotS", "vp_door_interior_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
         "fg": [
           "vp_door_interior_rotN_open",
-          "vp_door_interior_open_rotW",
+          "vp_door_interior_open_rotE",
           "vp_door_interior_rotS_open",
-          "vp_door_interior_open_rotE"
+          "vp_door_interior_open_rotW"
         ]
       },
       {
@@ -18,26 +18,36 @@
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
         "bg": [
           "vp_door_interior_rotN_open",
-          "vp_door_interior_open_rotW",
+          "vp_door_interior_open_rotE",
           "vp_door_interior_rotS_open",
-          "vp_door_interior_open_rotE"
+          "vp_door_interior_open_rotW"
         ]
       }
     ]
   },
   {
     "id": "vp_door_internal_front",
-    "fg": [ "vp_door_opaque_rear_rotS", "vp_door_full_left", "vp_door_interior_front_rotS", "vp_door_full_left_rotS" ],
+    "fg": [ "vp_door_opaque_rear_rotS", "vp_door_full_left_rotS", "vp_door_interior_front_rotS", "vp_door_full_left" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_rear_open_rotS", "vp_door_interior_front_open_rotW", "vp_door_interior_front_open_rotS", "vp_door_interior_front_open_rotE" ]
+        "fg": [
+          "vp_door_rear_open_rotS",
+          "vp_door_interior_front_open_rotE",
+          "vp_door_interior_front_open_rotS",
+          "vp_door_interior_front_open_rotW"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_door_rear_open_rotS", "vp_door_interior_front_open_rotW", "vp_door_interior_front_open_rotS", "vp_door_interior_front_open_rotE" ]
+        "bg": [
+          "vp_door_rear_open_rotS",
+          "vp_door_interior_front_open_rotE",
+          "vp_door_interior_front_open_rotS",
+          "vp_door_interior_front_open_rotW"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/doors/shutter/vp_door_shutter.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/doors/shutter/vp_door_shutter.json
@@ -1,65 +1,105 @@
 [
   {
     "id": "vp_door_shutter_front",
-    "fg": [ "vp_door_shutter_faceS", "vp_door_shutter_faceE", "vp_door_shutter_faceN", "vp_door_shutter_faceW" ],
+    "fg": [ "vp_door_shutter_faceS", "vp_door_shutter_faceW", "vp_door_shutter_faceN", "vp_door_shutter_faceE" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_shutter_open_faceS", "vp_door_shutter_open_faceE", "vp_door_shutter_open_faceN", "vp_door_shutter_open_faceW" ]
+        "fg": [
+          "vp_door_shutter_open_faceS",
+          "vp_door_shutter_open_faceW",
+          "vp_door_shutter_open_faceN",
+          "vp_door_shutter_open_faceE"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_door_shutter_open_faceS", "vp_door_shutter_open_faceE", "vp_door_shutter_open_faceN", "vp_door_shutter_open_faceW" ]
+        "bg": [
+          "vp_door_shutter_open_faceS",
+          "vp_door_shutter_open_faceW",
+          "vp_door_shutter_open_faceN",
+          "vp_door_shutter_open_faceE"
+        ]
       }
     ]
   },
   {
     "id": "vp_door_shutter_left",
-    "fg": [ "vp_door_shutter_faceW", "vp_door_shutter_left_rotW_right_rotE", "vp_door_shutter_faceE", "vp_door_shutter_faceN" ],
+    "fg": [ "vp_door_shutter_faceW", "vp_door_shutter_faceN", "vp_door_shutter_faceE", "vp_door_shutter_left_rotW_right_rotE" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_shutter_open_faceW", "vp_door_shutter_open_left_rotW_right_rotE", "vp_door_shutter_open_faceE", "vp_door_shutter_open_faceN" ]
+        "fg": [
+          "vp_door_shutter_open_faceW",
+          "vp_door_shutter_open_faceN",
+          "vp_door_shutter_open_faceE",
+          "vp_door_shutter_open_left_rotW_right_rotE"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_door_shutter_open_faceW", "vp_door_shutter_open_left_rotW_right_rotE", "vp_door_shutter_open_faceE", "vp_door_shutter_open_faceN" ]
+        "bg": [
+          "vp_door_shutter_open_faceW",
+          "vp_door_shutter_open_faceN",
+          "vp_door_shutter_open_faceE",
+          "vp_door_shutter_open_left_rotW_right_rotE"
+        ]
       }
     ]
   },
   {
     "id": "vp_door_shutter_right",
-    "fg": [ "vp_door_shutter_faceE", "vp_door_shutter_faceN", "vp_door_shutter_faceW", "vp_door_shutter_left_rotW_right_rotE" ],
+    "fg": [ "vp_door_shutter_faceE", "vp_door_shutter_left_rotW_right_rotE", "vp_door_shutter_faceW", "vp_door_shutter_faceN" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_shutter_open_faceE", "vp_door_shutter_open_faceN", "vp_door_shutter_open_faceW", "vp_door_shutter_open_left_rotW_right_rotE" ]
+        "fg": [
+          "vp_door_shutter_open_faceE",
+          "vp_door_shutter_open_left_rotW_right_rotE",
+          "vp_door_shutter_open_faceW",
+          "vp_door_shutter_open_faceN"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_door_shutter_open_faceE", "vp_door_shutter_open_faceN", "vp_door_shutter_open_faceW", "vp_door_shutter_open_left_rotW_right_rotE" ]
+        "bg": [
+          "vp_door_shutter_open_faceE",
+          "vp_door_shutter_open_left_rotW_right_rotE",
+          "vp_door_shutter_open_faceW",
+          "vp_door_shutter_open_faceN"
+        ]
       }
     ]
   },
   {
     "id": "vp_door_shutter_rear",
-    "fg": [ "vp_door_shutter_faceN", "vp_door_shutter_faceW", "vp_door_shutter_faceS", "vp_door_shutter_faceE" ],
+    "fg": [ "vp_door_shutter_faceN", "vp_door_shutter_faceE", "vp_door_shutter_faceS", "vp_door_shutter_faceW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_shutter_open_faceN", "vp_door_shutter_open_faceW", "vp_door_shutter_open_faceS", "vp_door_shutter_open_faceE" ]
+        "fg": [
+          "vp_door_shutter_open_faceN",
+          "vp_door_shutter_open_faceE",
+          "vp_door_shutter_open_faceS",
+          "vp_door_shutter_open_faceW"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48", "crack_metal_center_32x48" ],
-        "bg": [ "vp_door_shutter_open_faceN", "vp_door_shutter_open_faceW", "vp_door_shutter_open_faceS", "vp_door_shutter_open_faceE" ]
+        "bg": [
+          "vp_door_shutter_open_faceN",
+          "vp_door_shutter_open_faceE",
+          "vp_door_shutter_open_faceS",
+          "vp_door_shutter_open_faceW"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/doors/vp_door_32x64.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/doors/vp_door_32x64.json
@@ -1,117 +1,117 @@
 [
   {
     "id": [ "vp_door_rear", "vp_door_horizontal_rear" ],
-    "fg": [ "vp_door_rear", "vp_door_full_left_rotS", "vp_door_rear_rotS", "vp_door_full_left" ],
+    "fg": [ "vp_door_rear", "vp_door_full_left", "vp_door_rear_rotS", "vp_door_full_left_rotS" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [
-          "vp_door_rear_open",
-          "vp_door_full_left_open_rotS",
-          "vp_door_rear_open_rotS",
-          "vp_door_full_left_open"
-        ]
+        "fg": [ "vp_door_rear_open", "vp_door_full_left_open", "vp_door_rear_open_rotS", "vp_door_full_left_open_rotS" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall" ],
-        "bg": [
-          "vp_door_rear_open",
-          "vp_door_full_left_open_rotS",
-          "vp_door_rear_open_rotS",
-          "vp_door_full_left_open"
-        ]
+        "bg": [ "vp_door_rear_open", "vp_door_full_left_open", "vp_door_rear_open_rotS", "vp_door_full_left_open_rotS" ]
       }
     ]
   },
   {
     "id": [ "vp_door_front", "vp_door_horizontal_front" ],
-    "fg": [ "vp_door_rear_rotS", "vp_door_full_left", "vp_door_rear", "vp_door_full_left_rotS" ],
+    "fg": [ "vp_door_rear_rotS", "vp_door_full_left_rotS", "vp_door_rear", "vp_door_full_left" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_rear_open_rotS", "vp_door_full_left_open", "vp_door_rear_open", "vp_door_full_left_open_rotS" ]
+        "fg": [ "vp_door_rear_open_rotS", "vp_door_full_left_open_rotS", "vp_door_rear_open", "vp_door_full_left_open" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall" ],
-        "bg": [ "vp_door_rear_open_rotS", "vp_door_full_left_open", "vp_door_rear_open", "vp_door_full_left_open_rotS" ]
+        "bg": [ "vp_door_rear_open_rotS", "vp_door_full_left_open_rotS", "vp_door_rear_open", "vp_door_full_left_open" ]
       }
     ]
   },
   {
-    "id": [ "vp_door_opaque_rear", "vp_door_opaque_horizontal_rear" ], 
-    "fg": [ "vp_door_opaque_rear", "vp_door_full_left_rotS", "vp_door_opaque_rear_rotS", "vp_door_full_left" ],
+    "id": [ "vp_door_opaque_rear", "vp_door_opaque_horizontal_rear" ],
+    "fg": [ "vp_door_opaque_rear", "vp_door_full_left", "vp_door_opaque_rear_rotS", "vp_door_full_left_rotS" ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "open",
+        "fg": [ "vp_door_rear_open", "vp_door_opaque_full_left_open", "vp_door_rear_open_rotS", "vp_door_opaque_full_left_open_rotS" ]
+      },
+      {
+        "id": "broken",
+        "fg": [ "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall" ],
+        "bg": [ "vp_door_rear_open", "vp_door_opaque_full_left_open", "vp_door_rear_open_rotS", "vp_door_opaque_full_left_open_rotS" ]
+      }
+    ]
+  },
+  {
+    "id": [ "vp_door_opaque_front", "vp_door_opaque_horizontal_front" ],
+    "fg": [ "vp_door_opaque_rear_rotS", "vp_door_full_left_rotS", "vp_door_opaque_rear", "vp_door_full_left" ],
+    "multitile": true,
+    "additional_tiles": [
+      {
+        "id": "open",
+        "fg": [ "vp_door_rear_open_rotS", "vp_door_opaque_full_left_open_rotS", "vp_door_rear_open", "vp_door_opaque_full_left_open" ]
+      },
+      {
+        "id": "broken",
+        "fg": [ "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall" ],
+        "bg": [ "vp_door_rear_open_rotS", "vp_door_opaque_full_left_open_rotS", "vp_door_rear_open", "vp_door_opaque_full_left_open" ]
+      }
+    ]
+  },
+  {
+    "id": "vp_door_sliding_front",
+    "fg": [ "vp_door_full_left_rotS", "vp_door_opaque_full_right_rotE", "vp_door_full_left", "vp_door_opaque_rear_rotS" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
         "fg": [
-          "vp_door_rear_open",
-          "vp_door_opaque_full_left_open_rotS",
-          "vp_door_rear_open_rotS",
-          "vp_door_opaque_full_left_open"
+          "vp_door_sliding_open_faceE",
+          "vp_door_sliding_vertical_left_open_rotW_right_open_rotE",
+          "vp_door_sliding_open_faceW",
+          "vp_door_sliding_open_faceN"
         ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall" ],
         "bg": [
-          "vp_door_rear_open",
-          "vp_door_opaque_full_left_open_rotS",
-          "vp_door_rear_open_rotS",
-          "vp_door_opaque_full_left_open"
+          "vp_door_sliding_open_faceE",
+          "vp_door_sliding_vertical_left_open_rotW_right_open_rotE",
+          "vp_door_sliding_open_faceW",
+          "vp_door_sliding_open_faceN"
         ]
       }
     ]
   },
   {
-    "id": [ "vp_door_opaque_front", "vp_door_opaque_horizontal_front" ],
-    "fg": [ "vp_door_opaque_rear_rotS", "vp_door_full_left", "vp_door_opaque_rear", "vp_door_full_left_rotS" ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "open",
-        "fg": [ "vp_door_rear_open_rotS", "vp_door_opaque_full_left_open", "vp_door_rear_open", "vp_door_opaque_full_left_open_rotS" ]
-      },
-      {
-        "id": "broken",
-        "fg": [ "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall" ],
-        "bg": [ "vp_door_rear_open_rotS", "vp_door_opaque_full_left_open", "vp_door_rear_open", "vp_door_opaque_full_left_open_rotS" ]
-      }
-    ]
-  },
-  {
-    "id": "vp_door_sliding_front",
-    "fg": [ "vp_door_full_left_rotS", "vp_door_opaque_rear_rotS", "vp_door_full_left", "vp_door_opaque_full_right_rotE" ],
-    "multitile": true,
-    "additional_tiles": [
-      {
-        "id": "open",
-        "fg": [ "vp_door_sliding_open_faceE", "vp_door_sliding_open_faceN", "vp_door_sliding_open_faceW", "vp_door_sliding_vertical_left_open_rotW_right_open_rotE" ]
-      },
-      {
-        "id": "broken",
-        "fg": [ "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall" ],
-        "bg": [ "vp_door_sliding_open_faceE", "vp_door_sliding_open_faceN", "vp_door_sliding_open_faceW", "vp_door_sliding_vertical_left_open_rotW_right_open_rotE" ]
-      }
-    ]
-  },
-  {
     "id": "vp_door_sliding_left",
-    "fg": [ "vp_door_sliding_left", "vp_door_full_left", "vp_door_opaque_rear", "vp_door_full_left_rotS" ],
+    "fg": [ "vp_door_sliding_left", "vp_door_full_left_rotS", "vp_door_opaque_rear", "vp_door_full_left" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_sliding_left_open", "vp_door_sliding_open_faceW", "vp_door_sliding_rear_left_open", "vp_door_sliding_open_faceE" ]
+        "fg": [
+          "vp_door_sliding_left_open",
+          "vp_door_sliding_open_faceE",
+          "vp_door_sliding_rear_left_open",
+          "vp_door_sliding_open_faceW"
+        ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall" ],
-        "bg": [ "vp_door_sliding_left_open", "vp_door_sliding_open_faceW", "vp_door_sliding_rear_left_open", "vp_door_sliding_open_faceE" ]
+        "bg": [
+          "vp_door_sliding_left_open",
+          "vp_door_sliding_open_faceE",
+          "vp_door_sliding_rear_left_open",
+          "vp_door_sliding_open_faceW"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/doors/vp_door_full.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/doors/vp_door_full.json
@@ -1,16 +1,23 @@
 [
   {
-    "id": [ "vp_door_full_left", "vp_door_full_vertical_left", "vp_door_full_nw", "vp_door_full_front_left", "vp_door_full_sw", "vp_door_full_rear_left" ],
-    "fg": [ "vp_door_full_left", "vp_door_full_left_rotW", "vp_door_full_left_rotS", "vp_door_full_left_rotE" ],
+    "id": [
+      "vp_door_full_left",
+      "vp_door_full_vertical_left",
+      "vp_door_full_nw",
+      "vp_door_full_front_left",
+      "vp_door_full_sw",
+      "vp_door_full_rear_left"
+    ],
+    "fg": [ "vp_door_full_left", "vp_door_full_left_rotE", "vp_door_full_left_rotS", "vp_door_full_left_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
         "fg": [
           "vp_door_full_left_open",
-          "vp_door_full_left_open_rotW",
+          "vp_door_full_left_open_rotE",
           "vp_door_full_left_open_rotS",
-          "vp_door_full_left_open_rotE"
+          "vp_door_full_left_open_rotW"
         ]
       },
       {
@@ -18,36 +25,33 @@
         "fg": [ "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall" ],
         "bg": [
           "vp_door_full_left_open",
-          "vp_door_full_left_open_rotW",
+          "vp_door_full_left_open_rotE",
           "vp_door_full_left_open_rotS",
-          "vp_door_full_left_open_rotE"
+          "vp_door_full_left_open_rotW"
         ]
       }
     ]
   },
   {
-    "id": [ "vp_door_full_right", "vp_door_full_vertical_right", "vp_door_full_ne", "vp_door_full_front_right", "vp_door_full_se", "vp_door_full_rear_right" ],
-    "fg": [ "vp_door_full_left_rotS", "vp_door_rear_rotS", "vp_door_full_left", "vp_door_full_right_rotE" ],
+    "id": [
+      "vp_door_full_right",
+      "vp_door_full_vertical_right",
+      "vp_door_full_ne",
+      "vp_door_full_front_right",
+      "vp_door_full_se",
+      "vp_door_full_rear_right"
+    ],
+    "fg": [ "vp_door_full_left_rotS", "vp_door_full_right_rotE", "vp_door_full_left", "vp_door_rear_rotS" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [
-          "vp_door_full_left_open_rotS",
-          "vp_door_rear_open_rotS",
-          "vp_door_full_left_open",
-          "vp_door_full_right_open_rotE"
-        ]
+        "fg": [ "vp_door_full_left_open_rotS", "vp_door_full_right_open_rotE", "vp_door_full_left_open", "vp_door_rear_open_rotS" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall" ],
-        "bg": [
-          "vp_door_full_left_open_rotS",
-          "vp_door_rear_open_rotS",
-          "vp_door_full_left_open",
-          "vp_door_full_right_open_rotE"
-        ]
+        "bg": [ "vp_door_full_left_open_rotS", "vp_door_full_right_open_rotE", "vp_door_full_left_open", "vp_door_rear_open_rotS" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/doors/vp_door_opaque_full.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/doors/vp_door_opaque_full.json
@@ -1,16 +1,16 @@
 [
   {
     "id": "vp_door_opaque_full_left",
-    "fg": [ "vp_door_full_left", "vp_door_opaque_full_left_rotW", "vp_door_full_left_rotS", "vp_door_opaque_full_left_rotE" ],
+    "fg": [ "vp_door_full_left", "vp_door_opaque_full_left_rotE", "vp_door_full_left_rotS", "vp_door_opaque_full_left_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
         "fg": [
           "vp_door_opaque_full_left_open",
-          "vp_door_full_left_open_rotW",
+          "vp_door_full_left_open_rotE",
           "vp_door_opaque_full_left_open_rotS",
-          "vp_door_full_left_open_rotE"
+          "vp_door_full_left_open_rotW"
         ]
       },
       {
@@ -18,25 +18,25 @@
         "fg": [ "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall" ],
         "bg": [
           "vp_door_opaque_full_left_open",
-          "vp_door_full_left_open_rotW",
+          "vp_door_full_left_open_rotE",
           "vp_door_opaque_full_left_open_rotS",
-          "vp_door_full_left_open_rotE"
+          "vp_door_full_left_open_rotW"
         ]
       }
     ]
   },
   {
     "id": "vp_door_opaque_full_right",
-    "fg": [ "vp_door_full_left_rotS", "vp_door_opaque_rear_rotS", "vp_door_full_left", "vp_door_opaque_full_right_rotE" ],
+    "fg": [ "vp_door_full_left_rotS", "vp_door_opaque_full_right_rotE", "vp_door_full_left", "vp_door_opaque_rear_rotS" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
         "fg": [
           "vp_door_opaque_full_left_open_rotS",
-          "vp_door_rear_open_rotS",
+          "vp_door_full_right_open_rotE",
           "vp_door_opaque_full_left_open",
-          "vp_door_full_right_open_rotE"
+          "vp_door_rear_open_rotS"
         ]
       },
       {
@@ -44,9 +44,9 @@
         "fg": [ "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall" ],
         "bg": [
           "vp_door_opaque_full_left_open_rotS",
-          "vp_door_rear_open_rotS",
+          "vp_door_full_right_open_rotE",
           "vp_door_opaque_full_left_open",
-          "vp_door_full_right_open_rotE"
+          "vp_door_rear_open_rotS"
         ]
       }
     ]

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/motorcycle/motorcycle_handle.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/motorcycle/motorcycle_handle.json
@@ -1,13 +1,13 @@
 [
   {
     "id": "vp_frame_handle",
-    "fg": [ "handle_motor_rotN", "handle_motor_rotW", "handle_motor_rotS", "handle_motor_rotE" ],
+    "fg": [ "handle_motor_rotN", "handle_motor_rotE", "handle_motor_rotS", "handle_motor_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "handle_motor_rotN", "handle_motor_rotW", "handle_motor_rotS", "handle_motor_rotE" ]
+        "bg": [ "handle_motor_rotN", "handle_motor_rotE", "handle_motor_rotS", "handle_motor_rotW" ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/stowboards/stowboards.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/stowboards/stowboards.json
@@ -1,145 +1,225 @@
 [
   {
     "id": "vp_stowboard_ne",
-    "fg": [ "vp_stowboard_ne", "vp_stowboard_ne_rotW", "vp_stowboard_ne_rotS", "vp_stowboard_ne_rotE" ],
+    "fg": [ "vp_stowboard_ne", "vp_stowboard_ne_rotE", "vp_stowboard_ne_rotS", "vp_stowboard_ne_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_stowboard_ne", "vp_stowboard_ne_rotW", "vp_stowboard_ne_rotS", "vp_stowboard_ne_rotE" ]
+        "bg": [ "vp_stowboard_ne", "vp_stowboard_ne_rotE", "vp_stowboard_ne_rotS", "vp_stowboard_ne_rotW" ]
       }
     ]
   },
   {
     "id": "vp_stowboard_nw",
-    "fg": [ "vp_stowboard_ne_rotW", "vp_stowboard_nw_rotW", "vp_stowboard_nw_rotS", "vp_stowboard_ne" ],
+    "fg": [ "vp_stowboard_ne_rotW", "vp_stowboard_ne", "vp_stowboard_nw_rotS", "vp_stowboard_nw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_stowboard_ne_rotW", "vp_stowboard_nw_rotW", "vp_stowboard_nw_rotS", "vp_stowboard_ne" ]
+        "bg": [ "vp_stowboard_ne_rotW", "vp_stowboard_ne", "vp_stowboard_nw_rotS", "vp_stowboard_nw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_stowboard_se",
-    "fg": [ "vp_stowboard_se", "vp_stowboard_ne", "vp_stowboard_ne_rotW", "vp_stowboard_se_rotE" ],
+    "fg": [ "vp_stowboard_se", "vp_stowboard_se_rotE", "vp_stowboard_ne_rotW", "vp_stowboard_ne" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_stowboard_se", "vp_stowboard_ne", "vp_stowboard_ne_rotW", "vp_stowboard_se_rotE" ]
+        "bg": [ "vp_stowboard_se", "vp_stowboard_se_rotE", "vp_stowboard_ne_rotW", "vp_stowboard_ne" ]
       }
     ]
   },
   {
     "id": "vp_stowboard_sw",
-    "fg": [ "vp_stowboard_sw", "vp_stowboard_sw_rotW", "vp_stowboard_ne", "vp_stowboard_ne_rotW" ],
+    "fg": [ "vp_stowboard_sw", "vp_stowboard_ne_rotW", "vp_stowboard_ne", "vp_stowboard_sw_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_stowboard_sw", "vp_stowboard_sw_rotW", "vp_stowboard_ne", "vp_stowboard_ne_rotW" ]
+        "bg": [ "vp_stowboard_sw", "vp_stowboard_ne_rotW", "vp_stowboard_ne", "vp_stowboard_sw_rotW" ]
       }
     ]
   },
   {
     "id": "vp_stowboard_vertical_left",
-    "fg": [ "vp_stowboard_horizontal_front_rotW", "vp_stowboard_vertical_left_rotW_right_rotE", "vp_stowboard_horizontal_front_rotE", "vp_stowboard_horizontal_front" ],
+    "fg": [
+      "vp_stowboard_horizontal_front_rotW",
+      "vp_stowboard_horizontal_front",
+      "vp_stowboard_horizontal_front_rotE",
+      "vp_stowboard_vertical_left_rotW_right_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_stowboard_horizontal_front_rotW", "vp_stowboard_vertical_left_rotW_right_rotE", "vp_stowboard_horizontal_front_rotE", "vp_stowboard_horizontal_front" ]
+        "bg": [
+          "vp_stowboard_horizontal_front_rotW",
+          "vp_stowboard_horizontal_front",
+          "vp_stowboard_horizontal_front_rotE",
+          "vp_stowboard_vertical_left_rotW_right_rotE"
+        ]
       }
     ]
   },
   {
     "id": "vp_stowboard_vertical_right",
-    "fg": [ "vp_stowboard_horizontal_front_rotE", "vp_stowboard_horizontal_front", "vp_stowboard_horizontal_front_rotW", "vp_stowboard_vertical_left_rotW_right_rotE" ],
+    "fg": [
+      "vp_stowboard_horizontal_front_rotE",
+      "vp_stowboard_vertical_left_rotW_right_rotE",
+      "vp_stowboard_horizontal_front_rotW",
+      "vp_stowboard_horizontal_front"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_stowboard_horizontal_front_rotE", "vp_stowboard_horizontal_front", "vp_stowboard_horizontal_front_rotW", "vp_stowboard_vertical_left_rotW_right_rotE" ]
+        "bg": [
+          "vp_stowboard_horizontal_front_rotE",
+          "vp_stowboard_vertical_left_rotW_right_rotE",
+          "vp_stowboard_horizontal_front_rotW",
+          "vp_stowboard_horizontal_front"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_stowboard_horizontal", "vp_stowboard_horizontal_2" ],
-    "fg": [ "vp_stowboard_horizontal_front", "vp_stowboard_horizontal_rotW", "vp_stowboard_horizontal_front", "vp_stowboard_vertical_rotNS" ],
+    "fg": [
+      "vp_stowboard_horizontal_front",
+      "vp_stowboard_vertical_rotNS",
+      "vp_stowboard_horizontal_front",
+      "vp_stowboard_horizontal_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_stowboard_horizontal_front", "vp_stowboard_horizontal_rotW", "vp_stowboard_horizontal_front", "vp_stowboard_vertical_rotNS" ]
+        "bg": [
+          "vp_stowboard_horizontal_front",
+          "vp_stowboard_vertical_rotNS",
+          "vp_stowboard_horizontal_front",
+          "vp_stowboard_horizontal_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_stowboard_horizontal_front",
-    "fg": [ "vp_stowboard_horizontal_front", "vp_stowboard_horizontal_front_rotW", "vp_stowboard_horizontal_front_rotS", "vp_stowboard_horizontal_front_rotE" ],
+    "fg": [
+      "vp_stowboard_horizontal_front",
+      "vp_stowboard_horizontal_front_rotE",
+      "vp_stowboard_horizontal_front_rotS",
+      "vp_stowboard_horizontal_front_rotW"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_stowboard_horizontal_front", "vp_stowboard_horizontal_front_rotW", "vp_stowboard_horizontal_front_rotS", "vp_stowboard_horizontal_front_rotE" ]
+        "bg": [
+          "vp_stowboard_horizontal_front",
+          "vp_stowboard_horizontal_front_rotE",
+          "vp_stowboard_horizontal_front_rotS",
+          "vp_stowboard_horizontal_front_rotW"
+        ]
       }
     ]
   },
   {
     "id": "vp_stowboard_horizontal_rear",
-    "fg": [ "vp_stowboard_horizontal_rear", "vp_stowboard_horizontal_front_rotE", "vp_stowboard_horizontal_front", "vp_stowboard_horizontal_front_rotW" ],
+    "fg": [
+      "vp_stowboard_horizontal_rear",
+      "vp_stowboard_horizontal_front_rotW",
+      "vp_stowboard_horizontal_front",
+      "vp_stowboard_horizontal_front_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_stowboard_horizontal_rear", "vp_stowboard_horizontal_front_rotE", "vp_stowboard_horizontal_front", "vp_stowboard_horizontal_front_rotW" ]
+        "bg": [
+          "vp_stowboard_horizontal_rear",
+          "vp_stowboard_horizontal_front_rotW",
+          "vp_stowboard_horizontal_front",
+          "vp_stowboard_horizontal_front_rotE"
+        ]
       }
     ]
   },
   {
     "id": [ "vp_stowboard_vertical", "vp_stowboard_vertical_2" ],
-    "fg": [ "vp_stowboard_vertical_rotNS", "vp_stowboard_horizontal_front", "vp_stowboard_vertical_rotNS", "vp_stowboard_horizontal_front" ],
+    "fg": [
+      "vp_stowboard_vertical_rotNS",
+      "vp_stowboard_horizontal_front",
+      "vp_stowboard_vertical_rotNS",
+      "vp_stowboard_horizontal_front"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg":[ "vp_stowboard_vertical_rotNS", "vp_stowboard_horizontal_front", "vp_stowboard_vertical_rotNS", "vp_stowboard_horizontal_front" ]
+        "bg": [
+          "vp_stowboard_vertical_rotNS",
+          "vp_stowboard_horizontal_front",
+          "vp_stowboard_vertical_rotNS",
+          "vp_stowboard_horizontal_front"
+        ]
       }
     ]
   },
   {
     "id": "vp_stowboard_wheel_left",
-    "fg": [ "vp_stowboard_horizontal_front_rotW", "vp_stowboard_wheel_left_rotW_right_rotE", "vp_stowboard_horizontal_front_rotE", "vp_stowboard_horizontal_front" ],
+    "fg": [
+      "vp_stowboard_horizontal_front_rotW",
+      "vp_stowboard_horizontal_front",
+      "vp_stowboard_horizontal_front_rotE",
+      "vp_stowboard_wheel_left_rotW_right_rotE"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_stowboard_horizontal_front_rotW", "vp_stowboard_wheel_left_rotW_right_rotE", "vp_stowboard_horizontal_front_rotE", "vp_stowboard_horizontal_front" ]
+        "bg": [
+          "vp_stowboard_horizontal_front_rotW",
+          "vp_stowboard_horizontal_front",
+          "vp_stowboard_horizontal_front_rotE",
+          "vp_stowboard_wheel_left_rotW_right_rotE"
+        ]
       }
     ]
   },
   {
     "id": "vp_stowboard_wheel_right",
-    "fg": [ "vp_stowboard_horizontal_front_rotE", "vp_stowboard_horizontal_front", "vp_stowboard_horizontal_front_rotW", "vp_stowboard_wheel_left_rotW_right_rotE" ],
+    "fg": [
+      "vp_stowboard_horizontal_front_rotE",
+      "vp_stowboard_wheel_left_rotW_right_rotE",
+      "vp_stowboard_horizontal_front_rotW",
+      "vp_stowboard_horizontal_front"
+    ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "broken",
         "fg": "crack_metal_center",
-        "bg": [ "vp_stowboard_horizontal_front_rotE", "vp_stowboard_horizontal_front", "vp_stowboard_horizontal_front_rotW", "vp_stowboard_wheel_left_rotW_right_rotE" ]
+        "bg": [
+          "vp_stowboard_horizontal_front_rotE",
+          "vp_stowboard_wheel_left_rotW_right_rotE",
+          "vp_stowboard_horizontal_front_rotW",
+          "vp_stowboard_horizontal_front"
+        ]
       }
     ]
   }

--- a/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/vp_door_trunk/vp_door_trunk.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/vehicle/vp_door_trunk/vp_door_trunk.json
@@ -1,17 +1,17 @@
 [
   {
     "id": "vp_door_trunk_front",
-    "fg": [ "vp_door_trunk", "vp_door_trunk_rotW", "vp_door_trunk_rotS", "vp_door_trunk_rotE" ],
+    "fg": [ "vp_door_trunk", "vp_door_trunk_rotE", "vp_door_trunk_rotS", "vp_door_trunk_rotW" ],
     "multitile": true,
     "additional_tiles": [
       {
         "id": "open",
-        "fg": [ "vp_door_trunk_open", "vp_door_trunk_open_rotW", "vp_door_trunk_open_rotS", "vp_door_trunk_open_rotE" ]
+        "fg": [ "vp_door_trunk_open", "vp_door_trunk_open_rotE", "vp_door_trunk_open_rotS", "vp_door_trunk_open_rotW" ]
       },
       {
         "id": "broken",
         "fg": [ "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall", "crack_metal_center_tall" ],
-        "bg": [ "vp_door_trunk_open", "vp_door_trunk_open_rotW", "vp_door_trunk_open_rotS", "vp_door_trunk_open_rotE" ]
+        "bg": [ "vp_door_trunk_open", "vp_door_trunk_open_rotE", "vp_door_trunk_open_rotS", "vp_door_trunk_open_rotW" ]
       }
     ]
   }


### PR DESCRIPTION
#### Summary
Part of the tile rotation update PRs. Updates tile definitions to account for the fixes in https://github.com/CleverRaven/Cataclysm-DDA/pull/86335 and https://github.com/CleverRaven/Cataclysm-DDA/pull/86574

#### Content of the change
The dependent PR changed the tile drawing code to rotate tiles in the correct direction (clockwise instead of counter clockwise) and it will select tiles in an order opposite than it used to.
Every tile definition that defines all four rotations had to have indexes 1 and 3 swapped so the engine will select the correct tile to draw. 


#### Testing
Composed locally checked around for any obviously broken tiles. Attached is a save with a lot of testing material placed down in-game and on the overmap.
[Debug.tar.gz](https://github.com/user-attachments/files/26925717/Debug.tar.gz)


#### Additional information
Depends on https://github.com/CleverRaven/Cataclysm-DDA/pull/86574 being merged.