### PR TITLE
[ASCIIOvermap] Overmap rotations

### DIFF
--- a/gfx/ASCII_Overmap/pngs_ASCIITiles_10x10/json_legacy/etc.json
+++ b/gfx/ASCII_Overmap/pngs_ASCIITiles_10x10/json_legacy/etc.json
@@ -16,8 +16,8 @@
     "multitile": true,
     "additional_tiles": [
       { "id": "center", "fg": [ "dark_gray197" ], "bg": [  ] },
-      { "id": "corner", "fg": [ "dark_gray218", "dark_gray192", "dark_gray217", "dark_gray191" ], "bg": [  ] },
-      { "id": "t_connection", "fg": [ "dark_gray194", "dark_gray195", "dark_gray193", "dark_gray180" ], "bg": [  ] },
+      { "id": "corner", "fg": [ "dark_gray218", "dark_gray191", "dark_gray217", "dark_gray192" ], "bg": [  ] },
+      { "id": "t_connection", "fg": [ "dark_gray194", "dark_gray180", "dark_gray193", "dark_gray195" ], "bg": [  ] },
       { "id": "edge", "fg": [ "dark_gray179", "dark_gray196" ], "bg": [  ] },
       { "id": "end_piece", "fg": [ "dark_gray179", "dark_gray196", "dark_gray179", "dark_gray196" ], "bg": [  ] },
       { "id": "unconnected", "fg": [ "dark_gray197", "dark_gray197" ], "bg": [  ] }
@@ -30,8 +30,8 @@
     "multitile": true,
     "additional_tiles": [
       { "id": "center", "fg": [ "green197" ], "bg": [  ] },
-      { "id": "corner", "fg": [ "green218", "green192", "green217", "green191" ], "bg": [  ] },
-      { "id": "t_connection", "fg": [ "green194", "green195", "green193", "green180" ], "bg": [  ] },
+      { "id": "corner", "fg": [ "green218", "green191", "green217", "green192" ], "bg": [  ] },
+      { "id": "t_connection", "fg": [ "green194", "green180", "green193", "green195" ], "bg": [  ] },
       { "id": "edge", "fg": [ "green179", "green196" ], "bg": [  ] },
       { "id": "end_piece", "fg": [ "green179", "green196", "green179", "green196" ], "bg": [  ] },
       { "id": "unconnected", "fg": [ "green197", "green197" ], "bg": [  ] }
@@ -44,8 +44,8 @@
     "multitile": true,
     "additional_tiles": [
       { "id": "center", "fg": [ "brown197" ], "bg": [  ] },
-      { "id": "corner", "fg": [ "brown218", "brown192", "brown217", "brown191" ], "bg": [  ] },
-      { "id": "t_connection", "fg": [ "brown194", "brown195", "brown193", "brown180" ], "bg": [  ] },
+      { "id": "corner", "fg": [ "brown218", "brown191", "brown217", "brown192" ], "bg": [  ] },
+      { "id": "t_connection", "fg": [ "brown194", "brown180", "brown193", "brown195" ], "bg": [  ] },
       { "id": "edge", "fg": [ "brown179", "brown196" ], "bg": [  ] },
       { "id": "end_piece", "fg": [ "brown179", "brown196", "brown179", "brown196" ], "bg": [  ] },
       { "id": "unconnected", "fg": [ "brown197", "brown197" ], "bg": [  ] }
@@ -58,8 +58,8 @@
     "multitile": true,
     "additional_tiles": [
       { "id": "center", "fg": [ "brown197" ], "bg": [  ] },
-      { "id": "corner", "fg": [ "brown218", "brown192", "brown217", "brown191" ], "bg": [  ] },
-      { "id": "t_connection", "fg": [ "brown194", "brown195", "brown193", "brown180" ], "bg": [  ] },
+      { "id": "corner", "fg": [ "brown218", "brown191", "brown217", "brown192" ], "bg": [  ] },
+      { "id": "t_connection", "fg": [ "brown194", "brown180", "brown193", "brown195" ], "bg": [  ] },
       { "id": "edge", "fg": [ "brown179", "brown196" ], "bg": [  ] },
       { "id": "end_piece", "fg": [ "brown179", "brown196", "brown179", "brown196" ], "bg": [  ] },
       { "id": "unconnected", "fg": [ "brown197", "brown197" ], "bg": [  ] }


### PR DESCRIPTION
#### Summary
Part of the tile rotation update PRs. Updates tile definitions to account for the fixes in https://github.com/CleverRaven/Cataclysm-DDA/pull/86335 and https://github.com/CleverRaven/Cataclysm-DDA/pull/86574

#### Content of the change
The dependent PR changed the tile drawing code to rotate tiles in the correct direction (clockwise instead of counter clockwise) and it will select tiles in an order opposite than it used to.
Every tile definition that defines all four rotations had to have indexes 1 and 3 swapped so the engine will select the correct tile to draw. 


#### Testing
Composed locally checked around for any obviously broken tiles. Attached is a save with a lot of testing material placed down in-game and on the overmap.
[Debug.tar.gz](https://github.com/user-attachments/files/26925717/Debug.tar.gz)


#### Additional information
Depends on https://github.com/CleverRaven/Cataclysm-DDA/pull/86574 being merged.