### PR TITLE
[Ultica] Fix rotation on road/dirt/trail corners

### DIFF
--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/dirt_road/dirt_road.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/dirt_road/dirt_road.json
@@ -8,7 +8,7 @@
       { "id": "center", "fg": "dirt_road_center" },
       {
         "id": "corner",
-        "fg": [ "dirt_road_corner_nw", "dirt_road_corner_ne", "dirt_road_corner_se", "dirt_road_corner_sw" ],
+        "fg": [ "dirt_road_corner_se", "dirt_road_corner_sw", "dirt_road_corner_nw", "dirt_road_corner_ne" ],
         "bg": "field"
       },
       {

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/forest_trail/forest_trail.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/forest_trail/forest_trail.json
@@ -6,7 +6,7 @@
     { "id": "center", "fg": "forest_trail_center" },
     {
       "id": "corner",
-      "fg": [ "forest_trail_corner_nw", "forest_trail_corner_ne", "forest_trail_corner_se", "forest_trail_corner_sw" ]
+      "fg": [ "forest_trail_corner_se", "forest_trail_corner_sw", "forest_trail_corner_nw", "forest_trail_corner_ne" ]
     },
     {
       "id": "t_connection",

--- a/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/road/road.json
+++ b/gfx/UltimateCataclysm/pngs_normal_32x32/overmap/road/road.json
@@ -8,7 +8,7 @@
       { "id": "center", "fg": "road_center" },
       {
         "id": "corner",
-        "fg": [ "road_corner_nw", "road_corner_ne", "road_corner_se", "road_corner_sw" ],
+        "fg": [ "road_corner_se", "road_corner_sw", "road_corner_nw", "road_corner_ne" ],
         "bg": "field"
       },
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
<!-- Brief description  -->
@thaelina's recent fixes swapped positions 1 and 3 of every rotation array, but left the base slot unchanged. For most multitile corner subtiles that was correct, because sprites named *_corner_nw seem to convey "the NW outer corner of this shape".

Roads, dirt roads, and forest trails use the opposite convention for some reason. *_corner_nw is the road itself curving through the NW quadrant, meaning the tile connects on N+W.

#### Content of the change
This commit rotates the `corner` subtile arrays to account for this.

#### Testing
I didn't bother taking screenshots, but I validated this in-game. I also double checked things like sidewalks, railroads (turned on the railroad mod to generate them), and fences but those all used the expected conventions. 

#### Additional information
There might be other types like this that I've missed, but I haven't seen any yet.