### PR TITLE
Fix Dresser E/W Facing

### DIFF
--- a/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_dresser/f_dresser.json
+++ b/gfx/UltimateCataclysm/pngs_tall_32x64/furniture/f_dresser/f_dresser.json
@@ -3,9 +3,9 @@
   "rotates": true,
   "fg": [
     "f_dresser_faceS",
-    "f_dresser_faceE",
+    "f_dresser_faceW",
     "f_dresser_faceN",
-    "f_dresser_faceW"
+    "f_dresser_faceE"
   ],
   "bg": ""
 }


### PR DESCRIPTION
Fixed the reversed east/west facing for dressers.


#### Summary
Similar fix to #2905.

East/West Facing for Dressers are reversed, this would correct that.

#### Content of the change

Rotation order is N/E/S/W, so having "faceE" in the East position makes it so the sprite faces the wall it is rotating towards. By switching them (as faceN and faceS already are) this will make it face the correct direction.

#### Testing

I repacked the sprites after making the change and it looked correct.

#### Additional information

I did do this a week or more ago, but I cannot see anything in the repo that shows it being fixed already. After seeing #2905, I realized I should probably push this change as well. If it has already been fixed by some other means and I am just super blind, sorry.
