### PR TITLE
Use Ravenfolk wings sprite for Strix wings.

### DIFF
--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/Magiclysm/character/mutation/overlay_mutation_ravenfolk_wings.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/Magiclysm/character/mutation/overlay_mutation_ravenfolk_wings.json
@@ -1,0 +1,10 @@
+{
+  "id": "overlay_mutation_RAVENFOLK_WINGS",
+  "fg": [
+    "overlay_mutation_RAVENFOLK_WINGS"
+  ],
+  "bg": [
+    
+  ],
+  "rotates": false
+}

--- a/gfx/MShockXotto+/pngs_tiles_32x32/mods/xedra_evolved/character/mutations/overlay_mutation_wings_strix.json
+++ b/gfx/MShockXotto+/pngs_tiles_32x32/mods/xedra_evolved/character/mutations/overlay_mutation_wings_strix.json
@@ -1,0 +1,10 @@
+{
+  "id": "overlay_mutation_WINGS_STRIX",
+  "fg": [
+    "overlay_mutation_RAVENFOLK_WINGS"
+  ],
+  "bg": [
+    
+  ],
+  "rotates": false
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Comment blocks, surrounded with <!–– and ––>, won't be visible in the actual post.-->

#### Summary
Strix wings added in: https://github.com/CleverRaven/Cataclysm-DDA/pull/88285 need a sprite, and we already have the ravenfolk sprite.

#### Content of the change

Apply sprite to Strix wings too. 

<!-- Explain what does this pull request contain. -->

#### Testing

Checked both ravenfolk and Strix form, made sure sprites are visible.

Sprite can be seen in #2801

<!-- If applicable include screenshots of the sprites in game.
For non-sprite contribution explain what you did to verify your changes are correct and how others can verify them.-->

#### Additional information
